### PR TITLE
fix(dashboard): Chart.js responsive=false

### DIFF
--- a/templates/construccion/dashboard_curva_s.html
+++ b/templates/construccion/dashboard_curva_s.html
@@ -59,7 +59,7 @@
     <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-4">
         <h2 class="font-semibold mb-2">Curva S — Planeado vs Ejecutado</h2>
         <div class="relative" style="height: 400px;">
-            <canvas id="curva-s-chart"></canvas>
+            <canvas id="curva-s-chart" width="1200" height="400"></canvas>
         </div>
     </div>
 
@@ -182,7 +182,10 @@ function dashboardCurvaS(cfg) {
                     ],
                 },
                 options: {
-                    responsive: true, maintainAspectRatio: false,
+                    // responsive=false evita resize listener que falla si el canvas se
+                    // detacha (Alpine re-render). El size lo controlamos vía CSS height
+                    // del contenedor.
+                    responsive: false, maintainAspectRatio: false,
                     scales: {
                         y: { beginAtZero: true, max: 100, ticks: { callback: v => v + '%' } },
                         x: { ticks: { maxRotation: 45 } },


### PR DESCRIPTION
Stacktrace: chart.umd.min.js Te → clear → draw → ResizeObserver dispara draw en canvas detached. Fix: responsive=false + dims fijas.