### PR TITLE
hotfix(templates): TemplateSyntaxError 'ignore missing' rompe /campo/avance/registrar/

### DIFF
--- a/templates/campo/avance_registrar.html
+++ b/templates/campo/avance_registrar.html
@@ -12,7 +12,7 @@
     </div>
 
     {# B2.1 hook (Sofi mayo 2026) — segmentar grid por semestre S1/S2/TA. Sub-feature crea templates/lineas/_filtro_semestre.html. #}
-    {% include 'lineas/_filtro_semestre.html' ignore missing %}
+    {% include 'lineas/_filtro_semestre.html' %}
 
     <!-- Error Message -->
     {% if error %}

--- a/templates/lineas/detalle.html
+++ b/templates/lineas/detalle.html
@@ -15,7 +15,7 @@
 {% block content %}
 <div class="space-y-6">
     {# B2.1 hook (Sofi mayo 2026) — sub-feature crea templates/lineas/_filtro_semestre.html. Mientras no exista, Django no falla por `ignore missing`. #}
-    {% include 'lineas/_filtro_semestre.html' ignore missing %}
+    {% include 'lineas/_filtro_semestre.html' %}
     <!-- Header -->
     <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
         <div class="flex items-center gap-4">


### PR DESCRIPTION
## Causa raíz HTTP 500 confirmada

PR #107 agregó logger.exception y permitió capturar:
\`\`\`
TemplateSyntaxError: Unknown argument for 'include' tag: 'ignore'.
\`\`\`

La sintaxis \`{% include 'lineas/_filtro_semestre.html' ignore missing %}\` que F2 del /modulo plantó NO la reconoce esta versión de Django (loader_tags.py:343 lanza). B3 lo detectó al cargar /cuadrillas/ y removió en cuadrillas/lista.html. Pero F2 plantó la misma sintaxis en 2 templates más que nadie tocó.

## Fix

Remover \`ignore missing\` de:
- \`templates/campo/avance_registrar.html:15\`
- \`templates/lineas/detalle.html:18\`

B2.1 ya creó \`_filtro_semestre.html\` en el mismo bundle, así que el flag \`ignore missing\` era defensive durante window F2→F3 que ya no existe.

## Test plan
- Deploy + curl \`/campo/avance/registrar/?linea_id=<UUID>\` → HTTP 200
- \`/lineas/<UUID>/\` → HTTP 200
- Re-correr \`/qa-prod Instelec\` → b12 verde

Refs: #101 (cierra HTTP 500)

🤖 Generado por hotfix manual post-/modulo