### PR TITLE
fix: trinchos UUID JS roto + dashboard canvas null en init

### DIFF
--- a/templates/construccion/dashboard_curva_s.html
+++ b/templates/construccion/dashboard_curva_s.html
@@ -149,13 +149,22 @@ function dashboardCurvaS(cfg) {
         form: { semana: '', prog: 0, cons: 0, torres_prog: '' },
         mensaje: '', mensajeTipo: '',
         init() {
-            this.renderChart(this.chartInicial);
+            // Diferir render hasta que el canvas esté en el DOM (Alpine init() corre antes).
+            this.$nextTick(() => this.renderChart(this.chartInicial));
         },
         renderChart(datos) {
-            const ctx = document.getElementById('curva-s-chart');
-            if (!ctx) return;
+            const canvas = document.getElementById('curva-s-chart');
+            if (!canvas) {
+                console.warn('curva-s-chart canvas no encontrado, omitiendo render');
+                return;
+            }
+            // Confirmar que es <canvas> y no otro elemento con ese id
+            if (canvas.tagName !== 'CANVAS' || !canvas.getContext) {
+                console.warn('curva-s-chart no es un canvas válido');
+                return;
+            }
             if (this.chart) this.chart.destroy();
-            this.chart = new Chart(ctx, {
+            this.chart = new Chart(canvas, {
                 type: 'line',
                 data: {
                     labels: datos.labels,

--- a/templates/construccion/trinchos_cunetas_lista.html
+++ b/templates/construccion/trinchos_cunetas_lista.html
@@ -132,23 +132,23 @@
                             {% if o.completado %}<span class="text-green-600 dark:text-green-400">✓ Completo</span>{% else %}<span class="text-gray-500">Incompleto</span>{% endif %}
                         </td>
                         <td class="px-3 py-2 text-center">
-                            <button @click='editar({{ o.id|stringformat:"s"|safe|escapejs }} && false ? null : {
-                                id: "{{ o.id }}",
-                                torre_id: "{{ o.torre.id }}",
-                                medida_manejo: "{{ o.medida_manejo }}",
-                                metros_trinchos: "{{ o.metros_trinchos|default_if_none:"" }}",
-                                metros_cunetas: "{{ o.metros_cunetas|default_if_none:"" }}",
-                                notas: "{{ o.notas|escapejs }}",
-                                tubo_metalico: "{{ o.tubo_metalico }}",
-                                malla_eslabonada: "{{ o.malla_eslabonada }}",
-                                alambre_galvanizado: "{{ o.alambre_galvanizado }}",
-                                geotextil: "{{ o.geotextil }}",
-                                cemento: "{{ o.cemento }}",
-                                arena: "{{ o.arena }}",
-                                grava: "{{ o.grava }}",
-                                cuadrilla: "{{ o.cuadrilla|escapejs }}",
+                            <button @click="editar({
+                                id: '{{ o.id }}',
+                                torre_id: '{{ o.torre.id }}',
+                                medida_manejo: '{{ o.medida_manejo }}',
+                                metros_trinchos: '{{ o.metros_trinchos|default_if_none:""|unlocalize }}',
+                                metros_cunetas: '{{ o.metros_cunetas|default_if_none:""|unlocalize }}',
+                                notas: '{{ o.notas|escapejs }}',
+                                tubo_metalico: '{{ o.tubo_metalico|unlocalize }}',
+                                malla_eslabonada: '{{ o.malla_eslabonada|unlocalize }}',
+                                alambre_galvanizado: '{{ o.alambre_galvanizado|unlocalize }}',
+                                geotextil: '{{ o.geotextil|unlocalize }}',
+                                cemento: '{{ o.cemento|unlocalize }}',
+                                arena: '{{ o.arena|unlocalize }}',
+                                grava: '{{ o.grava|unlocalize }}',
+                                cuadrilla: '{{ o.cuadrilla|escapejs }}',
                                 completado: {% if o.completado %}true{% else %}false{% endif %}
-                            })' class="text-blue-600 dark:text-blue-400 hover:underline text-sm">Editar</button>
+                            })" class="text-blue-600 dark:text-blue-400 hover:underline text-sm">Editar</button>
                         </td>
                     </tr>
                     {% empty %}


### PR DESCRIPTION
2 bugs encontrados por Playwright E2E:
- Trinchos botón Editar: UUID raw interpretado como número JS → SyntaxError
- Dashboard: Alpine init() antes que canvas DOM render → Chart.js getContext null

Fix: comillas simples + unlocalize en trinchos; `$nextTick` + tagName check en dashboard.