### PR TITLE
hotfix: {# multiline #} fugando como texto visible (refs #111)

### DIFF
--- a/templates/construccion/_actividades_finales_row.html
+++ b/templates/construccion/_actividades_finales_row.html
@@ -1,5 +1,7 @@
-{# B1 — Partial: fila de la matriz Actividades Finales.
-   Reemplazado por HTMX tras un toggle. Refresca celdas + % avance + badge. #}
+{% comment %}
+B1 — Partial: fila de la matriz Actividades Finales.
+Reemplazado por HTMX tras un toggle. Refresca celdas + % avance + badge.
+{% endcomment %}
 {% load l10n %}
 {% localize off %}
 <tr id="fila-torre-{{ fila.torre.id }}"

--- a/templates/construccion/_proyecto_tabs.html
+++ b/templates/construccion/_proyecto_tabs.html
@@ -1,5 +1,7 @@
-{# Breadcrumb compacto. La navegación principal entre categorías está ahora
-   en el sidebar izquierdo (panel lateral) — issue #71. #}
+{% comment %}
+Breadcrumb compacto. La navegación principal entre categorías está ahora
+en el sidebar izquierdo (panel lateral) — issue #71.
+{% endcomment %}
 <div class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 mb-4">
   <a href="{% url 'construccion:lista' %}" class="hover:underline">Proyectos</a>
   <span>›</span>

--- a/templates/construccion/partials/_kpi_card.html
+++ b/templates/construccion/partials/_kpi_card.html
@@ -1,6 +1,7 @@
-{# B3 — KPI card individual. Espera 'kpi' en contexto con keys:
-   key, label, value, unit, status, accent ('green'|'amber'|'red'), description.
-#}
+{% comment %}
+B3 — KPI card individual. Espera 'kpi' en contexto con keys:
+key, label, value, unit, status, accent ('green'|'amber'|'red'), description.
+{% endcomment %}
 <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4
             border-l-4
             {% if kpi.accent == 'green' %}border-green-500

--- a/templates/indicadores/_ans_componente.html
+++ b/templates/indicadores/_ans_componente.html
@@ -1,5 +1,7 @@
-{# Componente ANS individual: barra progress + meta + estado.
-   Espera contexto: componente = {key, nombre, valor, peso, meta, ok} #}
+{% comment %}
+Componente ANS individual: barra progress + meta + estado.
+Espera contexto: componente = {key, nombre, valor, peso, meta, ok}
+{% endcomment %}
 <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
     <div class="flex items-start justify-between mb-2">
         <div>

--- a/templates/indicadores/_kpi_card_mant.html
+++ b/templates/indicadores/_kpi_card_mant.html
@@ -1,5 +1,7 @@
-{# KPI card generica de Mantenimiento.
-   Espera contexto: kpi = {label, valor, sufijo, meta_label, ok, color_ok, color_ko} #}
+{% comment %}
+KPI card generica de Mantenimiento.
+Espera contexto: kpi = {label, valor, sufijo, meta_label, ok, color_ok, color_ko}
+{% endcomment %}
 <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border-l-4 {% if kpi.ok %}{{ kpi.color_ok|default:'border-green-500' }}{% else %}{{ kpi.color_ko|default:'border-amber-500' }}{% endif %}">
     <p class="text-xs text-gray-500 dark:text-gray-400 mb-1">{{ kpi.label }}</p>
     <p class="text-3xl font-bold {% if kpi.ok %}text-green-700 dark:text-green-300{% else %}text-amber-700 dark:text-amber-300{% endif %}">

--- a/tests/unit/test_templates_no_multiline_django_comments.py
+++ b/tests/unit/test_templates_no_multiline_django_comments.py
@@ -1,0 +1,37 @@
+"""Regresión #111 — Django `{# ... #}` comments must be single-line.
+
+Django Template Language only parses `{# ... #}` as a comment when it stays
+on one line. Multi-line variants leak into the rendered HTML as plain text,
+which Ana Sofía reported as "aparecen estos textos como de codigo".
+For multi-line documentation use `{% comment %} ... {% endcomment %}`.
+"""
+import os
+import re
+
+from django.conf import settings
+
+
+_TEMPLATES_DIR = os.path.join(settings.BASE_DIR, 'templates')
+_MULTILINE = re.compile(r'\{#.*?#\}', re.DOTALL)
+
+
+def _walk_templates():
+    for root, _, files in os.walk(_TEMPLATES_DIR):
+        for f in files:
+            if f.endswith('.html'):
+                yield os.path.join(root, f)
+
+
+def test_no_multiline_django_comments_in_templates():
+    offenders = []
+    for path in _walk_templates():
+        with open(path, encoding='utf-8') as fh:
+            content = fh.read()
+        for m in _MULTILINE.finditer(content):
+            if '\n' in m.group(0):
+                offenders.append(f'{os.path.relpath(path, settings.BASE_DIR)}: {m.group(0)[:80]!r}')
+    assert not offenders, (
+        'Multi-line `{# ... #}` Django comments leak as visible text. '
+        'Use `{% comment %} ... {% endcomment %}` instead.\n  - '
+        + '\n  - '.join(offenders)
+    )


### PR DESCRIPTION
## Resumen

Django Template Language solo parsea `{# ... #}` como comentario si queda en **una sola línea**. Los partials que /modulo creó en B1/B3/B4 usaron `{# ... #}` multilínea — Django los renderiza como **texto plano visible** en la UI. Eso explica el reporte de Ana Sofía en #111: *"no están los datos correspondientes y aparecen estos textos como de codigo"*.

URLs afectadas (todas con HTTP 200, pero con basura visible):
- `/construccion/<id>/actividades-finales/` (#74 → B1, `_actividades_finales_row.html` aparece 64×N veces)
- `/construccion/<id>/indicadores-financieros/` (#97 → B3, `_kpi_card.html` × 6 + `_proyecto_tabs.html`)
- `/indicadores/dashboard/mantenimiento/` (#99 → B4, mismo patrón en `_kpi_card_mant.html` + `_ans_componente.html`)

## Fix

5 partials: convertir `{# ... \n ... #}` → `{% comment %}...{% endcomment %}`.

## Test regresión

`tests/unit/test_templates_no_multiline_django_comments.py` escanea todos los `templates/**/*.html` y falla si reaparece el patrón.

## Test plan

- [x] Test estático local verifica los 5 fixes
- [ ] CI green
- [ ] Smoke prod: las 2 URLs reportadas + dashboard-mantenimiento sin `{#` ni `{%` visibles

Refs #111