### PR TITLE
feat(dashboards): columna Pendientes + símbolo por fase Curva S (#75 #77)

### DIFF
--- a/apps/construccion/migrations/0022_dashboard_pendientes.py
+++ b/apps/construccion/migrations/0022_dashboard_pendientes.py
@@ -1,0 +1,21 @@
+"""Agregar campo `pendientes` (TextField) a DashboardAvanceSemanal — refs #75 #77."""
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('construccion', '0021_merge_b2_b3_oc_mont'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='dashboardavancesemanal',
+            name='pendientes',
+            field=models.TextField(
+                blank=True,
+                help_text='Texto libre — clima, falta materiales, espera permisos, etc.',
+                verbose_name='Pendientes',
+            ),
+        ),
+    ]

--- a/apps/construccion/models.py
+++ b/apps/construccion/models.py
@@ -1326,6 +1326,11 @@ class DashboardAvanceSemanal(BaseModel):
         'Torres incluidas (cons)', max_length=300, blank=True,
     )
 
+    pendientes = models.TextField(
+        'Pendientes', blank=True,
+        help_text='Texto libre — clima, falta materiales, espera permisos, etc.',
+    )
+
     class Meta:
         db_table = 'construccion_dashboard_semanal'
         verbose_name = 'Dashboard — Avance semanal'

--- a/apps/construccion/views.py
+++ b/apps/construccion/views.py
@@ -2239,6 +2239,7 @@ class DashboardSemanaUpsertView(LoginRequiredMixin, RoleRequiredMixin, View):
                 'torres_construidas_semana': cons,
                 'torres_incluidas_prog': request.POST.get('torres_incluidas_prog', '').strip()[:300],
                 'torres_incluidas_cons': request.POST.get('torres_incluidas_cons', '').strip()[:300],
+                'pendientes': request.POST.get('pendientes', '').strip(),
             },
         )
         recalcular_dashboard_acumulados(proyecto, fase)

--- a/templates/construccion/dashboard_curva_s.html
+++ b/templates/construccion/dashboard_curva_s.html
@@ -20,7 +20,7 @@
     <!-- Header con tabs de fase -->
     <div class="flex items-center gap-4">
         <div class="flex-1">
-            <h1 class="text-2xl font-bold text-gray-900 dark:text-white">📊 Dashboard Curva S</h1>
+            <h1 class="text-2xl font-bold text-gray-900 dark:text-white">{% if fase_activa == 'OOCC' %}🏗️ Dashboard Obra Civil{% elif fase_activa == 'MONTAJE' %}🔧 Dashboard Montaje{% elif fase_activa == 'TENDIDO' %}🔌 Dashboard Tendido{% else %}📊 Dashboard Curva S{% endif %}</h1>
             <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
                 Proyecto: <span class="font-medium">{{ proyecto.nombre }}</span>
                 · Total torres: <span class="font-medium">{{ total_torres }}</span>
@@ -66,7 +66,7 @@
     <!-- Form agregar/editar semana -->
     <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-4">
         <h2 class="font-semibold mb-3">Agregar / editar semana</h2>
-        <form @submit.prevent="guardar()" class="grid grid-cols-1 md:grid-cols-5 gap-3 text-sm items-end">
+        <form @submit.prevent="guardar()" class="grid grid-cols-1 md:grid-cols-6 gap-3 text-sm items-end">
             <label class="flex flex-col">
                 <span class="text-gray-500 mb-1">Semana (lunes)</span>
                 <input type="date" x-model="form.semana" required
@@ -85,6 +85,11 @@
             <label class="flex flex-col">
                 <span class="text-gray-500 mb-1">Torres prog (opt.)</span>
                 <input type="text" x-model="form.torres_prog" placeholder="1, 38, 39"
+                       class="px-3 py-1.5 rounded border border-gray-300 dark:border-gray-600 dark:bg-gray-700">
+            </label>
+            <label class="flex flex-col">
+                <span class="text-gray-500 mb-1">Pendientes (opt.)</span>
+                <input type="text" x-model="form.pendientes" placeholder="Clima, falta materiales, ..."
                        class="px-3 py-1.5 rounded border border-gray-300 dark:border-gray-600 dark:bg-gray-700">
             </label>
             <button type="submit" class="px-4 py-1.5 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium">Guardar</button>
@@ -106,6 +111,7 @@
                         <th class="px-3 py-2 text-right font-semibold">Ejec. acum.</th>
                         <th class="px-3 py-2 text-right font-semibold">% Ejec.</th>
                         <th class="px-3 py-2 text-right font-semibold">Varianza</th>
+                        <th class="px-3 py-2 text-left font-semibold">Pendientes</th>
                         <th class="px-3 py-2 text-center font-semibold">Acciones</th>
                     </tr>
                 </thead>
@@ -120,13 +126,14 @@
                         <td class="px-3 py-2 text-right">{{ s.torres_construidas_acum }}</td>
                         <td class="px-3 py-2 text-right">{{ s.pct_construido }}%</td>
                         <td class="px-3 py-2 text-right {% if s.varianza_acum < 0 %}text-red-600{% elif s.varianza_acum > 0 %}text-green-600{% endif %}">{{ s.varianza_acum }}</td>
+                        <td class="px-3 py-2 text-left text-xs text-gray-700 dark:text-gray-300 max-w-xs truncate" title="{{ s.pendientes }}">{{ s.pendientes|default:"—" }}</td>
                         <td class="px-3 py-2 text-center">
