### PR TITLE
fix: coma decimal rompe JSON inline en vistas matriz/dashboard

### DIFF
--- a/templates/construccion/dashboard_curva_s.html
+++ b/templates/construccion/dashboard_curva_s.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
+{% load l10n %}
 
 {% block title %}Dashboard {{ fase_activa }} — {{ proyecto.nombre }}{% endblock %}
 
 {% block content %}
+{% localize off %}
 <div class="space-y-6"
      x-data='dashboardCurvaS({
         urlUpsert: "{% url "construccion:dashboard_semana_upsert" proyecto_id=proyecto.id %}",
@@ -227,4 +229,5 @@ function dashboardCurvaS(cfg) {
     };
 }
 </script>
+{% endlocalize %}
 {% endblock %}

--- a/templates/construccion/montaje_matriz.html
+++ b/templates/construccion/montaje_matriz.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
+{% load l10n %}
 
 {% block title %}Montaje — {{ proyecto.nombre }}{% endblock %}
 
 {% block content %}
+{% localize off %}
 <div class="space-y-6"
      x-data='montajeMatriz({
          proyectoId: "{{ proyecto.id }}",
@@ -306,4 +308,5 @@ function filaMontaje(torreId, avancesIniciales) {
     };
 }
 </script>
+{% endlocalize %}
 {% endblock %}

--- a/templates/construccion/obra_civil_matriz.html
+++ b/templates/construccion/obra_civil_matriz.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
+{% load l10n %}
 
 {% block title %}Obra Civil — {{ proyecto.nombre }}{% endblock %}
 
 {% block content %}
+{% localize off %}
 <div class="space-y-6"
      x-data='obraCivilMatriz({
          proyectoId: "{{ proyecto.id }}",
@@ -320,4 +322,5 @@ window.addEventListener('DOMContentLoaded', () => {
     }, 50);
 });
 </script>
+{% endlocalize %}
 {% endblock %}

--- a/templates/construccion/spt_pintura_torre.html
+++ b/templates/construccion/spt_pintura_torre.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
-{% load static %}
+{% load static l10n %}
 
 {% block title %}SPT y Pintura — Torre {{ torre.numero }}{% endblock %}
 
 {% block content %}
+{% localize off %}
 <div class="space-y-6"
      x-data='sptPinturaTorre({
         urlUpdate: "{% url "construccion:spt_pintura_update" proyecto_id=proyecto.id torre_id=torre.id %}",
@@ -294,4 +295,5 @@ function sptPinturaTorre(cfg) {
     };
 }
 </script>
+{% endlocalize %}
 {% endblock %}

--- a/templates/construccion/tendido_matriz.html
+++ b/templates/construccion/tendido_matriz.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
+{% load l10n %}
 
 {% block title %}CANT TENDIDO — {{ proyecto.nombre }}{% endblock %}
 
 {% block content %}
+{% localize off %}
 <div class="space-y-6"
      x-data='tendidoMatriz({
         proyectoId: "{{ proyecto.id }}",
@@ -299,4 +301,5 @@ function filaTendido(torreId, campos) {
     };
 }
 </script>
+{% endlocalize %}
 {% endblock %}

--- a/templates/construccion/trinchos_cunetas_lista.html
+++ b/templates/construccion/trinchos_cunetas_lista.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
+{% load l10n %}
 
 {% block title %}Trinchos y Cunetas — {{ proyecto.nombre }}{% endblock %}
 
 {% block content %}
+{% localize off %}
 <div class="space-y-6"
      x-data='trinchosCunetas({
         urlUpsert: "{% url "construccion:trinchos_cunetas_upsert" proyecto_id=proyecto.id %}",
@@ -230,4 +232,5 @@ function trinchosCunetas(cfg) {
     };
 }
 </script>
+{% endlocalize %}
 {% endblock %}


### PR DESCRIPTION
Bug detectado en E2E Playwright contra prod (Page error 'Unexpected number' en consola). Django ES renderiza Decimals con coma → JS lo parsea mal. Fix con `{% localize off %}` en los 6 templates afectados. 121 tests siguen pasando.