-                            <button @click="cargarFila('{{ s.semana|date:'Y-m-d' }}', {{ s.torres_programadas_semana }}, {{ s.torres_construidas_semana }}, '{{ s.torres_incluidas_prog|escapejs }}')" class="text-blue-600 hover:underline text-xs">Editar</button>
+                            <button @click="cargarFila('{{ s.semana|date:'Y-m-d' }}', {{ s.torres_programadas_semana }}, {{ s.torres_construidas_semana }}, '{{ s.torres_incluidas_prog|escapejs }}', '{{ s.pendientes|escapejs }}')" class="text-blue-600 hover:underline text-xs">Editar</button>
                             <button @click="borrar('{{ s.id }}')" class="text-red-600 hover:underline text-xs ml-2">Borrar</button>
                         </td>
                     </tr>
                     {% empty %}
-                    <tr><td colspan="9" class="px-3 py-8 text-center text-gray-500">No hay semanas capturadas todavía.</td></tr>
+                    <tr><td colspan="10" class="px-3 py-8 text-center text-gray-500">No hay semanas capturadas todavía.</td></tr>
                     {% endfor %}
                 </tbody>
             </table>
@@ -146,7 +153,7 @@ function dashboardCurvaS(cfg) {
         totalTorres: cfg.totalTorres,
         chartInicial: cfg.chartInicial,
         chart: null,
-        form: { semana: '', prog: 0, cons: 0, torres_prog: '' },
+        form: { semana: '', prog: 0, cons: 0, torres_prog: '', pendientes: '' },
         mensaje: '', mensajeTipo: '',
         init() {
             // Esperar a window.load (todos los recursos cargados, incluido Chart.js script)
@@ -214,8 +221,8 @@ function dashboardCurvaS(cfg) {
                 this.renderChart(d);
             }
         },
-        cargarFila(semana, prog, cons, torres_prog) {
-            this.form = { semana, prog, cons, torres_prog };
+        cargarFila(semana, prog, cons, torres_prog, pendientes) {
+            this.form = { semana, prog, cons, torres_prog, pendientes: pendientes || '' };
             this.mensaje = '';
         },
         async guardar() {
@@ -226,6 +233,7 @@ function dashboardCurvaS(cfg) {
             fd.append('torres_programadas_semana', this.form.prog);
             fd.append('torres_construidas_semana', this.form.cons);
             fd.append('torres_incluidas_prog', this.form.torres_prog);
+            fd.append('pendientes', this.form.pendientes || '');
             try {
                 const r = await fetch(this.urlUpsert, {
                     method: 'POST',

--- a/tests/unit/test_dashboard_curva_s.py
+++ b/tests/unit/test_dashboard_curva_s.py
@@ -166,6 +166,27 @@ class TestDashboardSemanaUpsert:
         })
         assert resp.status_code == 400
 
+    def test_pendientes_se_persiste_y_se_muestra(self, admin_client, proyecto):
+        """Refs #75 #77 — campo pendientes texto libre por semana."""
+        resp = admin_client.post(self._url(proyecto), {
+            "fase": "OOCC", "semana": "2026-01-05",
+            "torres_programadas_semana": "2", "torres_construidas_semana": "1",
+            "pendientes": "Clima desfavorable, falta permisos",
+        })
+        assert resp.status_code == 200
+        obj = DashboardAvanceSemanal.objects.get(
+            proyecto=proyecto, fase='OOCC', semana=date(2026, 1, 5),
+        )
+        assert obj.pendientes == "Clima desfavorable, falta permisos"
+        # La vista del dashboard debe renderizar el texto
+        url_dashboard = reverse("construccion:dashboard_obra_civil",
+                                kwargs={"proyecto_id": proyecto.id})
+        page = admin_client.get(url_dashboard)
+        assert page.status_code == 200
+        assert b"Clima desfavorable" in page.content
+        # Símbolo Obra Civil debe aparecer en el header (no el genérico 📊)
+        assert "🏗️ Dashboard Obra Civil".encode() in page.content
+
 
 @pytest.mark.django_db
 class TestDashboardSemanaDelete:


### PR DESCRIPTION
## Resumen

Gap menor del plan original de Ana Sofía en los dashboards Curva S (#75 OC, #77 Montaje):
1. **Columna "Pendientes"** texto libre por semana (clima, falta materiales, espera permisos, etc.).
2. **Símbolo del Dashboard Obra Civil** cambia de genérico 📊 a contextual 🏗️ (Ana Sofía pidió esto explícitamente en su edición del plan).

## Cambios

- **Modelo** `DashboardAvanceSemanal`: agregar `TextField pendientes` (blank=True).
- **Migration 0022_dashboard_pendientes** (AddField, no destructiva).
- **Vista** `DashboardSemanaUpsertView` acepta `pendientes` del POST y lo persiste.
- **Template** `dashboard_curva_s.html`:
  - Header: símbolo dinámico por fase — OOCC 🏗️, MONTAJE 🔧, TENDIDO 🔌.
  - Form: input "Pendientes (opt.)" + JS form state + payload extendido en `guardar()`.
  - Tabla: columna "Pendientes" con truncate + tooltip + colspan empty actualizado.
  - `cargarFila()`: firma extendida para preservar el campo al editar.
- **Test** `test_pendientes_se_persiste_y_se_muestra`: verifica persistencia + render texto + presencia del nuevo símbolo en el header.

## Test plan

- [x] py_compile OK
- [x] No `{# multilínea #}` (test estático preserva regla #111)
- [ ] CI suite verde (sin venv local, diferido a runner)
- [ ] Deploy + smoke post-deploy

Refs: #75 #77