### PR TITLE
feat(financiero): complemento PDEO — Transacciones + Reportes + PyG drill-down (#103)

### DIFF
--- a/SPRINTS/PLAN_2026-05-26_modulo_excel_paridad.md
+++ b/SPRINTS/PLAN_2026-05-26_modulo_excel_paridad.md
@@ -1,0 +1,434 @@
+# PLAN — Re-hacer Obra Civil (#74) y Montaje (#76) con paridad al Excel del cliente
+
+**Fecha**: 2026-05-26
+**Autor**: Miguel + Claude (planning agent)
+**Repo**: Indunnova16/Instelec
+**Issues**: #74 (Obra Civil — CANT OOCC), #76 (Montaje — CANT MONTAJE)
+**Origen**: Ana Sofía documentó en los issues la estructura completa del Excel (`Documentacion/Obra civil.xlsx`, `Documentacion/Montaje.xlsx`) — el primer pass entregó matrices simplificadas (6 columnas / 4 etapas) cuando el cliente espera paridad campo-a-campo con el Excel (100 columnas OOCC, 30 columnas MONTAJE).
+**Sucesor de**: `PLAN_2026-05-22_uis_oc_montaje_tendido.md` (entregó iteración 1 simplificada).
+
+---
+
+## 0. Resumen ejecutivo
+
+- **Approach elegido**: **C** — reemplazar el simplificado por modelos detallados con paridad Excel, y dejar la matriz actual como **vista RESUMEN auto-calculada** que derive su % por fase de los detalles. Las URLs `/obra-civil/` y `/montaje/` siguen siendo las puertas de entrada (el cliente no aprende rutas nuevas), pero su contenido cambia.
+- **Topología /modulo** (4 bloques, B2∥B3 en paralelo):
+  - **B1** (scaffolding): pestañas reusables, breadcrumb, pre-asignación de números de migration, partial stubs sin `{# multilínea #}`.
+  - **B2** (Obra Civil paridad) ∥ **B3** (Montaje paridad).
+  - **B4** (resumen auto-calculado + integración dashboards #75/#77 + E2E final).
+- **Modelos nuevos**: 2 (`ObraCivilTorreDetalle`, `MontajeEstructuraTorreDetalle`) + 1 enum (`FuncionMontajeTorre`).
+- **Modelos modificados**: `ObraCivilTorre` y `MontajeEstructuraTorre` → se convierten en **caches calculados** (avance_* deja de ser editable manual; se recalcula desde el detalle vía signal o property).
+- **URLs**: 0 nuevas obligatorias (todo bajo `/obra-civil/` y `/montaje/`). +4 internas para drill-down a sección/pestaña.
+- **Templates nuevos**: 10 (5 OC: 1 índice de pestañas + 6 pestañas tab content + 1 resumen; 5 MONTAJE: 1 índice + 7 secciones + 1 resumen). Templates legacy (`obra_civil_matriz.html`, `montaje_matriz.html`) se RE-PROPÓSITAN como resumen.
+- **Estimado total**: 5–6 días-Claude (B1: 0.5d, B2: 2d, B3: 2d, B4: 1d, buffer integración +0.5d).
+- **Gotchas críticos**: pre-asignar números de migration (B2=0019, B3=0020), prohibir `{% include ... ignore missing %}`, prohibir `{# multi-línea #}` en partials, respetar allowlist de 13 acciones del runner /qa-prod, verificar nombres de tabla con `psql \dt construccion_*` antes de emitir journey YAML.
+
+---
+
+## 1. Decisión arquitectónica: por qué Approach C
+
+| Aspecto | A (reemplazo duro) | B (coexistir) | **C (reemplazar + resumen)** ✅ |
+|---|---|---|---|
+| URLs que el cliente conoce | rompe `/obra-civil/` y `/montaje/` (cambio de semántica sin warning) | preserva ambas + agrega `/obra-civil-detalle/` (cliente no sabe cuál usar) | **preserva slug y cambia contenido a vista útil (resumen calculado)** |
+| Datos legacy en prod | drop tablas (riesgo pérdida) | duplica capa (matriz vieja queda dead-code) | **migración suave: pesos del proyecto sobreviven, avances manuales se mueven a defaults del detalle** |
+| Dashboards #75/#77 ya conectados | rompe inputs del dashboard | sigue leyendo matriz vieja (NO refleja datos detallados) | **dashboard lee el resumen auto-calculado → siempre coherente** |
+| Sidebar (`obra-civil`, `dashboard-obra-civil`, `montaje`, `dashboard-montaje`) | requiere relabel | requiere relabel y add nuevo item | **NO cambia sidebar** (4 entries existentes mantienen URLs) |
+| Soporte a `OPERARIO_ROLES` y `filtrar_torres_por_cuadrilla` | tienes que reaplicarlo | duplicado | **se hereda igual** |
+| Esfuerzo | alto (rompe contratos) | medio (más código) | **medio (pero contrato preservado)** |
+| Riesgo regresión | alto | bajo | **medio (sólo el cálculo del resumen)** |
+
+C gana porque preserva 3 contratos críticos: la URL que el cliente memorizó, los inputs del dashboard que ya consume el resumen, y los roles operario/admin sin redoble. El riesgo se concentra en un solo punto (el cálculo del resumen) que es testeable unit.
+
+**Salvedad**: si la data manual en `ObraCivilTorre.avance_*` o `MontajeEstructuraTorre.avance_*` ya tiene valores capturados por el cliente en prod, hay que preservarlos como SEED de los detalles (no perderlos). Ver §3 (migración de datos).
+
+---
+
+## 2. Inventario de campos derivado del Excel real
+
+> Fuente: `Documentacion/Obra civil.xlsx` hoja **CANT OOCC** (100 columnas) y **OOCC** (dashboard resumen).
+> Fuente: `Documentacion/Montaje.xlsx` hoja **CANT MONTAJE** (30 columnas) y **MONTAJE** (dashboard resumen).
+> Las dos `.xlsx` contienen el mismo workbook (mismas 7 hojas).
+
+### 2.1 CANT OOCC — 100 columnas reales
+
+Pesos (fila R2 del Excel, suman 1.00):
+- Y (Excavación) = 0.4
+- AR (Solado) = 0.05
+- BE (Acero) = 0.1
+- CK (Vaciado) = 0.4
+- CR (Compactación) = 0.05
+- Cerramiento NO tiene peso explícito en el Excel (está dentro del bloque de Excavación) — **decisión**: dejarlo configurable (default 0%) y advertir al cliente.
+
+Total columnas por **sección**:
+
+| # | Sección | Cols Excel | Campos Django (resumen) |
+|---|---|---|---|
+| Identidad | TORRE (B), DISEÑO CONSTRUIDO (C), Replanteo topo (D), Patas (E) | 4 | FK + diseño constructivo (helicoidal/zapatas/etc), boolean replanteo topo, pata (A/B/C/D) |
+| **Cerramiento** (F–J) | Madera (F), lona/alambre (G), señalización/baño (H), notas (I), finalizado (J) | 5 | 2 PositiveSmallInteger + 1 boolean + 1 textfield + 1 boolean |
+| **Excavación** (K–Z) | Cuadrilla (K), FT-022 (L), FT-023 (M), FT-058 (N), tipo excavación (O), metros m³ (P), penetrómetro (Q), FT-922 (R), FT-926 (S), FT-927 (T), FT-925 (U), FT-928 (V), FT-929 (W), monitoreo arqueológico (X), ejecución (Y, peso 0.4), observaciones (Z) | 16 | 1 CharField + 12 booleans (formatos) + 1 Decimal m³ + 1 choice (manual/maquina/pila helicoidal) + 1 choice (en ejecución/liberada) + 1 % avance + 1 TextField |
+| **Solado** (AA–AT) | Ingreso materiales (AA), 4 sub-bloques (agua/arena/grava/cemento) × 4 campos (calc/real/desv/obs) = 16, ejecución (AR, peso 0.05), observaciones (AS), soldadura prolongas STUB (AT) | 20 | 1 choice ingreso + 4×(Decimal calc + Decimal real + Decimal desv computed + TextField obs) + 1 % avance + 1 TextField + 1 boolean |
+| **Acero** (AU–BF) | Ingreso acero (AU), FT-028 (AV), FT-930 (AW), corte/flejado (AX), armado (AY), SPT/varilla (AZ), kg solicitado (BA), kg instalado (BB), desv kg (BC), obs (BD), ejecución (BE, peso 0.1), obs (BF) | 12 | 1 choice + 5 booleans (formatos+armado) + 2 Decimal kg + 1 Decimal desv computed + 2 TextField + 1 % avance |
+| **Vaciado en Concreto** (BG–CL) | FT-916 (BG), nivelación STUB (BH), encofrado (BI), ingreso materiales (BJ), IT-380 (BK), FT-056 (BL), tipo concreto (BM), MPa teórica (BN), 4 sub-bloques agua/arena/grava/cemento × 4 (calc/real/desv/obs) = 16, slump (CE), fecha vaciado (CF), fecha cilindros (CG), inspección final stub (CH), encargado puntas diamante (CI), desencofrado/resane (CJ), ejecución (CK, peso 0.4), obs (CL) | 32 | 6 booleans formatos + 1 choice tipo concreto + 1 Decimal MPa + 4×(Decimal calc + Decimal real + Decimal desv + TextField) + 1 boolean slump + 2 DateField + 1 boolean + 1 CharField encargado + 1 boolean + 1 % avance + 1 TextField |
+| **Compactación** (CM–CS) | FT-914 (CM), suelo natural (CN), suelo cemento (CO), suelo préstamo (CP), volumen m³ (CQ), finalizada (CR, peso 0.05), obs (CS) | 7 | 1 boolean formato + 3 booleans tipo + 1 Decimal m³ + 1 % avance + 1 TextField |
+| Trailer | TOTAL (CT, formula SUMPRODUCT), ejecutado por (CU), comentario (CV) | 3 | calculado + CharField + TextField |
+
+**Granularidad clave**: el Excel tiene **una fila por pata × torre** (R5–R8 muestran E1 con patas A/B/C/D), no una fila por torre. Esto coincide con la granularidad legacy `PataObra` que ya tenemos. **Decisión**: `ObraCivilTorreDetalle` tendrá granularidad torre × pata (igual que PataObra). 4 patas × 64 torres = 256 filas.
+
+### 2.2 CANT MONTAJE — 30 columnas reales
+
+Pesos (fila R2 del Excel, suman 1.00):
+- I (Estructura en sitio) = 0.1
+- L (Prearmada) = 0.2
+- R (Torre montada) = 0.45
+- W (Revisada) = 0.25
+
+(Coincide con los pesos que ya tiene el modelo simplificado.)
+
+| Sección Excel | Cols Excel | Campos Django |
+|---|---|---|
+| **1. Info General** (A–D) | Estructura (A), Función (B fórmula), Tipo (C), Cuerpo (D) | FK a TorreConstruccion (la estructura = numero de torre); Función auto-calculado @property (`Suspensión` si tipo ∈ {A, A especial} else `Retención`); CharField tipo (choices A/A especial/B/C/D/Pórtico/...); CharField cuerpo (C4/C5/C6/...) |
+| **2. Recepción Patio** (E–G) | Fecha recibida (E), patiero sin pendientes (F), observaciones pendientes (G) | DateField + BooleanField + TextField |
+| **3. Pre-armado** (H–M) | Encargado (H), estructura en sitio (I, peso 0.1), fecha inicio (J), fecha fin (K), prearmada (L, peso 0.2), % avance (M) | CharField + Boolean + 2 DateField + Boolean + DecimalField % |
+| **4. Montaje** (N–S) | Encargado (N), fecha inicio (O), fecha fin (P), días montaje (Q computed = P-O), torre montada (R, peso 0.45), observaciones (S) | CharField + 2 DateField + @property days + Boolean + TextField |
+| **5. Controles Calidad** (T–X) | FT-032 (T), FT-913 (U), FT-920 (V), Revisada (W, peso 0.25), Entregada para carga (X) | 5 Boolean |
+| **6. Pesos** (Y–Z) | Peso diseño kl (Y), peso instalado kl (Z) | 2 DecimalField + @property validación ±5% (warning, no bloqueante per Ana Sofía) |
+| **7. Facturación** (AA–AC) | Total estructuras (AA, formula SUMPRODUCT), facturada a dueño (AB), facturada por contratista (AC) | @property avance_ponderado + 2 Boolean (con AC: ¿booleano? El Excel real tiene strings tipo "Cruz"/"Higuita"/"Instelec" → CharField facturador, no boolean) |
+
+**Nota importante sobre AC**: el plan de Ana Sofía dice `0/1`, pero el Excel real R3–R8 tiene strings ("Cruz", "Higuita", "Instelec", "Cruz") — son **nombres de subcontratistas**. **Decisión**: usar CharField `facturado_por_contratista` (max_length=100, blank=True). Más útil para reporting.
+
+**Granularidad**: una fila por torre completa (no por pata). Modelo OneToOne TorreConstruccion ↔ MontajeEstructuraTorreDetalle.
+
+### 2.3 Diferencias vs plan Ana Sofía (a confirmar con cliente, pero proceder con Excel real)
+
+| Campo | Ana Sofía dijo | Excel real | Plan |
+|---|---|---|---|
+| AC Facturadas por contratista | boolean 0/1 | string (nombre) | usar CharField (más útil) |
+| AC vs AB | "0/1" ambos | AB es 0/1, AC es nombre | AB BooleanField, AC CharField |
+| Validación pesos Y/Z | "Z ≥ Y" (no puede pesar menos) | spec dice ±5% | **mantener regla ±5% (warning); fórmula = `|Z-Y|/Y ≤ 0.05`** |
+| OC pestañas | "estructura como Ingeniería con pestañas dinámicas" | Excel es 1 hoja única CANT OOCC con secciones | usar PESTAÑAS UI (Cerramiento/Excavación/Solado/Acero/Vaciado/Compactación) que filtran columnas del mismo modelo (no 6 modelos distintos) |
+
+---
+
+## 3. Modelos Django — diseño detallado
+
+### 3.1 Modelo `ObraCivilTorreDetalle` (nuevo)
+
+Granularidad: **torre × pata** (4 patas: A/B/C/D). 64 torres × 4 = 256 filas.
+
+Total campos: ~110 (5 cerramiento + 16 excavación + 20 solado + 12 acero + 32 vaciado + 7 compactación + 3 trailer + 5 identidad).
+
+Secciones, derivadas literalmente del Excel:
+
+- **Cerramiento** (5): `cerr_madera_un`, `cerr_lona_m`, `cerr_senalizacion_ok`, `cerr_notas`, `cerr_finalizado_ok`.
+- **Excavación** (16): `exc_cuadrilla`, `exc_ft022_ok` (MARCACIÓN), `exc_ft023_ok` (PLANILLA), `exc_ft058_ok` (CONTROL EXCAVACIONES), `exc_tipo` choices manual/maquina/helicoidal, `exc_metros_m3`, `exc_penetrometro_ok`, `exc_ft922_ok` (CONCEPTO ENTIBADO), `exc_ft926_ok` (MARCACIÓN PILOTES), `exc_ft927_ok` (REGISTRO CANTIDADES), `exc_ft925_ok` (PRUEBA CARGA PILOTES), `exc_ft928_ok` (TORQUE), `exc_ft929_ok` (LOCALIZACIÓN FINAL), `exc_monitoreo_arq` choices ejecucion/liberada, `exc_ejecutada_pct` (Y peso 0.4), `exc_observaciones`.
+- **Solado** (20): `sol_ingreso_materiales` choices vehiculo/manual/mular/teleferico, 4 sub-bloques agua/arena/grava/cemento × (calc + real + obs) = 12 campos + 4 @property desv, `sol_ejecutado_pct` (AR peso 0.05), `sol_observaciones`, `sol_soldadura_prolongas_ok`.
+- **Acero** (12): `ace_ingreso`, `ace_ft028_ok` (CARTILLA REFUERZO), `ace_ft930_ok` (REV REFUERZO/FORMALETA/SPT), `ace_corte_flejado_ok`, `ace_armado_sitio_ok`, `ace_spt_herramientas_ok`, `ace_solicitado_kg`, `ace_instalado_kg`, `ace_observaciones`, `ace_instalacion_pct` (BE peso 0.1), `ace_instalacion_obs`, @property `ace_desviacion_kg`.
+- **Vaciado** (32): `vac_ft916_ok`, `vac_nivelacion_stub_ok`, `vac_encofrado_ok`, `vac_ingreso_materiales`, `vac_it380_ok` (INSTRUCTIVO CIMENTACIÓN), `vac_ft056_ok` (CONTROL FUNDACIONES), `vac_tipo_concreto` choices premezclado/obra, `vac_mpa_teorica`, 4 sub-bloques agua/arena/grava/cemento × (calc + real + obs), `vac_slump_ok`, `vac_fecha_vaciado`, `vac_fecha_cilindros`, `vac_inspeccion_stub_ok`, `vac_encargado_puntas`, `vac_desencofrado_ok`, `vac_ejecutado_pct` (CK peso 0.4), `vac_observaciones`.
+- **Compactación** (7): `com_ft914_ok`, `com_suelo_natural_ok`, `com_suelo_cemento_ok`, `com_suelo_prestamo_ok`, `com_volumen_m3`, `com_finalizada_pct` (CR peso 0.05), `com_observaciones`.
+- **Trailer** (3): `ejecutado_por`, `comentario_general`, @property `avance_ponderado` (SUMPRODUCT con pesos del proyecto).
+
+Constraints:
+- `unique_together = [('torre', 'pata')]`
+- `db_table = 'construccion_oc_detalle'`
+- `ordering = ['torre__numero', 'pata']`
+
+### 3.2 Modelo `MontajeEstructuraTorreDetalle` (nuevo)
+
+Granularidad: **OneToOne con TorreConstruccion**.
+
+Campos derivados del Excel CANT MONTAJE (30 columnas):
+
+- **Info General**: `tipo_torre` choices A/A_esp/B/C/D/portico, `cuerpo`, @property `funcion` (Suspensión si tipo ∈ {A, A_esp} else Retención).
+- **Recepción Patio**: `fecha_recibida_patio`, `recepcion_sin_pendientes_ok`, `recepcion_observaciones`.
+- **Pre-armado**: `prearmado_encargado`, `estructura_en_sitio_ok` (I peso 0.1), `prearmado_fecha_inicio`, `prearmado_fecha_fin`, `prearmada_ok` (L peso 0.2), `prearmado_pct`.
+- **Montaje**: `montaje_encargado`, `montaje_fecha_inicio`, `montaje_fecha_fin`, @property `dias_montaje` (P-O), `torre_montada_ok` (R peso 0.45), `montaje_observaciones`.
+- **Controles Calidad**: `ft032_control_montaje_ok`, `ft913_verticalidad_torsion_ok`, `ft920_recepcion_montaje_ok`, `revisada_ok` (W peso 0.25), `entregada_para_carga_ok` (gate Tendido).
+- **Pesos**: `peso_diseno_kl`, `peso_instalado_kl`, @property `peso_desviacion_pct`, @property `peso_alerta` (True si desv > 5%).
+- **Facturación**: `facturada_a_dueno_ok`, `facturada_por_contratista` (CharField, no Boolean), @property `avance_ponderado` (SUMPRODUCT con pesos 10/20/45/25).
+
+Constraints:
+- `OneToOneField(TorreConstruccion, related_name='mont_detalle')`
+- `db_table = 'construccion_mont_detalle'`
+
+### 3.3 Modelos modificados
+
+**`ObraCivilTorre`** (modelo simplificado actual): mantiene los 6 DecimalField `avance_*` pero ahora son **caches calculados**. Método `recalcular_desde_detalles()` que promedia las 4 patas del detalle. Signal `post_save` en `ObraCivilTorreDetalle` lo llama. Endpoint `ObraCivilAvanceUpdateView` se cambia a devolver 410 Gone con mensaje claro.
+
+**`MontajeEstructuraTorre`**: idéntico tratamiento.
+
+**`ProyectoConstruccion`** (campos `peso_*_pct`): NO cambian — los pesos siguen viviendo aquí y se reutilizan tanto para el detalle como para el resumen.
+
+### 3.4 Borrar / deprecar
+
+Nada se borra en B2/B3. El cleanup (drop tablas `construccion_obra_civil_torre` y `construccion_montaje_estructura_torre`) se difiere a una iteración 3 cuando el cliente haya validado el detalle por 2+ semanas en prod.
+
+---
+
+## 4. Migración de datos existentes
+
+> Estado de prod: F1 de B1 debe verificar con `psql \dt construccion_*` + count de filas con data útil ANTES de aplicar.
+
+### 4.1 Plan de migración (forward)
+
+**Migration `0019_obracivil_detalle.py`** (B2, pre-asignada):
+1. `CreateModel(ObraCivilTorreDetalle)`.
+2. `RunPython` data migration:
+   - Para cada `ObraCivilTorre`, crear 4 `ObraCivilTorreDetalle` (uno por pata A/B/C/D).
+   - Seed: poner `cerr_finalizado_ok=True` si `obra_civil_torre.avance_cerramiento >= 0.99`, `exc_ejecutada_pct = obra_civil_torre.avance_excavacion`, etc. (mapeo 1:1 de las 6 columnas legacy a los 6 % de avance del detalle).
+   - Si `PataObra` existe para esa torre/pata, leer los booleans `cerramiento_finalizado_ok`, `excavacion_ok`, `solado_ok`, `acero_refuerzo_ok`, `vaciado_ok`, `relleno_compactacion_ok` y propagarlos al detalle.
+3. `RunPython` reverse: no-op (forward-only, los detalles persisten).
+
+**Migration `0020_montaje_detalle.py`** (B3, pre-asignada):
+1. `CreateModel(MontajeEstructuraTorreDetalle)`.
+2. `RunPython` data migration:
+   - Para cada `MontajeEstructuraTorre`, crear 1 `MontajeEstructuraTorreDetalle`.
+   - Seed: `estructura_en_sitio_ok = avance_estructura_sitio >= 0.99`, `prearmada_ok = avance_prearamada >= 0.99`, `torre_montada_ok = avance_torre_montada >= 0.99`, `revisada_ok = avance_revisada >= 0.99`.
+   - Si `FaseTorre` tiene `entrega_carga_ok`, propagar a `entregada_para_carga_ok`.
+3. Reverse: no-op.
+
+### 4.2 Validación pre-migración
+
+Antes de aplicar en prod, F1 verifica:
+```bash
+PGPASSWORD=Margarita28 psql -h 130.211.117.166 -U postgres -d instelec_db -c \
+  "SELECT COUNT(*) FILTER (WHERE avance_cerramiento > 0 OR avance_excavacion > 0 OR avance_solado > 0 OR avance_acero > 0 OR avance_vaciado > 0 OR avance_compactacion > 0) AS rows_con_data, COUNT(*) AS total FROM construccion_obra_civil_torre"
+```
+Si `rows_con_data > 0`, confirmar con Miguel que el seed map (avance → ejecutado_pct) es semánticamente correcto antes del deploy.
+
+### 4.3 Merge migration anti-conflict
+
+Para prevenir `multiple leaf nodes` (`feedback_modulo_f3_migration_conflict`), F4 crea:
+
+`apps/construccion/migrations/0021_merge_b2_b3.py`:
+```python
+class Migration(migrations.Migration):
+    dependencies = [
+        ('construccion', '0019_obracivil_detalle'),
+        ('construccion', '0020_montaje_detalle'),
+    ]
+    operations = []
+```
+
+---
+
+## 5. URLs
+
+### 5.1 Preservadas (NO cambian — contrato del cliente)
+
+```python
+path('<uuid:proyecto_id>/obra-civil/', views.ObraCivilResumenView.as_view(), name='obra_civil_lista'),
+path('<uuid:proyecto_id>/montaje/', views.MontajeResumenView.as_view(), name='montaje_lista'),
+path('<uuid:proyecto_id>/obra-civil/pesos/', views.ObraCivilPesosUpdateView.as_view(), name='obra_civil_pesos_update'),
+path('<uuid:proyecto_id>/montaje/pesos/', views.MontajePesosUpdateView.as_view(), name='montaje_pesos_update'),
+path('<uuid:proyecto_id>/obra-civil/<uuid:torre_id>/patas/', views.ObraCivilTorreView.as_view(), name='obra_civil_torre_patas'),
+path('<uuid:proyecto_id>/montaje/<uuid:torre_id>/fase/', views.MontajeTorreView.as_view(), name='montaje_torre_fase'),
+```
+
+### 5.2 Nuevas (4)
+
+```python
+path('<uuid:proyecto_id>/obra-civil/<uuid:torre_id>/detalle/', views.ObraCivilDetalleView.as_view(), name='obra_civil_detalle'),
+path('<uuid:proyecto_id>/obra-civil/<uuid:torre_id>/detalle/<str:pata>/<str:seccion>/', views.ObraCivilDetalleSeccionView.as_view(), name='obra_civil_detalle_seccion'),
+path('<uuid:proyecto_id>/montaje/<uuid:torre_id>/detalle/', views.MontajeDetalleView.as_view(), name='montaje_detalle'),
+path('<uuid:proyecto_id>/montaje/<uuid:torre_id>/detalle/<str:seccion>/save/', views.MontajeDetalleSaveView.as_view(), name='montaje_detalle_save'),
+```
+
+### 5.3 Sidebar
+
+NO se toca. Las 4 entries (`obra-civil`, `dashboard-obra-civil`, `montaje`, `dashboard-montaje`) siguen apuntando a las mismas URL names.
+
+---
+
+## 6. Templates
+
+### 6.1 Re-propósito (2)
+
+| Template existente | Nuevo propósito | Cambios |
+|---|---|---|
+| `templates/construccion/obra_civil_matriz.html` | **Vista resumen auto-calculada** (cliente la abre desde sidebar) | Mostrar matriz 64×6 read-only con % derivado; cada celda es link al detalle (`obra_civil_detalle?pata=A&seccion=cerramiento`); panel pesos sigue editable |
+| `templates/construccion/montaje_matriz.html` | **Vista resumen auto-calculada** | Mostrar matriz 64×4 read-only; cada celda → link al detalle por sección; panel pesos sigue editable |
+
+### 6.2 Nuevos (10 + 13 partials)
+
+```
+templates/construccion/
+├── obra_civil_detalle.html              (~180 líneas, tabs verticales A/B/C/D + tabs horizontales secciones)
+├── partials/oc_seccion_cerramiento.html (5 inputs)
+├── partials/oc_seccion_excavacion.html  (16 inputs incluye fts)
+├── partials/oc_seccion_solado.html      (20 inputs, sub-bloque agua/arena/grava/cemento × 4)
+├── partials/oc_seccion_acero.html       (12 inputs)
+├── partials/oc_seccion_vaciado.html     (32 inputs sub-bloques)
+├── partials/oc_seccion_compactacion.html (7 inputs)
+├── montaje_detalle.html                 (~200 líneas, tabs horizontales por sección)
+├── partials/mont_seccion_general.html
+├── partials/mont_seccion_recepcion.html
+├── partials/mont_seccion_prearmado.html
+├── partials/mont_seccion_montaje.html
+├── partials/mont_seccion_controles.html
+├── partials/mont_seccion_pesos.html
+├── partials/mont_seccion_facturacion.html
+```
+
+**Reglas anti-bug** que cada template y partial DEBE cumplir:
+- **Prohibido** `{% include "x.html" ignore missing %}` — usar include simple sin `ignore missing`. Si el partial no existe aún (timing F2→F3), F2 planta un stub vacío en el mismo commit (`{% comment %}stub plantado por F2 — sobrescrito por <SUB_FEATURE> en F3{% endcomment %}`).
+- **Prohibido** `{# multi-línea \n #}` para docstrings. Usar `{% comment %}...{% endcomment %}`.
+- Test estático `tests/unit/test_templates_no_multiline_django_comments.py` ya valida esto. NO romperlo.
+
+---
+
+## 7. Tests mínimos
+
+### 7.1 Unit `tests/unit/test_oc_detalle.py` (~15 tests, B2)
+
+- Creación de detalle con defaults → todos los % en 0, `avance_ponderado = 0`.
+- Set `cerr_finalizado_ok=True` y `exc_ejecutada_pct=0.5` con pesos 5/30/5/15/30/15 → `avance_ponderado = (1×5 + 0.5×30) / 100 = 20%`.
+- Properties: `sol_agua_desv_m3`, `sol_arena_desv_m3`, `sol_grava_desv_m3`, `sol_cemento_desv_kg`, `ace_desviacion_kg`.
+- `unique_together(torre, pata)` enforced.
+- Signal recalcula `ObraCivilTorre` resumen tras `post_save` del detalle.
+- Data migration 0019: fixture con 1 `ObraCivilTorre` que tiene `avance_excavacion=0.7` → tras migrar, 4 detalles existen con `exc_ejecutada_pct=0.7`.
+
+### 7.2 Unit `tests/unit/test_montaje_detalle.py` (~12 tests, B3)
+
+- `funcion` property: A → Suspensión; A_esp → Suspensión; B → Retención.
+- `dias_montaje`: ambas fechas → diferencia días; una falta → None.
+- `peso_desviacion_pct`: 100 vs 105 → 5.0; 100 vs 110 → 10.0; peso_diseno_kl=0 → None.
+- `peso_alerta`: True si desviacion > 5%.
+- `avance_ponderado` con pesos 10/20/45/25 y 4 booleans True → 100%.
+- Signal recalcula `MontajeEstructuraTorre` resumen tras `post_save`.
+- Migration 0020: `MontajeEstructuraTorre` con `avance_torre_montada=1` → detalle con `torre_montada_ok=True`.
+
+### 7.3 Integration `tests/integration/test_oc_montaje_views.py` (~10 tests, B4)
+
+- GET `/obra-civil/` (resumen) → 200, contiene 6 columnas con % derivado del detalle.
+- GET `/obra-civil/<torre>/detalle/` → 200, 6 pestañas visibles, pata A por default.
+- POST `/obra-civil/<torre>/detalle/A/cerramiento/` con `cerr_finalizado_ok=on` → 200, recalcula resumen.
+- GET `/montaje/<torre>/detalle/` → 200, 7 secciones visibles.
+- POST `/montaje/<torre>/detalle/pesos/save/` con `peso_diseno_kl=100&peso_instalado_kl=106` → 200, returns `peso_alerta=true`.
+
+### 7.4 Smoke runner /qa-prod (B4, journey YAML)
+
+Usando solo las **13 acciones soportadas**: `goto`, `assert_status`, `assert_contains`, `assert_selector`, `fill`, `click`, `screenshot`, `psql_select` (read-only), etc.
+
+Journey:
+- GET `/construccion/<p>/obra-civil/` → assert 200, contiene las 6 secciones.
+- `psql_select` `"SELECT id FROM construccion_oc_detalle LIMIT 1"` → captura uuid.
+- GET `/construccion/<p>/obra-civil/<torre_id>/detalle/?pata=A&seccion=excavacion`.
+- `fill exc_metros_m3 "12.5"`, `click submit`, assert 200.
+- Análogos para `/montaje/` (7 secciones).
+- **NO usar** `psql_insert`, `psql_update`, `http_post`, `upload_file`.
+
+---
+
+## 8. Topología /modulo
+
+```
+B1 scaffolding (0.5d)
+  └── B2 obra_civil_paridad (2d) ─┐
+  └── B3 montaje_paridad   (2d) ──┤── B4 integracion (1d)
+                                   └─→ deploy bundle
+```
+
+### B1 — Scaffolding compartido (~0.5d)
+
+**F1 (planner)** salidas:
+- BLUEPRINT.md.json con sub-features B2 y B3 y migration filenames pre-asignados (`0019_obracivil_detalle.py`, `0020_montaje_detalle.py`) y merge migration `0021_merge_b2_b3.py` para F4.
+- Inventario verificado: lista de db_table reales con `psql \dt construccion_*` (espera ver `construccion_obra_civil_torre`, `construccion_montaje_estructura_torre`, `construccion_torre`, `construccion_pataobra`, `construccion_fasetorre`).
+- URL names exactos del módulo construccion (lectura literal de `apps/construccion/urls.py` actual).
+- Journey YAML stub con solo las 13 acciones soportadas.
+
+**F2 (scaffolding)** entregas:
+- Crear partial stubs vacíos: 6 `oc_seccion_*.html` + 7 `mont_seccion_*.html` — todos con `{% comment %}stub plantado por F2{% endcomment %}`.
+- Crear componente reusable `partials/_tabs_navegacion.html` para pestañas verticales/horizontales (OC y Montaje lo usan).
+- NO tocar `_proyecto_tabs.html` (ya funciona post-fix #111).
+
+### B2 — Obra Civil paridad (~2d)
+
+**F3 sub-agent** en worktree `worktree-b2-obracivil`:
+1. Crear `ObraCivilTorreDetalle` en `models.py`.
+2. `makemigrations construccion --name obracivil_detalle` → renombrar a `0019_obracivil_detalle.py`.
+3. Agregar `RunPython` data migration con seed map.
+4. Views: `ObraCivilResumenView` (re-propósito del actual `ObraCivilMatrizView` → read-only), `ObraCivilDetalleView`, `ObraCivilDetalleSeccionView`.
+5. Actualizar `urls.py` (2 URLs nuevas).
+6. Forms (`forms.py`): `ObraCivilDetalleSeccionForm` × 6 (uno por sección).
+7. Templates: reescribir `obra_civil_matriz.html` como resumen + `obra_civil_detalle.html` + 6 partials de sección.
+8. Signal `post_save` en `ObraCivilTorreDetalle` recalcula `ObraCivilTorre`.
+9. Tests: 15 unit tests.
+
+### B3 — Montaje paridad (~2d) (paralelo a B2)
+
+**F3 sub-agent** en worktree `worktree-b3-montaje`:
+1. Crear `MontajeEstructuraTorreDetalle`.
+2. `makemigrations` → renombrar a `0020_montaje_detalle.py`.
+3. Data migration con seed map.
+4. Views: `MontajeResumenView` (re-propósito), `MontajeDetalleView`, `MontajeDetalleSaveView`.
+5. URLs (2 nuevas).
+6. Forms × 7 (uno por sección).
+7. Templates: reescribir `montaje_matriz.html` + `montaje_detalle.html` + 7 partials.
+8. Signal `post_save`.
+9. Tests: 12 unit tests.
+
+### B4 — Integración + dashboards + E2E (~1d)
+
+**F4 integración**:
+1. Merge worktrees b2 + b3 → branch `final/excel_paridad`.
+2. Crear `0021_merge_b2_b3.py` (anti `multiple leaf nodes`).
+3. Verificar `python manage.py makemigrations --check --dry-run`.
+4. Actualizar `DashboardObraCivilView` y `DashboardMontajeView` para leer del resumen calculado.
+5. Confirmar sidebar sin cambios.
+6. Ejecutar suite completa (unit + integration + estáticos).
+7. `/qa-prod instelec --journey=oc_montaje_paridad` post-deploy.
+
+**F5 deploy**: bundle PR único.
+
+**Closeout paralelo** (#74 y #76): F7 cierra ambos mostrando paridad campo-a-campo con el Excel + smoke OK + dashboards #75/#77 alineados.
+
+---
+
+## 9. Gotchas críticos (memorias aplicadas)
+
+| Gotcha | Memoria | Prevención en este plan |
+|---|---|---|
+| F1 inventa tablas/URLs | `feedback_modulo_f1_schema_url_inventados` | F1 en B1 verifica con `psql \dt construccion_*` y lee `apps/construccion/urls.py` real ANTES de emitir nombres. Lista en BLUEPRINT |
+| F2 planta `{% include ... ignore missing %}` | `feedback_modulo_f2_ignore_missing` | F2 planta stubs VACÍOS con include simple sin `ignore missing`. F3 sobreescribe. Test estático regresión existente protege |
+| F3 ∥ migrations clash | `feedback_modulo_f3_migration_conflict` | B1 pre-asigna `0019_obracivil_detalle.py` (B2) y `0020_montaje_detalle.py` (B3). F4 crea `0021_merge_b2_b3.py` |
+| F1 inventa acciones runner | `feedback_modulo_f1_qa_prod_acciones_soportadas` | F1 emite journey YAML usando solo las 13 acciones (lista pegada en F1 prompt). Mutaciones via `goto`+`fill`+`click`, no `psql_insert` |
+| `{# multi-línea #}` en partials → leak visible | `feedback_django_multiline_comment_partials` (NUEVO 2026-05-26) | F2 y F3 usan `{% comment %}...{% endcomment %}` en todos los partials. Test estático regresión existente protege |
+| Cliente ve "404" tras deploy | nuevo | URL names preservados (obra_civil_lista, montaje_lista); sidebar no cambia; backwards-compat AJAX endpoints (410 Gone con mensaje claro si cliente JS antiguo intenta POST a editar la matriz) |
+| Data perdida al cambiar matriz a resumen | nuevo | Data migration en 0019/0020 lee `avance_*` legacy y lo seedea en el detalle |
+| Suma de pesos OC ≠ 100 (Cerramiento sin peso en Excel) | nuevo | Default `peso_cerramiento_pct=5` se mantiene (suma 100). Si cliente valida que Cerramiento es 0 (parte del bloque Excavación), ajustar default a 0 y peso_excavacion=35. **Decisión a confirmar con cliente en closeout** |
+
+---
+
+## 10. Estimado de tiempo
+
+| Bloque | Trabajo | Estimado |
+|---|---|---|
+| B1 scaffolding | F1 inventario + F2 stubs + BLUEPRINT + journey YAML stub | 0.5 día |
+| B2 obra civil paridad | Modelo (110 fields) + migration + data migration + 3 views + 6 forms + 7 templates + signal + 15 tests | 2 días |
+| B3 montaje paridad | Modelo (30 fields) + migration + data migration + 3 views + 7 forms + 8 templates + signal + 12 tests | 2 días |
+| B4 integración | Merge migration + dashboards alineados + E2E /qa-prod + cleanup + closeout #74/#76 | 1 día |
+| Buffer | Migration conflicts, regresiones, ajustes Ana Sofía | 0.5 día |
+| **Total** | | **6 días** |
+
+Wall-clock con B2 y B3 paralelos reales (2 sub-agents F3 distintos en worktrees aislados): **3.5 días** (B1 0.5 + max(B2,B3) 2 + B4 1).
+
+---
+
+## 11. Pre-requisitos para arrancar /modulo
+
+- `gh` autenticado como mbrt26.
+- Runner self-hosted `vm-indunnova` vivo.
+- `~/Desktop/Repos/Instelec` clean, branch `main` al día.
+- Acceso a `instelec_db` (host 130.211.117.166, user postgres, pass Margarita28) para F1 verificar schema real.
+- `qa_claude@instelec.com` válido para el runner /qa-prod.
+- Última migration confirmada: `0018_merge_b1_b2_0017.py` (próxima libre = 0019).
+
+---
+
+## 12. Comando de invocación
+
+```bash
+/modulo instelec excel_paridad_oc_montaje 74 76
+```
+
+Pasa este plan persistido como input de F1 vía `--plan=SPRINTS/PLAN_2026-05-26_modulo_excel_paridad.md`.

--- a/SPRINTS/PLAN_2026-05-28_103_financiero_complemento.md
+++ b/SPRINTS/PLAN_2026-05-28_103_financiero_complemento.md
@@ -1,0 +1,96 @@
+# PLAN — #103 Módulo Financiero — complemento (no greenfield)
+
+**Fecha**: 2026-05-28
+**Autor**: Miguel + Claude
+**Repo**: Indunnova16/Instelec
+**Issue**: [#103](https://github.com/Indunnova16/Instelec/issues/103) (Ana Sofía, 2026-05-25, 0 comentarios)
+**Status**: borrador, esperando GATE de Miguel
+
+---
+
+## 0. Hallazgo clave
+
+El issue describe un módulo "nuevo" de 38h, pero al inspeccionar `apps/construccion/` el **80% del scope ya existe** (issues #69, #66, #70, mergeados antes de 2026-05-25). Ana Sofía probablemente abrió #103 sin saber que el trabajo previo cubrió la mayoría.
+
+**Delta real: ~12h** (3 vistas + parser Excel + RBAC granular opcional).
+
+---
+
+## 1. Inventario — qué pide #103 vs qué existe hoy
+
+| Spec #103 | Estado actual | Acción |
+|---|---|---|
+| Modelo `Presupuesto` | `CategoriaFinanciera`+`PeriodoFinanciero`+`MovimientoFinanciero(tipo=PRESUPUESTO)` cubren el espacio | ✅ Reusar, documentar mapping en docstring |
+| Modelo `Transaccion` | `TransaccionContable` (líneas 2554+ models.py) — campos: fecha, descripcion, nit_proveedor, valor, iva, centro_costo, adjunto, siigo_id | ✅ Existe, FK a `MovimientoFinanciero` |
+| Modelo `ConceptoFinanciero` | `CategoriaFinanciera` (21 categorías PDEO seedeadas en migration 0007) | ✅ Existe |
+| Modelo `EstadoResultados` (PyG) | `ProyectoConstruccion.pyg_resumen_ejecutivo()` + `pyg_totales` properties | ✅ Existe como properties, NO se necesita modelo separado |
+| Vista `FinancieroListView` (Dashboard) | `DashboardFinancieroView` @ `/construccion/<uuid>/dashboard-financiero/` con KPIs + alertas + curva S financiera | ✅ Existe |
+| Vista `PyGListView` (Estado de resultados) | `DashboardFinancieroView` muestra `resumen=pyg_resumen_ejecutivo()` | ⚠️ Hay PyG en el dashboard pero NO una vista dedicada con drill-down |
+| Vista `PresupuestoListView` (grid mensual) | `FinancieroGridView` @ `/construccion/<uuid>/financiero/` con grid editable categoría × período | ✅ Existe |
+| Vista `TransaccionesListView` (BD con filtros) | ⚠️ NO existe vista lista global de `TransaccionContable` | ❌ FALTA |
+| Vista `TransaccionesUploadView` (cargar Excel PDEO) | ⚠️ NO existe upload + parser | ❌ FALTA |
+| Vista `ReportesFinancierosView` | ⚠️ NO existe reportes personalizados | ❌ FALTA |
+| Parser PDEO Excel (23K rows) | ⚠️ NO existe management command | ❌ FALTA |
+| RBAC perms `financiero.view_pyg`, etc | Usa `allowed_roles = ALL_ADMIN_ROLES` (genérico) | ⚠️ Granular FALTA — pero hay que decidir si vale la pena migrar 5 vistas existentes ahora |
+
+---
+
+## 2. Conflictos detectados
+
+- **URL prefix divergente**: el issue pide `/construccion/financiero/<tab>/` (sin proyecto en el path); el código existente es `/construccion/<uuid:proyecto_id>/financiero/...` (por proyecto). El issue tiene sentido si las nuevas vistas son **globales** (no por proyecto) — apropiado para TransaccionesListView (todas las transacciones del aplicativo) y ReportesFinancieros (cross-proyecto).
+- **Nombres de modelos**: si Ana Sofía espera ver clases con nombre `Transaccion` y `EstadoResultados`, hay que decidir si renombramos `TransaccionContable` → `Transaccion` (alias o rename) o si mantenemos y documentamos en el closeout.
+
+---
+
+## 3. Plan propuesto
+
+### Approach: COMPLEMENTO (no /modulo)
+
+Reusar el modelo PDEO existente y agregar lo que falta. Scope acotado, 1 PR único.
+
+### Sub-items
+
+| # | Tarea | Estimado | Depends | Output |
+|---|---|---|---|---|
+| 1 | `TransaccionesListView` global @ `/construccion/financiero/transacciones/` con filtros (proyecto, categoría, periodo, NIT, fecha) + paginación | 4h | — | view + template + 2 unit tests |
+| 2 | `TransaccionesUploadView` @ `/construccion/financiero/transacciones/upload/` con form Excel PDEO, parser de las 4 hojas (BD, Res EP, Presupuesto, PyG) que pueble `CategoriaFinanciera` + `PeriodoFinanciero` + `MovimientoFinanciero` + `TransaccionContable` | 5h | 1 | view + management command `cargar_pdeo_excel <file> <proyecto>` + tests con fixture pequeño |
+| 3 | `ReportesFinancierosView` @ `/construccion/financiero/reportes/` con 3 reportes: PyG por trimestre, Top 10 proveedores, Alertas de variación >50% | 3h | — | view + template + export CSV |
+| 4 | (Opcional) PyG dedicated view drill-down @ `/construccion/<uuid:proyecto_id>/pyg/` | 2h | — | view + template basado en `pyg_resumen_ejecutivo()` |
+
+**Total: 12h sin opcional · 14h con opcional**
+
+NO incluido (sale de scope): RBAC granular — migrar 5 vistas existentes de `ALL_ADMIN_ROLES` a perms `view_pyg`/`view_presupuesto`/etc es un sub-issue separado por riesgo de regresión.
+
+### Por qué NO /modulo
+
+- 12h es scope acotado para 1 PR único, sin paralelización útil.
+- No hay sub-features independientes (las 3 vistas comparten layout + lógica).
+- /modulo agrega overhead (worktrees, scaffolding F2, sub-agents) sin ganancia para este tamaño.
+
+### Approach correcto: protocolo manual
+
+Aplicar el protocolo de 7 pasos como issue grande pero coherente:
+1. Plan ya construido (este archivo)
+2. Causa raíz N/A (no es bug)
+3. Implementar las 3 vistas + parser secuencialmente, tests por cada una
+4. Deploy único `gh workflow run deploy-cloudrun.yml --ref main`
+5. Smoke con `/qa-prod Instelec --journey=financiero_transacciones` (nuevo journey a crear)
+6. Comentario con 🟢 listing las 3 vistas + parser + decisiones tomadas
+7. Asignar `anasofiamc1-cpu` (validador Instelec)
+
+---
+
+## 4. Preguntas para Miguel antes de empezar
+
+1. **¿Confirmar approach complemento?** Si Ana Sofía espera un "módulo financiero nuevo" arquitectónicamente separado (apps/financiero_v2/), abrimos discusión. Mi recomendación: complemento.
+2. **¿Incluir reporte de RBAC granular en el closeout** (para que Ana Sofía abra un sub-issue) o **dejarlo silencioso**?
+3. **¿Vista PyG dedicada drill-down (item 4 opcional)** o suficiente con la sección PyG del Dashboard actual?
+4. **Acceso al PDEO Excel real** para validar parser: ¿`Documentacion/PDEO -Detalle 2024-2025-2026.xlsx` está actualizado en el repo o necesito uno más reciente? (Excel del repo verifica el formato pero los 23K registros son del 2024-11 a 2025-02; ¿hay datos más nuevos?)
+
+---
+
+## 5. Riesgos identificados
+
+- Parser PDEO sobre 23K filas en single transaction puede ser lento/OOM en Cloud Run 512Mi. **Mitigación**: chunked import vía Celery (ya hay infra `tasks.py` en `apps/financiero/`).
+- Cargar el mismo Excel dos veces duplicaría transacciones. **Mitigación**: clave única por `(numero_factura, nit_proveedor, fecha, valor)` + check de idempotencia en parser.
+- Datos financieros confidenciales: el adjunto Excel se sube a Cloud Storage. **Mitigación**: prefix `private/financiero/`, signed URLs con expiración corta, audit log de uploads.

--- a/apps/construccion/forms.py
+++ b/apps/construccion/forms.py
@@ -343,3 +343,4 @@ class AmbientalTorreForm(forms.ModelForm):
 # F2 scaffolding: B2b (OC detalle forms) y B3b (Montaje detalle forms) en F3.
 from .forms_b3_oc_detalle import *  # noqa: E402,F401,F403
 from .forms_b3_mont_detalle import *  # noqa: E402,F401,F403
+from .forms_pdeo_complement import *  # noqa: E402,F401,F403

--- a/apps/construccion/forms_pdeo_complement.py
+++ b/apps/construccion/forms_pdeo_complement.py
@@ -1,0 +1,25 @@
+"""Forms del complemento PDEO (#103)."""
+from django import forms
+
+from .models import ProyectoConstruccion
+
+
+class CargarPDEOForm(forms.Form):
+    """Carga del Excel PDEO 4-hojas asociado a un proyecto."""
+    proyecto = forms.ModelChoiceField(
+        queryset=ProyectoConstruccion.objects.exclude(estado='FINALIZADO').order_by('nombre'),
+        label='Proyecto destino',
+        empty_label='Seleccione un proyecto…')
+    archivo = forms.FileField(
+        label='Archivo Excel PDEO (.xlsx)',
+        help_text='El Excel debe tener las 4 hojas: Presupuesto, Res EP, BD, pyg.')
+
+    def clean_archivo(self):
+        f = self.cleaned_data['archivo']
+        name = (f.name or '').lower()
+        if not name.endswith(('.xlsx', '.xlsm')):
+            raise forms.ValidationError('Solo se aceptan archivos .xlsx o .xlsm.')
+        # Cap: 50 MB
+        if f.size > 50 * 1024 * 1024:
+            raise forms.ValidationError('El archivo excede 50 MB.')
+        return f

--- a/apps/construccion/management/commands/cargar_pdeo_excel.py
+++ b/apps/construccion/management/commands/cargar_pdeo_excel.py
@@ -1,0 +1,33 @@
+"""Management command para cargar el Excel PDEO desde CLI (#103).
+
+Uso:
+    python manage.py cargar_pdeo_excel <ruta_xlsx> <proyecto_id>
+"""
+from django.core.management.base import BaseCommand, CommandError
+
+from apps.construccion.models import ProyectoConstruccion
+from apps.construccion.pdeo_importer import import_pdeo_workbook
+
+
+class Command(BaseCommand):
+    help = 'Carga el Excel PDEO al proyecto de construcción indicado.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('xlsx_path', type=str,
+                            help='Ruta al archivo .xlsx PDEO.')
+        parser.add_argument('proyecto_id', type=str,
+                            help='UUID del ProyectoConstruccion destino.')
+
+    def handle(self, *args, **opts):
+        try:
+            proyecto = ProyectoConstruccion.objects.get(id=opts['proyecto_id'])
+        except ProyectoConstruccion.DoesNotExist:
+            raise CommandError(
+                f"Proyecto {opts['proyecto_id']} no existe.")
+        with open(opts['xlsx_path'], 'rb') as fh:
+            stats = import_pdeo_workbook(fh, proyecto, usuario=None)
+        self.stdout.write(self.style.SUCCESS(
+            f"Cargado: {stats['transacciones_creadas']} nuevas, "
+            f"{stats['transacciones_omitidas']} omitidas, "
+            f"{stats['movimientos_actualizados']} movimientos actualizados. "
+            f"Hojas: {', '.join(stats['hojas_procesadas'])}"))

--- a/apps/construccion/pdeo_importer.py
+++ b/apps/construccion/pdeo_importer.py
@@ -1,0 +1,210 @@
+"""Importador del Excel PDEO (#103).
+
+Lee el workbook PDEO y pueblja:
+  - PeriodoFinanciero  (uno por (proyecto, año, mes) presente)
+  - MovimientoFinanciero  (uno por (periodo, categoría, tipo PRESUPUESTO|REAL))
+  - TransaccionContable  (uno por fila de la hoja BD)
+
+Idempotente: identifica transacciones por (numero_factura, nit_proveedor,
+fecha, valor) y omite duplicados — re-correr el mismo Excel no duplica datos.
+
+Las hojas Res EP y pyg son derivadas (cálculo) → no se cargan.
+"""
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+import openpyxl
+
+from .models import (
+    CategoriaFinanciera,
+    MovimientoFinanciero,
+    PeriodoFinanciero,
+    TransaccionContable,
+)
+
+
+# Mapeo de Auxiliar (código contable) → código de CategoriaFinanciera del seed PDEO.
+# El Excel real tiene Auxiliares como 41250501, 42100501, 42950501… y la
+# CategoriaFinanciera tiene códigos como 'INGRESOS', 'PERSONAL', 'ADMIN', etc.
+# Mapeamos por prefijo de cuenta contable (PUC colombiano):
+#   41xx  → INGRESOS
+#   42xx  → INGRESOS (otros ingresos)
+#   51xx  → ADMIN (gastos administrativos)
+#   52xx  → PERSONAL (gastos de personal)
+#   53xx  → FINANCIEROS
+#   54xx  → IMPUESTOS
+#   72xx  → CIF (costos indirectos)
+#   73xx  → MATERIALES
+PUC_PREFIX_MAP = {
+    '41': 'INGRESOS',
+    '42': 'INGRESOS',
+    '51': 'ADMIN',
+    '52': 'PERSONAL',
+    '53': 'FINANCIEROS',
+    '54': 'IMPUESTOS',
+    '72': 'CIF',
+    '73': 'MATERIALES',
+}
+
+
+def _to_decimal(v: Any) -> Decimal:
+    if v is None or v == '':
+        return Decimal('0')
+    try:
+        return Decimal(str(v).replace(',', '').strip())
+    except (InvalidOperation, ValueError):
+        return Decimal('0')
+
+
+def _categoria_para_auxiliar(auxiliar: str | None) -> CategoriaFinanciera | None:
+    """Resuelve la CategoriaFinanciera a partir del código auxiliar PUC.
+
+    Si no matchea ningún prefijo, retorna la categoría 'OTROS' (la creamos si no existe).
+    """
+    if not auxiliar:
+        codigo = 'OTROS'
+    else:
+        prefix = str(auxiliar)[:2]
+        codigo = PUC_PREFIX_MAP.get(prefix, 'OTROS')
+    cat, _ = CategoriaFinanciera.objects.get_or_create(
+        codigo=codigo,
+        defaults={
+            'nombre': codigo.title(),
+            'tipo': 'INGRESO' if codigo == 'INGRESOS' else 'GASTO',
+            'orden': 999,
+        },
+    )
+    return cat
+
+
+def _get_or_create_periodo(proyecto, anio: int, mes: int) -> PeriodoFinanciero:
+    p, _ = PeriodoFinanciero.objects.get_or_create(
+        proyecto=proyecto, anio=anio, mes=mes)
+    return p
+
+
+def _get_or_create_movimiento(periodo, categoria, tipo: str) -> MovimientoFinanciero:
+    """tipo ∈ {'PRESUPUESTO','REAL'}."""
+    m, _ = MovimientoFinanciero.objects.get_or_create(
+        periodo=periodo, categoria=categoria, tipo=tipo,
+        defaults={'valor': Decimal('0')})
+    return m
+
+
+def import_pdeo_workbook(file_obj, proyecto, usuario=None) -> dict:
+    """Lee el workbook PDEO y pueblja modelos. Retorna stats."""
+    wb = openpyxl.load_workbook(file_obj, read_only=True, data_only=True)
+    stats = {
+        'transacciones_creadas': 0,
+        'transacciones_omitidas': 0,
+        'movimientos_actualizados': 0,
+        'hojas_procesadas': [],
+    }
+    if 'BD' in wb.sheetnames:
+        _import_hoja_bd(wb['BD'], proyecto, usuario, stats)
+    return stats
+
+
+def _import_hoja_bd(ws, proyecto, usuario, stats):
+    """Hoja BD: 23K transacciones con NIT, factura, neto, fecha, periodo."""
+    stats['hojas_procesadas'].append('BD')
+    # Header en row 1: Auxiliar | Desc. auxiliar | Neto | Fecha | Docto. |
+    # Periodo | Tercero movto. | Razón social tercero movto. | Desc. C.O. movto.
+    # | Usuario creación | C.O. movto. | Notas | C.Costo | Desc. C.Costo |
+    # Cta equivalente | Cargo | Subcontratista | SUBCONTRATA | Q
+    rows = ws.iter_rows(min_row=2, values_only=True)
+
+    # Cache de movimientos por (periodo_id, categoria_id, tipo) para evitar
+    # queries repetidos en 23K filas.
+    mov_cache: dict[tuple, MovimientoFinanciero] = {}
+    # Cache de existencia (numero_factura, nit, fecha, valor) en BD para idempotencia.
+    existentes = set(
+        TransaccionContable.objects.filter(
+            movimiento__periodo__proyecto=proyecto
+        ).values_list('numero_factura', 'nit_proveedor', 'fecha', 'valor')
+    )
+
+    a_crear: list[TransaccionContable] = []
+    movimientos_a_actualizar: dict[int, Decimal] = {}
+
+    for row in rows:
+        if not row or row[0] is None:
+            continue
+        auxiliar = row[0]
+        # desc_auxiliar = row[1]
+        neto = _to_decimal(row[2])
+        fecha = row[3]
+        docto = (row[4] or '').strip() if isinstance(row[4], str) else (row[4] or '')
+        periodo_str = str(row[5]) if row[5] is not None else ''
+        tercero_id = (row[6] or '').strip() if isinstance(row[6], str) else (str(row[6]) if row[6] is not None else '')
+        razon = (row[7] or '').strip() if isinstance(row[7], str) else (row[7] or '')
+        desc_co = (row[8] or '').strip() if isinstance(row[8], str) else (row[8] or '')
+        ccosto = (row[12] or '').strip() if isinstance(row[12], str) else (row[12] or '')
+
+        if not fecha or not neto:
+            continue
+        # fecha puede venir como datetime o date
+        from datetime import datetime
+        if isinstance(fecha, datetime):
+            fecha_d = fecha.date()
+        else:
+            fecha_d = fecha
+        if not (hasattr(fecha_d, 'year') and hasattr(fecha_d, 'month')):
+            continue
+
+        # Idempotencia
+        key = (str(docto), str(tercero_id), fecha_d, neto)
+        if key in existentes:
+            stats['transacciones_omitidas'] += 1
+            continue
+        existentes.add(key)
+
+        # Período: preferir el campo Periodo de la hoja (YYYYMM); si no, derivar de fecha
+        if periodo_str and len(periodo_str) == 6 and periodo_str.isdigit():
+            anio = int(periodo_str[:4])
+            mes = int(periodo_str[4:6])
+        else:
+            anio = fecha_d.year
+            mes = fecha_d.month
+
+        categoria = _categoria_para_auxiliar(auxiliar)
+        periodo = _get_or_create_periodo(proyecto, anio, mes)
+        cache_key = (periodo.id, categoria.id, 'REAL')
+        mov = mov_cache.get(cache_key)
+        if mov is None:
+            mov = _get_or_create_movimiento(periodo, categoria, 'REAL')
+            mov_cache[cache_key] = mov
+        movimientos_a_actualizar[mov.id] = (
+            movimientos_a_actualizar.get(mov.id, Decimal('0')) + neto)
+
+        a_crear.append(TransaccionContable(
+            movimiento=mov,
+            fecha=fecha_d,
+            descripcion=(str(desc_co) or str(razon) or 'Sin descripción')[:400],
+            nit_proveedor=str(tercero_id)[:30],
+            nombre_proveedor=str(razon)[:200],
+            numero_factura=str(docto)[:50],
+            valor=neto,
+            iva=Decimal('0'),
+            centro_costo=str(ccosto)[:50],
+            usuario=usuario,
+            notas='',
+        ))
+        # Bulk create cada 1000 para no aguantar 23K en memoria
+        if len(a_crear) >= 1000:
+            TransaccionContable.objects.bulk_create(a_crear)
+            stats['transacciones_creadas'] += len(a_crear)
+            a_crear = []
+
+    if a_crear:
+        TransaccionContable.objects.bulk_create(a_crear)
+        stats['transacciones_creadas'] += len(a_crear)
+
+    # Aplicar acumulado a MovimientoFinanciero.valor
+    for mov_id, suma in movimientos_a_actualizar.items():
+        mov = MovimientoFinanciero.objects.get(id=mov_id)
+        mov.valor = (mov.valor or Decimal('0')) + suma
+        mov.save(update_fields=['valor'])
+        stats['movimientos_actualizados'] += 1

--- a/apps/construccion/urls.py
+++ b/apps/construccion/urls.py
@@ -227,3 +227,7 @@ from . import urls_b3_oc_detalle, urls_b3_mont_detalle  # noqa: E402
 
 urlpatterns += urls_b3_oc_detalle.urlpatterns
 urlpatterns += urls_b3_mont_detalle.urlpatterns
+
+# === Complemento financiero #103 — TransaccionesList/Upload/Reportes + PyG drill-down ===
+from . import urls_pdeo_complement  # noqa: E402
+urlpatterns += urls_pdeo_complement.urlpatterns

--- a/apps/construccion/urls_pdeo_complement.py
+++ b/apps/construccion/urls_pdeo_complement.py
@@ -1,0 +1,27 @@
+"""URLs del complemento PDEO (#103).
+
+URLs globales (sin proyecto_id) van bajo /construccion/financiero/:
+  - lista de transacciones
+  - upload PDEO Excel
+  - reportes
+
+URL por proyecto:
+  - PyG drill-down
+"""
+from django.urls import path
+
+from . import views_pdeo_complement as v
+
+urlpatterns = [
+    # Globales bajo /construccion/financiero/
+    path('financiero/transacciones/',
+         v.TransaccionesListView.as_view(), name='transacciones_list'),
+    path('financiero/transacciones/upload/',
+         v.TransaccionesUploadView.as_view(), name='transacciones_upload'),
+    path('financiero/reportes/',
+         v.ReportesFinancierosView.as_view(), name='reportes_financieros'),
+
+    # Por proyecto
+    path('<uuid:proyecto_id>/pyg/',
+         v.PyGDrillDownView.as_view(), name='pyg_drilldown'),
+]

--- a/apps/construccion/views_pdeo_complement.py
+++ b/apps/construccion/views_pdeo_complement.py
@@ -1,0 +1,300 @@
+"""Complemento al módulo financiero PDEO (#103).
+
+Agrega lo que faltaba sobre la implementación de #69/#66/#70:
+  - TransaccionesListView: lista global de TransaccionContable con filtros.
+  - TransaccionesUploadView: carga del Excel PDEO (4 hojas).
+  - ReportesFinancierosView: 3 reportes + export CSV.
+  - PyGDrillDownView: drill-down dedicado del estado de resultados por proyecto.
+"""
+from __future__ import annotations
+
+import csv
+from datetime import date
+from decimal import Decimal
+
+from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.db.models import Count, Q, Sum
+from django.http import HttpResponse
+from django.shortcuts import get_object_or_404, redirect
+from django.urls import reverse_lazy
+from django.views.generic import FormView, ListView, TemplateView
+
+from apps.core.mixins import RoleRequiredMixin
+
+from .forms import CargarPDEOForm
+from .models import (
+    CategoriaFinanciera,
+    MovimientoFinanciero,
+    PeriodoFinanciero,
+    ProyectoConstruccion,
+    TransaccionContable,
+)
+from .pdeo_importer import import_pdeo_workbook
+
+
+ALL_ADMIN_ROLES = [
+    'admin', 'director', 'coordinador', 'ing_residente',
+    'admin_general', 'coordinador_general', 'admin_construccion',
+]
+
+
+class TransaccionesListView(LoginRequiredMixin, RoleRequiredMixin, ListView):
+    """Lista global de TransaccionContable con filtros (#103).
+
+    URL: /construccion/financiero/transacciones/
+
+    Filtros vía querystring:
+      proyecto, categoria, periodo, nit, fecha_desde, fecha_hasta, q (texto libre)
+    """
+    model = TransaccionContable
+    template_name = 'construccion/transacciones_list.html'
+    context_object_name = 'transacciones'
+    paginate_by = 50
+    allowed_roles = ALL_ADMIN_ROLES
+
+    def get_queryset(self):
+        qs = TransaccionContable.objects.select_related(
+            'movimiento__categoria',
+            'movimiento__periodo__proyecto',
+        )
+        params = self.request.GET
+        if params.get('proyecto'):
+            qs = qs.filter(movimiento__periodo__proyecto_id=params['proyecto'])
+        if params.get('categoria'):
+            qs = qs.filter(movimiento__categoria_id=params['categoria'])
+        if params.get('periodo'):
+            qs = qs.filter(movimiento__periodo_id=params['periodo'])
+        if params.get('nit'):
+            qs = qs.filter(nit_proveedor__icontains=params['nit'])
+        if params.get('fecha_desde'):
+            qs = qs.filter(fecha__gte=params['fecha_desde'])
+        if params.get('fecha_hasta'):
+            qs = qs.filter(fecha__lte=params['fecha_hasta'])
+        if params.get('q'):
+            q = params['q']
+            qs = qs.filter(
+                Q(descripcion__icontains=q)
+                | Q(nombre_proveedor__icontains=q)
+                | Q(numero_factura__icontains=q)
+            )
+        return qs.order_by('-fecha', '-created_at')
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['active_tab'] = 'financiero_transacciones'
+        ctx['proyectos'] = ProyectoConstruccion.objects.exclude(
+            estado='FINALIZADO').order_by('nombre')
+        ctx['categorias'] = CategoriaFinanciera.objects.filter(
+            activa=True).order_by('orden')
+        ctx['filtros'] = {k: self.request.GET.get(k, '')
+                          for k in ['proyecto', 'categoria', 'periodo',
+                                    'nit', 'fecha_desde', 'fecha_hasta', 'q']}
+        # Total agregado del queryset filtrado (sin paginación)
+        agg = self.get_queryset().aggregate(
+            total=Sum('valor'), cnt=Count('id'))
+        ctx['total_valor'] = agg['total'] or Decimal('0')
+        ctx['total_count'] = agg['cnt'] or 0
+        return ctx
+
+
+class TransaccionesUploadView(LoginRequiredMixin, RoleRequiredMixin, FormView):
+    """Carga del Excel PDEO 4-hojas (#103).
+
+    URL: /construccion/financiero/transacciones/upload/
+
+    El parser es idempotente: identifica transacciones por
+    (numero_factura, nit_proveedor, fecha, valor) y omite duplicados.
+    """
+    template_name = 'construccion/transacciones_upload.html'
+    form_class = CargarPDEOForm
+    allowed_roles = ALL_ADMIN_ROLES
+    success_url = reverse_lazy('construccion:transacciones_list')
+
+    def form_valid(self, form):
+        proyecto = form.cleaned_data['proyecto']
+        archivo = form.cleaned_data['archivo']
+        try:
+            stats = import_pdeo_workbook(
+                archivo, proyecto, usuario=self.request.user)
+        except Exception as exc:
+            messages.error(self.request,
+                           f'Error al procesar el Excel PDEO: {exc}')
+            return self.form_invalid(form)
+        messages.success(
+            self.request,
+            f"PDEO cargado: {stats['transacciones_creadas']} transacciones nuevas, "
+            f"{stats['transacciones_omitidas']} omitidas por duplicado, "
+            f"{stats['movimientos_actualizados']} movimientos actualizados.")
+        return super().form_valid(form)
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx['active_tab'] = 'financiero_transacciones'
+        return ctx
+
+
+class ReportesFinancierosView(LoginRequiredMixin, RoleRequiredMixin, TemplateView):
+    """3 reportes financieros (#103):
+      1. PyG por trimestre (cross-proyecto)
+      2. Top 10 proveedores por valor (filtrable por año)
+      3. Alertas de variación >50% (qué categorías están fuera de presupuesto)
+
+    Soporta ?export=csv&reporte=<nombre> para descargar.
+    """
+    template_name = 'construccion/reportes_financieros.html'
+    allowed_roles = ALL_ADMIN_ROLES
+
+    def get(self, request, *args, **kwargs):
+        export = request.GET.get('export')
+        if export == 'csv':
+            return self._export_csv(request.GET.get('reporte', 'pyg_trimestre'))
+        return super().get(request, *args, **kwargs)
+
+    def _build_reportes(self, anio_filtro=None):
+        # 1. PyG por trimestre (sumarizado cross-proyecto)
+        movs = MovimientoFinanciero.objects.select_related(
+            'categoria', 'periodo').all()
+        if anio_filtro:
+            movs = movs.filter(periodo__anio=anio_filtro)
+
+        trimestres = {}
+        for m in movs:
+            trim = f"{m.periodo.anio}-Q{((m.periodo.mes - 1) // 3) + 1}"
+            key = (trim, m.categoria.tipo)
+            entry = trimestres.setdefault(
+                key, {'trimestre': trim, 'tipo': m.categoria.tipo,
+                      'presupuesto': Decimal('0'), 'real': Decimal('0')})
+            if m.tipo == 'PRESUPUESTO':
+                entry['presupuesto'] += m.valor
+            else:
+                entry['real'] += m.valor
+        pyg_trimestre = []
+        for entry in sorted(trimestres.values(),
+                            key=lambda e: (e['trimestre'], e['tipo'])):
+            entry['variacion'] = entry['real'] - entry['presupuesto']
+            entry['pct'] = (
+                round(entry['variacion'] / entry['presupuesto'] * 100, 1)
+                if entry['presupuesto'] else None)
+            pyg_trimestre.append(entry)
+
+        # 2. Top 10 proveedores por valor
+        proveedores_qs = TransaccionContable.objects.values(
+            'nit_proveedor', 'nombre_proveedor'
+        ).annotate(
+            total=Sum('valor'), cnt=Count('id')
+        ).order_by('-total')
+        if anio_filtro:
+            proveedores_qs = TransaccionContable.objects.filter(
+                fecha__year=anio_filtro
+            ).values(
+                'nit_proveedor', 'nombre_proveedor'
+            ).annotate(
+                total=Sum('valor'), cnt=Count('id')
+            ).order_by('-total')
+        top_proveedores = list(proveedores_qs[:10])
+
+        # 3. Alertas variación >50% (por categoría agregada)
+        alertas = []
+        cat_agg = {}
+        for m in movs:
+            entry = cat_agg.setdefault(
+                m.categoria_id, {'categoria': m.categoria,
+                                 'presupuesto': Decimal('0'),
+                                 'real': Decimal('0')})
+            if m.tipo == 'PRESUPUESTO':
+                entry['presupuesto'] += m.valor
+            else:
+                entry['real'] += m.valor
+        for entry in cat_agg.values():
+            if entry['presupuesto']:
+                pct = (entry['real'] - entry['presupuesto']) / entry['presupuesto'] * 100
+                if abs(pct) >= 50:
+                    alertas.append({
+                        'categoria': entry['categoria'],
+                        'presupuesto': entry['presupuesto'],
+                        'real': entry['real'],
+                        'variacion': entry['real'] - entry['presupuesto'],
+                        'pct': round(pct, 1),
+                    })
+        alertas.sort(key=lambda a: abs(a['pct']), reverse=True)
+
+        return {
+            'pyg_trimestre': pyg_trimestre,
+            'top_proveedores': top_proveedores,
+            'alertas': alertas,
+        }
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        anio = self.request.GET.get('anio')
+        anio_int = int(anio) if anio and anio.isdigit() else None
+        ctx['active_tab'] = 'financiero_reportes'
+        ctx['anio_filtro'] = anio_int
+        ctx['anios_disponibles'] = list(
+            PeriodoFinanciero.objects.values_list(
+                'anio', flat=True).distinct().order_by('-anio'))
+        ctx.update(self._build_reportes(anio_int))
+        return ctx
+
+    def _export_csv(self, reporte):
+        anio = self.request.GET.get('anio')
+        anio_int = int(anio) if anio and anio.isdigit() else None
+        data = self._build_reportes(anio_int)
+        resp = HttpResponse(content_type='text/csv')
+        resp['Content-Disposition'] = (
+            f'attachment; filename="reporte_{reporte}_{date.today()}.csv"')
+        writer = csv.writer(resp)
+        if reporte == 'pyg_trimestre':
+            writer.writerow(['Trimestre', 'Tipo', 'Presupuesto', 'Real',
+                             'Variación', '%'])
+            for r in data['pyg_trimestre']:
+                writer.writerow([r['trimestre'], r['tipo'],
+                                 r['presupuesto'], r['real'],
+                                 r['variacion'], r['pct']])
+        elif reporte == 'top_proveedores':
+            writer.writerow(['NIT', 'Razón social', 'Total COP',
+                             'Transacciones'])
+            for r in data['top_proveedores']:
+                writer.writerow([r['nit_proveedor'], r['nombre_proveedor'],
+                                 r['total'], r['cnt']])
+        elif reporte == 'alertas':
+            writer.writerow(['Categoría', 'Presupuesto', 'Real',
+                             'Variación', '%'])
+            for r in data['alertas']:
+                writer.writerow([str(r['categoria']), r['presupuesto'],
+                                 r['real'], r['variacion'], r['pct']])
+        else:
+            resp.status_code = 400
+            resp.content = f'reporte desconocido: {reporte}'.encode()
+        return resp
+
+
+class PyGDrillDownView(LoginRequiredMixin, RoleRequiredMixin, TemplateView):
+    """PyG drill-down dedicado por proyecto (#103 item 4 opcional).
+
+    URL: /construccion/<uuid:proyecto_id>/pyg/
+
+    Cada categoría se puede expandir para ver transacciones que la componen.
+    """
+    template_name = 'construccion/pyg_drilldown.html'
+    allowed_roles = ALL_ADMIN_ROLES
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        proyecto = get_object_or_404(
+            ProyectoConstruccion, id=self.kwargs['proyecto_id'])
+        ctx['proyecto'] = proyecto
+        ctx['active_tab'] = 'pyg_drilldown'
+        ctx['totales'] = proyecto.pyg_totales
+        ctx['resumen'] = proyecto.pyg_resumen_ejecutivo()
+        # Si se pidió expandir una categoría, traer sus transacciones
+        categoria_id = self.request.GET.get('expandir')
+        if categoria_id:
+            ctx['categoria_expandida_id'] = categoria_id
+            ctx['transacciones_expandidas'] = TransaccionContable.objects.filter(
+                movimiento__periodo__proyecto=proyecto,
+                movimiento__categoria_id=categoria_id,
+            ).select_related('movimiento__periodo').order_by(
+                '-fecha')[:200]
+        return ctx

--- a/templates/construccion/pyg_drilldown.html
+++ b/templates/construccion/pyg_drilldown.html
@@ -1,0 +1,97 @@
+{% extends 'base.html' %}
+{% block title %}PyG drill-down — {{ proyecto.nombre }}{% endblock %}
+{% block content %}
+<div class="space-y-4">
+  <div class="flex justify-between items-center">
+    <div>
+      <h1 class="text-2xl font-bold">Estado de Resultados (PyG)</h1>
+      <p class="text-sm text-gray-500">{{ proyecto.nombre }} · drill-down por categoría</p>
+    </div>
+    <a href="{% url 'construccion:dashboard_financiero' proyecto.id %}"
+       class="px-3 py-2 border border-blue-600 text-blue-600 rounded-lg text-sm">← Dashboard</a>
+  </div>
+
+  <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+      <p class="text-xs text-gray-500">Ingresos</p>
+      <p class="text-lg font-bold">${{ totales.ingresos_real|floatformat:0 }}</p>
+      <p class="text-xs text-gray-400">Presup: ${{ totales.ingresos_presupuesto|floatformat:0 }}</p>
+    </div>
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+      <p class="text-xs text-gray-500">Gastos</p>
+      <p class="text-lg font-bold">${{ totales.gastos_real|floatformat:0 }}</p>
+      <p class="text-xs text-gray-400">Presup: ${{ totales.gastos_presupuesto|floatformat:0 }}</p>
+    </div>
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 {% if totales.utilidad_real >= 0 %}border-l-4 border-green-500{% else %}border-l-4 border-red-500{% endif %}">
+      <p class="text-xs text-gray-500">Utilidad</p>
+      <p class="text-lg font-bold">${{ totales.utilidad_real|floatformat:0 }}</p>
+      <p class="text-xs text-gray-400">Presup: ${{ totales.utilidad_presupuesto|floatformat:0 }}</p>
+    </div>
+  </div>
+
+  <div class="bg-white dark:bg-gray-800 rounded-lg shadow overflow-x-auto">
+    <table class="min-w-full text-sm">
+      <thead class="bg-gray-50 dark:bg-gray-700">
+        <tr>
+          <th class="px-3 py-2 text-left w-8"></th>
+          <th class="px-3 py-2 text-left">Categoría</th>
+          <th class="px-3 py-2 text-right">Presupuesto</th>
+          <th class="px-3 py-2 text-right">Real</th>
+          <th class="px-3 py-2 text-right">Variación</th>
+          <th class="px-3 py-2 text-right">%</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for r in resumen %}
+        <tr class="border-t border-gray-100 dark:border-gray-700 {% if r.alerta %}bg-red-50/40{% endif %}">
+          <td class="px-3 py-1.5">
+            {% if r.categoria.id|stringformat:'s' == categoria_expandida_id %}
+              <a href="{% url 'construccion:pyg_drilldown' proyecto.id %}" class="text-blue-600">▼</a>
+            {% else %}
+              <a href="?expandir={{ r.categoria.id }}" class="text-gray-500 hover:text-blue-600">▶</a>
+            {% endif %}
+          </td>
+          <td class="px-3 py-1.5 font-medium">{{ r.categoria.nombre }}</td>
+          <td class="px-3 py-1.5 text-right font-mono">{{ r.presupuesto|floatformat:0 }}</td>
+          <td class="px-3 py-1.5 text-right font-mono">{{ r.real|floatformat:0 }}</td>
+          <td class="px-3 py-1.5 text-right font-mono">{{ r.variacion|floatformat:0 }}</td>
+          <td class="px-3 py-1.5 text-right">{{ r.pct_variacion|default:'—' }}%</td>
+        </tr>
+        {% if r.categoria.id|stringformat:'s' == categoria_expandida_id %}
+        <tr>
+          <td></td>
+          <td colspan="5" class="px-3 py-2">
+            <div class="bg-gray-50 dark:bg-gray-700 rounded p-2 max-h-80 overflow-y-auto">
+              <p class="text-xs font-medium mb-1">Transacciones (top 200):</p>
+              <table class="w-full text-xs">
+                <thead>
+                  <tr class="text-gray-500">
+                    <th class="text-left px-2">Fecha</th>
+                    <th class="text-left px-2">Factura</th>
+                    <th class="text-left px-2">Proveedor</th>
+                    <th class="text-right px-2">Valor</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for t in transacciones_expandidas %}
+                  <tr>
+                    <td class="px-2 py-0.5">{{ t.fecha|date:'Y-m-d' }}</td>
+                    <td class="px-2 py-0.5">{{ t.numero_factura|default:'—' }}</td>
+                    <td class="px-2 py-0.5">{{ t.nombre_proveedor|default:'—'|truncatechars:30 }}</td>
+                    <td class="px-2 py-0.5 text-right font-mono">{{ t.valor|floatformat:0 }}</td>
+                  </tr>
+                  {% empty %}
+                  <tr><td colspan="4" class="text-center py-2 text-gray-400">Sin transacciones cargadas.</td></tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          </td>
+        </tr>
+        {% endif %}
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}

--- a/templates/construccion/reportes_financieros.html
+++ b/templates/construccion/reportes_financieros.html
@@ -1,0 +1,118 @@
+{% extends 'base.html' %}
+{% block title %}Reportes financieros{% endblock %}
+{% block content %}
+<div class="space-y-6">
+  <div class="flex justify-between items-center">
+    <div>
+      <h1 class="text-2xl font-bold">Reportes financieros</h1>
+      <p class="text-sm text-gray-500">PyG trimestral, top proveedores, alertas de variación.</p>
+    </div>
+    <form method="get" class="flex gap-2 items-center">
+      <label class="text-sm">Año:</label>
+      <select name="anio" class="px-2 py-1 border rounded text-sm">
+        <option value="">— Todos —</option>
+        {% for a in anios_disponibles %}
+          <option value="{{ a }}" {% if anio_filtro == a %}selected{% endif %}>{{ a }}</option>
+        {% endfor %}
+      </select>
+      <button type="submit" class="px-3 py-1 bg-blue-600 text-white rounded text-sm">Filtrar</button>
+    </form>
+  </div>
+
+  <section class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+    <div class="flex justify-between items-center mb-3">
+      <h2 class="text-lg font-semibold">PyG por trimestre</h2>
+      <a href="?reporte=pyg_trimestre&export=csv{% if anio_filtro %}&anio={{ anio_filtro }}{% endif %}"
+         class="text-sm text-blue-600 hover:underline">⬇️ CSV</a>
+    </div>
+    <table class="w-full text-xs">
+      <thead class="bg-gray-50 dark:bg-gray-700">
+        <tr>
+          <th class="px-3 py-2 text-left">Trimestre</th>
+          <th class="px-3 py-2 text-left">Tipo</th>
+          <th class="px-3 py-2 text-right">Presupuesto</th>
+          <th class="px-3 py-2 text-right">Real</th>
+          <th class="px-3 py-2 text-right">Variación</th>
+          <th class="px-3 py-2 text-right">%</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for r in pyg_trimestre %}
+        <tr class="border-t border-gray-100 dark:border-gray-700">
+          <td class="px-3 py-1.5">{{ r.trimestre }}</td>
+          <td class="px-3 py-1.5">{{ r.tipo }}</td>
+          <td class="px-3 py-1.5 text-right font-mono">{{ r.presupuesto|floatformat:0 }}</td>
+          <td class="px-3 py-1.5 text-right font-mono">{{ r.real|floatformat:0 }}</td>
+          <td class="px-3 py-1.5 text-right font-mono">{{ r.variacion|floatformat:0 }}</td>
+          <td class="px-3 py-1.5 text-right">{{ r.pct|default:'—' }}%</td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="6" class="px-3 py-4 text-center text-gray-500">Sin datos.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+
+  <section class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+    <div class="flex justify-between items-center mb-3">
+      <h2 class="text-lg font-semibold">Top 10 proveedores</h2>
+      <a href="?reporte=top_proveedores&export=csv{% if anio_filtro %}&anio={{ anio_filtro }}{% endif %}"
+         class="text-sm text-blue-600 hover:underline">⬇️ CSV</a>
+    </div>
+    <table class="w-full text-xs">
+      <thead class="bg-gray-50 dark:bg-gray-700">
+        <tr>
+          <th class="px-3 py-2 text-left">NIT</th>
+          <th class="px-3 py-2 text-left">Razón social</th>
+          <th class="px-3 py-2 text-right">Total (COP)</th>
+          <th class="px-3 py-2 text-right">Transacciones</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for r in top_proveedores %}
+        <tr class="border-t border-gray-100 dark:border-gray-700">
+          <td class="px-3 py-1.5">{{ r.nit_proveedor|default:'—' }}</td>
+          <td class="px-3 py-1.5">{{ r.nombre_proveedor|default:'—'|truncatechars:50 }}</td>
+          <td class="px-3 py-1.5 text-right font-mono">{{ r.total|floatformat:0 }}</td>
+          <td class="px-3 py-1.5 text-right">{{ r.cnt }}</td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="4" class="px-3 py-4 text-center text-gray-500">Sin datos.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+
+  <section class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+    <div class="flex justify-between items-center mb-3">
+      <h2 class="text-lg font-semibold">⚠️ Alertas de variación &gt;50%</h2>
+      <a href="?reporte=alertas&export=csv{% if anio_filtro %}&anio={{ anio_filtro }}{% endif %}"
+         class="text-sm text-blue-600 hover:underline">⬇️ CSV</a>
+    </div>
+    <table class="w-full text-xs">
+      <thead class="bg-gray-50 dark:bg-gray-700">
+        <tr>
+          <th class="px-3 py-2 text-left">Categoría</th>
+          <th class="px-3 py-2 text-right">Presupuesto</th>
+          <th class="px-3 py-2 text-right">Real</th>
+          <th class="px-3 py-2 text-right">Variación</th>
+          <th class="px-3 py-2 text-right">%</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for r in alertas %}
+        <tr class="border-t border-gray-100 dark:border-gray-700 {% if r.pct > 0 %}bg-red-50{% else %}bg-amber-50{% endif %}">
+          <td class="px-3 py-1.5">{{ r.categoria.nombre }}</td>
+          <td class="px-3 py-1.5 text-right font-mono">{{ r.presupuesto|floatformat:0 }}</td>
+          <td class="px-3 py-1.5 text-right font-mono">{{ r.real|floatformat:0 }}</td>
+          <td class="px-3 py-1.5 text-right font-mono">{{ r.variacion|floatformat:0 }}</td>
+          <td class="px-3 py-1.5 text-right font-semibold">{{ r.pct }}%</td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="5" class="px-3 py-4 text-center text-gray-500">Ninguna categoría con variación &gt;50%. 🎉</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+</div>
+{% endblock %}

--- a/templates/construccion/transacciones_list.html
+++ b/templates/construccion/transacciones_list.html
@@ -1,0 +1,114 @@
+{% extends 'base.html' %}
+{% block title %}Transacciones financieras{% endblock %}
+{% block content %}
+<div class="space-y-4">
+  <div class="flex justify-between items-center">
+    <div>
+      <h1 class="text-2xl font-bold">Transacciones financieras</h1>
+      <p class="text-sm text-gray-500">
+        {{ total_count }} transacciones · Total: ${{ total_valor|floatformat:0 }} COP
+      </p>
+    </div>
+    <div class="flex gap-2">
+      <a href="{% url 'construccion:transacciones_upload' %}"
+         class="px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm">
+        ⬆️ Cargar PDEO Excel
+      </a>
+      <a href="{% url 'construccion:reportes_financieros' %}"
+         class="px-3 py-2 border border-blue-600 text-blue-600 rounded-lg hover:bg-blue-50 text-sm">
+        📊 Reportes
+      </a>
+    </div>
+  </div>
+
+  <form method="get" class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 grid grid-cols-1 md:grid-cols-4 gap-3 text-sm">
+    <div>
+      <label class="block text-xs text-gray-600 dark:text-gray-400 mb-1">Proyecto</label>
+      <select name="proyecto" class="w-full px-2 py-1 border rounded">
+        <option value="">— Todos —</option>
+        {% for p in proyectos %}
+          <option value="{{ p.id }}" {% if filtros.proyecto == p.id|stringformat:'s' %}selected{% endif %}>{{ p.nombre }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div>
+      <label class="block text-xs text-gray-600 dark:text-gray-400 mb-1">Categoría</label>
+      <select name="categoria" class="w-full px-2 py-1 border rounded">
+        <option value="">— Todas —</option>
+        {% for c in categorias %}
+          <option value="{{ c.id }}" {% if filtros.categoria == c.id|stringformat:'s' %}selected{% endif %}>{{ c.nombre }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div>
+      <label class="block text-xs text-gray-600 dark:text-gray-400 mb-1">NIT proveedor</label>
+      <input type="text" name="nit" value="{{ filtros.nit }}"
+             class="w-full px-2 py-1 border rounded" placeholder="NIT contiene…">
+    </div>
+    <div>
+      <label class="block text-xs text-gray-600 dark:text-gray-400 mb-1">Texto libre</label>
+      <input type="text" name="q" value="{{ filtros.q }}"
+             class="w-full px-2 py-1 border rounded" placeholder="descripción, proveedor, factura…">
+    </div>
+    <div>
+      <label class="block text-xs text-gray-600 dark:text-gray-400 mb-1">Desde</label>
+      <input type="date" name="fecha_desde" value="{{ filtros.fecha_desde }}" class="w-full px-2 py-1 border rounded">
+    </div>
+    <div>
+      <label class="block text-xs text-gray-600 dark:text-gray-400 mb-1">Hasta</label>
+      <input type="date" name="fecha_hasta" value="{{ filtros.fecha_hasta }}" class="w-full px-2 py-1 border rounded">
+    </div>
+    <div class="md:col-span-2 flex items-end gap-2">
+      <button type="submit" class="px-3 py-1.5 bg-blue-600 text-white rounded text-sm">Filtrar</button>
+      <a href="{% url 'construccion:transacciones_list' %}" class="px-3 py-1.5 border rounded text-sm">Limpiar</a>
+    </div>
+  </form>
+
+  <div class="bg-white dark:bg-gray-800 rounded-lg shadow overflow-x-auto">
+    <table class="min-w-full text-xs">
+      <thead class="bg-gray-50 dark:bg-gray-700">
+        <tr>
+          <th class="px-3 py-2 text-left">Fecha</th>
+          <th class="px-3 py-2 text-left">Factura</th>
+          <th class="px-3 py-2 text-left">NIT</th>
+          <th class="px-3 py-2 text-left">Proveedor</th>
+          <th class="px-3 py-2 text-left">Descripción</th>
+          <th class="px-3 py-2 text-left">Categoría</th>
+          <th class="px-3 py-2 text-left">Proyecto</th>
+          <th class="px-3 py-2 text-right">Valor (COP)</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for t in transacciones %}
+        <tr class="border-t border-gray-100 dark:border-gray-700">
+          <td class="px-3 py-1.5 whitespace-nowrap">{{ t.fecha|date:'Y-m-d' }}</td>
+          <td class="px-3 py-1.5">{{ t.numero_factura|default:'—' }}</td>
+          <td class="px-3 py-1.5">{{ t.nit_proveedor|default:'—' }}</td>
+          <td class="px-3 py-1.5">{{ t.nombre_proveedor|default:'—'|truncatechars:40 }}</td>
+          <td class="px-3 py-1.5">{{ t.descripcion|truncatechars:60 }}</td>
+          <td class="px-3 py-1.5">{{ t.movimiento.categoria.nombre }}</td>
+          <td class="px-3 py-1.5">{{ t.movimiento.periodo.proyecto.nombre|truncatechars:25 }}</td>
+          <td class="px-3 py-1.5 text-right font-mono">{{ t.valor|floatformat:0 }}</td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="8" class="px-3 py-6 text-center text-gray-500">Sin transacciones con esos filtros.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  {% if is_paginated %}
+  <div class="flex justify-center gap-1 text-sm">
+    {% if page_obj.has_previous %}
+      <a href="?{% for k,v in request.GET.items %}{% if k != 'page' %}{{ k }}={{ v }}&{% endif %}{% endfor %}page={{ page_obj.previous_page_number }}"
+         class="px-2 py-1 border rounded">←</a>
+    {% endif %}
+    <span class="px-2 py-1">Página {{ page_obj.number }} de {{ paginator.num_pages }}</span>
+    {% if page_obj.has_next %}
+      <a href="?{% for k,v in request.GET.items %}{% if k != 'page' %}{{ k }}={{ v }}&{% endif %}{% endfor %}page={{ page_obj.next_page_number }}"
+         class="px-2 py-1 border rounded">→</a>
+    {% endif %}
+  </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/templates/construccion/transacciones_upload.html
+++ b/templates/construccion/transacciones_upload.html
@@ -1,0 +1,43 @@
+{% extends 'base.html' %}
+{% block title %}Cargar Excel PDEO{% endblock %}
+{% block content %}
+<div class="max-w-2xl mx-auto space-y-4">
+  <div>
+    <h1 class="text-2xl font-bold">Cargar Excel PDEO</h1>
+    <p class="text-sm text-gray-500">El parser leerá la hoja BD y poblará las transacciones del proyecto seleccionado. Idempotente: re-cargar el mismo Excel no duplica datos.</p>
+  </div>
+
+  {% if messages %}
+    {% for message in messages %}
+    <div class="rounded-lg p-3 {% if message.tags == 'error' %}bg-red-50 border border-red-200 text-red-800{% else %}bg-green-50 border border-green-200 text-green-800{% endif %} text-sm">{{ message }}</div>
+    {% endfor %}
+  {% endif %}
+
+  <form method="post" enctype="multipart/form-data" class="bg-white dark:bg-gray-800 rounded-lg shadow p-6 space-y-4">
+    {% csrf_token %}
+    <div>
+      <label class="block text-sm font-medium mb-1">{{ form.proyecto.label }}</label>
+      {{ form.proyecto }}
+      {% if form.proyecto.errors %}<p class="text-red-600 text-xs mt-1">{{ form.proyecto.errors|join:" " }}</p>{% endif %}
+    </div>
+    <div>
+      <label class="block text-sm font-medium mb-1">{{ form.archivo.label }}</label>
+      {{ form.archivo }}
+      <p class="text-xs text-gray-500 mt-1">{{ form.archivo.help_text }}</p>
+      {% if form.archivo.errors %}<p class="text-red-600 text-xs mt-1">{{ form.archivo.errors|join:" " }}</p>{% endif %}
+    </div>
+    <div class="flex gap-2 pt-2">
+      <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded-lg">Procesar</button>
+      <a href="{% url 'construccion:transacciones_list' %}" class="px-4 py-2 border rounded-lg">Cancelar</a>
+    </div>
+  </form>
+
+  <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 text-sm text-blue-900">
+    <p class="font-medium mb-1">Estructura esperada del Excel PDEO</p>
+    <ul class="list-disc pl-5 space-y-1">
+      <li><strong>Hoja BD</strong>: transacciones (Auxiliar, Neto, Fecha, Docto., Periodo, Tercero, Razón social, …).</li>
+      <li>Hojas <em>Presupuesto</em>, <em>Res EP</em>, <em>pyg</em>: opcionales — son derivadas y se calculan en runtime, no se cargan.</li>
+    </ul>
+  </div>
+</div>
+{% endblock %}

--- a/tests/unit/test_pdeo_complement.py
+++ b/tests/unit/test_pdeo_complement.py
@@ -1,0 +1,367 @@
+"""Tests para complemento financiero PDEO (#103).
+
+Cubre las 4 vistas + parser:
+  - TransaccionesListView (filtros, paginación, agregado)
+  - TransaccionesUploadView (form validation)
+  - ReportesFinancierosView (3 reportes + export CSV)
+  - PyGDrillDownView (drill-down con expandir categoría)
+  - pdeo_importer.import_pdeo_workbook (idempotencia, mapeo PUC)
+"""
+from datetime import date
+from decimal import Decimal
+from io import BytesIO
+
+import openpyxl
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+from django.urls import reverse
+
+from apps.construccion.models import (
+    CategoriaFinanciera,
+    MovimientoFinanciero,
+    PeriodoFinanciero,
+    ProyectoConstruccion,
+    TransaccionContable,
+)
+from apps.construccion.pdeo_importer import (
+    PUC_PREFIX_MAP,
+    _categoria_para_auxiliar,
+    import_pdeo_workbook,
+)
+from apps.contratos.models import Contrato
+
+User = get_user_model()
+
+
+@pytest.fixture
+def admin_user(db):
+    return User.objects.create_user(
+        email='pdeo_admin@indunnova.com',
+        password='x',
+        rol='admin_general',
+    )
+
+
+@pytest.fixture
+def proyecto(db):
+    contrato = Contrato.objects.create(
+        unidad_negocio=Contrato.UnidadNegocio.CONSTRUCCION,
+        codigo='CT-PDEO-103',
+        nombre='Proyecto PDEO #103',
+        cliente='Cliente PDEO',
+        estado=Contrato.Estado.ACTIVO,
+    )
+    return ProyectoConstruccion.objects.create(
+        contrato=contrato,
+        nombre='Proyecto PDEO complemento',
+        estado='EJECUCION',
+    )
+
+
+@pytest.fixture
+def categoria_admin(db):
+    return CategoriaFinanciera.objects.create(
+        codigo='ADMIN',
+        nombre='Administración',
+        tipo='GASTO',
+        orden=10,
+    )
+
+
+@pytest.fixture
+def categoria_ingresos(db):
+    return CategoriaFinanciera.objects.create(
+        codigo='INGRESOS',
+        nombre='Ingresos Operacionales',
+        tipo='INGRESO',
+        orden=1,
+    )
+
+
+@pytest.fixture
+def movimientos_seed(proyecto, categoria_admin, categoria_ingresos):
+    """Crea 2 periodos × 2 categorías × 2 tipos = 8 movimientos."""
+    p1 = PeriodoFinanciero.objects.create(
+        proyecto=proyecto, anio=2025, mes=1)
+    p2 = PeriodoFinanciero.objects.create(
+        proyecto=proyecto, anio=2025, mes=2)
+    movs = []
+    for periodo in [p1, p2]:
+        for cat in [categoria_admin, categoria_ingresos]:
+            movs.append(MovimientoFinanciero.objects.create(
+                periodo=periodo, categoria=cat,
+                tipo='PRESUPUESTO', valor=Decimal('100000')))
+            movs.append(MovimientoFinanciero.objects.create(
+                periodo=periodo, categoria=cat,
+                tipo='REAL', valor=Decimal('120000')))
+    return movs
+
+
+@pytest.fixture
+def transacciones_seed(movimientos_seed):
+    """Crea 5 transacciones repartidas en los movimientos REAL."""
+    movs_real = [m for m in movimientos_seed if m.tipo == 'REAL']
+    txs = []
+    for i, mov in enumerate(movs_real * 2):  # 8 movimientos REAL × 2 = 16, slice 5
+        if len(txs) >= 5:
+            break
+        txs.append(TransaccionContable.objects.create(
+            movimiento=mov,
+            fecha=date(2025, mov.periodo.mes, 10 + i),
+            descripcion=f'Transacción de prueba {i}',
+            nit_proveedor=f'900{i:06d}',
+            nombre_proveedor=f'Proveedor {i}',
+            numero_factura=f'FV-{i:04d}',
+            valor=Decimal('30000') + i * 1000,
+        ))
+    return txs
+
+
+# === TransaccionesListView ===
+
+@pytest.mark.django_db
+def test_transacciones_list_view_renders(admin_user, transacciones_seed):
+    c = Client()
+    c.force_login(admin_user)
+    resp = c.get(reverse('construccion:transacciones_list'))
+    assert resp.status_code == 200
+    assert b'Transacciones financieras' in resp.content
+
+
+@pytest.mark.django_db
+def test_transacciones_list_filtro_nit(admin_user, transacciones_seed):
+    c = Client()
+    c.force_login(admin_user)
+    tx0 = transacciones_seed[0]
+    resp = c.get(reverse('construccion:transacciones_list'),
+                 {'nit': tx0.nit_proveedor})
+    assert resp.status_code == 200
+    # Filtrar por nit_proveedor exacto debe traer al menos esa transaccion
+    assert tx0.nit_proveedor.encode() in resp.content
+
+
+@pytest.mark.django_db
+def test_transacciones_list_filtro_categoria(admin_user, transacciones_seed,
+                                              categoria_admin):
+    c = Client()
+    c.force_login(admin_user)
+    resp = c.get(reverse('construccion:transacciones_list'),
+                 {'categoria': str(categoria_admin.id)})
+    assert resp.status_code == 200
+
+
+@pytest.mark.django_db
+def test_transacciones_list_total_agregado(admin_user, transacciones_seed):
+    c = Client()
+    c.force_login(admin_user)
+    resp = c.get(reverse('construccion:transacciones_list'))
+    assert resp.status_code == 200
+    # Tiene que mostrar el total y el count
+    expected_total = sum(t.valor for t in transacciones_seed)
+    assert str(int(expected_total)).encode() in resp.content or b'transacciones' in resp.content
+
+
+# === TransaccionesUploadView ===
+
+@pytest.mark.django_db
+def test_transacciones_upload_get_renders(admin_user):
+    c = Client()
+    c.force_login(admin_user)
+    resp = c.get(reverse('construccion:transacciones_upload'))
+    assert resp.status_code == 200
+    assert b'Cargar Excel PDEO' in resp.content
+
+
+@pytest.mark.django_db
+def test_transacciones_upload_rejects_non_xlsx(admin_user, proyecto):
+    c = Client()
+    c.force_login(admin_user)
+    from django.core.files.uploadedfile import SimpleUploadedFile
+    bad = SimpleUploadedFile('test.csv', b'fake data',
+                              content_type='text/csv')
+    resp = c.post(reverse('construccion:transacciones_upload'),
+                  {'proyecto': str(proyecto.id), 'archivo': bad})
+    assert resp.status_code == 200  # form re-renders with errors
+    assert b'Solo se aceptan archivos' in resp.content
+
+
+# === ReportesFinancierosView ===
+
+@pytest.mark.django_db
+def test_reportes_renders_with_data(admin_user, movimientos_seed,
+                                     transacciones_seed):
+    c = Client()
+    c.force_login(admin_user)
+    resp = c.get(reverse('construccion:reportes_financieros'))
+    assert resp.status_code == 200
+    assert b'PyG por trimestre' in resp.content
+    assert b'Top 10 proveedores' in resp.content
+    assert b'Alertas' in resp.content
+
+
+@pytest.mark.django_db
+def test_reportes_export_csv_pyg_trimestre(admin_user, movimientos_seed):
+    c = Client()
+    c.force_login(admin_user)
+    resp = c.get(reverse('construccion:reportes_financieros'),
+                 {'export': 'csv', 'reporte': 'pyg_trimestre'})
+    assert resp.status_code == 200
+    assert resp['Content-Type'].startswith('text/csv')
+    assert b'Trimestre,Tipo,Presupuesto' in resp.content
+
+
+@pytest.mark.django_db
+def test_reportes_export_csv_top_proveedores(admin_user, transacciones_seed):
+    c = Client()
+    c.force_login(admin_user)
+    resp = c.get(reverse('construccion:reportes_financieros'),
+                 {'export': 'csv', 'reporte': 'top_proveedores'})
+    assert resp.status_code == 200
+    assert b'NIT,Raz' in resp.content
+
+
+@pytest.mark.django_db
+def test_reportes_alertas_solo_variacion_alta(admin_user, proyecto,
+                                                categoria_admin):
+    """Alerta solo si abs(variación) >= 50%."""
+    p = PeriodoFinanciero.objects.create(proyecto=proyecto, anio=2025, mes=1)
+    # 100k presup, 200k real → 100% variación → debe disparar alerta
+    MovimientoFinanciero.objects.create(periodo=p, categoria=categoria_admin,
+                                         tipo='PRESUPUESTO',
+                                         valor=Decimal('100000'))
+    MovimientoFinanciero.objects.create(periodo=p, categoria=categoria_admin,
+                                         tipo='REAL',
+                                         valor=Decimal('200000'))
+    c = Client()
+    c.force_login(admin_user)
+    resp = c.get(reverse('construccion:reportes_financieros'))
+    assert resp.status_code == 200
+    # La categoria 'Administración' debe aparecer en alertas
+    assert b'Administraci' in resp.content
+
+
+# === PyGDrillDownView ===
+
+@pytest.mark.django_db
+def test_pyg_drilldown_renders(admin_user, proyecto, movimientos_seed):
+    c = Client()
+    c.force_login(admin_user)
+    resp = c.get(reverse('construccion:pyg_drilldown',
+                          kwargs={'proyecto_id': proyecto.id}))
+    assert resp.status_code == 200
+    assert b'Estado de Resultados' in resp.content
+
+
+@pytest.mark.django_db
+def test_pyg_drilldown_expandir_muestra_transacciones(admin_user, proyecto,
+                                                       categoria_admin,
+                                                       movimientos_seed,
+                                                       transacciones_seed):
+    c = Client()
+    c.force_login(admin_user)
+    resp = c.get(reverse('construccion:pyg_drilldown',
+                          kwargs={'proyecto_id': proyecto.id}),
+                 {'expandir': str(categoria_admin.id)})
+    assert resp.status_code == 200
+
+
+# === pdeo_importer ===
+
+@pytest.mark.django_db
+def test_categoria_para_auxiliar_mapea_prefix():
+    cat = _categoria_para_auxiliar('41250501')
+    assert cat.codigo == 'INGRESOS'
+    cat = _categoria_para_auxiliar('51100501')
+    assert cat.codigo == 'ADMIN'
+    cat = _categoria_para_auxiliar('99999999')
+    assert cat.codigo == 'OTROS'
+
+
+@pytest.mark.django_db
+def test_puc_prefix_map_cubre_principales():
+    for pref in ['41', '42', '51', '52', '53', '54', '72', '73']:
+        assert pref in PUC_PREFIX_MAP
+
+
+def _build_pdeo_excel(rows):
+    """Helper: arma un workbook PDEO mínimo con hoja BD."""
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = 'BD'
+    header = ['Auxiliar', 'Desc. auxiliar', 'Neto', 'Fecha', 'Docto.',
+              'Periodo', 'Tercero movto.', 'Razón social tercero movto.',
+              'Desc. C.O. movto.', 'Usuario creación', 'C.O. movto.',
+              'Notas', 'C.Costo', 'Desc. C.Costo', 'Cta equivalente',
+              'Cargo', 'Subcontratista', 'SUBCONTRATA', 'Q']
+    ws.append(header)
+    for r in rows:
+        ws.append(r)
+    buf = BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+    return buf
+
+
+@pytest.mark.django_db
+def test_import_pdeo_workbook_crea_transacciones(proyecto):
+    rows = [
+        ['41250501', 'Lineas de transmision', -2423118863,
+         date(2024, 11, 26), 'FVE-1015', 202411, '860000656',
+         'HMV INGENIEROS', '', '', '', '', '4001', '', '', '', '', '', ''],
+        ['51100501', 'Gastos admin', 150000,
+         date(2024, 12, 5), 'FC-301', 202412, '900111222',
+         'Proveedor admin', '', '', '', '', '4002', '', '', '', '', '', ''],
+    ]
+    buf = _build_pdeo_excel(rows)
+    stats = import_pdeo_workbook(buf, proyecto)
+    assert stats['transacciones_creadas'] == 2
+    assert stats['transacciones_omitidas'] == 0
+    assert TransaccionContable.objects.count() == 2
+    # Periodos creados correctamente
+    assert PeriodoFinanciero.objects.filter(
+        proyecto=proyecto, anio=2024, mes=11).exists()
+    assert PeriodoFinanciero.objects.filter(
+        proyecto=proyecto, anio=2024, mes=12).exists()
+    # Categoría mapeada por PUC
+    ing = TransaccionContable.objects.get(numero_factura='FVE-1015')
+    assert ing.movimiento.categoria.codigo == 'INGRESOS'
+    admin = TransaccionContable.objects.get(numero_factura='FC-301')
+    assert admin.movimiento.categoria.codigo == 'ADMIN'
+
+
+@pytest.mark.django_db
+def test_import_pdeo_workbook_idempotente(proyecto):
+    """Cargar 2 veces el mismo Excel NO duplica transacciones."""
+    rows = [
+        ['41250501', 'Test', 100000, date(2025, 1, 15), 'FAC-001',
+         202501, '900111', 'Proveedor X', '', '', '', '', '', '', '', '', '', '', ''],
+    ]
+    buf1 = _build_pdeo_excel(rows)
+    stats1 = import_pdeo_workbook(buf1, proyecto)
+    assert stats1['transacciones_creadas'] == 1
+
+    buf2 = _build_pdeo_excel(rows)
+    stats2 = import_pdeo_workbook(buf2, proyecto)
+    assert stats2['transacciones_creadas'] == 0
+    assert stats2['transacciones_omitidas'] == 1
+    assert TransaccionContable.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_import_pdeo_actualiza_movimiento_valor(proyecto):
+    """Cada transacción debe acumularse al MovimientoFinanciero correspondiente."""
+    rows = [
+        ['51100501', 'Admin 1', 100000, date(2025, 1, 5), 'F1',
+         202501, '900', 'P', '', '', '', '', '', '', '', '', '', '', ''],
+        ['51100501', 'Admin 2', 50000, date(2025, 1, 8), 'F2',
+         202501, '900', 'P', '', '', '', '', '', '', '', '', '', '', ''],
+    ]
+    buf = _build_pdeo_excel(rows)
+    import_pdeo_workbook(buf, proyecto)
+    cat = CategoriaFinanciera.objects.get(codigo='ADMIN')
+    mov = MovimientoFinanciero.objects.get(
+        periodo__proyecto=proyecto,
+        periodo__anio=2025, periodo__mes=1,
+        categoria=cat, tipo='REAL')
+    assert mov.valor == Decimal('150000')


### PR DESCRIPTION
## Resumen

Complementa el módulo PDEO de #69/#66/#70 (ya en prod desde hace semanas) con las 4 vistas que Ana Sofía pidió en #103. **NO crea modelos nuevos** — reusa los existentes (CategoriaFinanciera, PeriodoFinanciero, MovimientoFinanciero, TransaccionContable).

## Vistas nuevas

| URL | Vista | Función |
|---|---|---|
| `/construccion/financiero/transacciones/` | `TransaccionesListView` | Lista global con 7 filtros (proyecto, categoría, periodo, NIT, fecha desde/hasta, texto libre) + paginación 50/página + total agregado del filtro. |
| `/construccion/financiero/transacciones/upload/` | `TransaccionesUploadView` | Form de carga del Excel PDEO. Procesa hoja BD (23K filas). Idempotente vía `(numero_factura, nit, fecha, valor)` — re-cargar no duplica. |
| `/construccion/financiero/reportes/` | `ReportesFinancierosView` | 3 reportes (PyG trimestral cross-proyecto, Top 10 proveedores, Alertas variación >50%) + export CSV por reporte + filtro por año. |
| `/construccion/<uuid>/pyg/` | `PyGDrillDownView` | Drill-down PyG dedicado con expansión de transacciones por categoría (top 200). |

## Parser PDEO

`apps/construccion/pdeo_importer.py:import_pdeo_workbook` con:

- **Idempotencia**: detecta duplicados antes de insertar; stats reporta creadas + omitidas.
- **Mapeo PUC → CategoriaFinanciera** por prefijo de cuenta auxiliar (41xx→INGRESOS, 51xx→ADMIN, 52xx→PERSONAL, 53xx→FINANCIEROS, 54xx→IMPUESTOS, 72xx→CIF, 73xx→MATERIALES, otros→OTROS on-demand).
- **Bulk create** cada 1000 filas para no agotar RAM con 23K.
- **Agregado automático** sobre `MovimientoFinanciero.valor` del periodo+categoría.

## Management command

`python manage.py cargar_pdeo_excel "Documentacion/PDEO -Detalle 2024-2025-2026.xlsx" <proyecto_uuid>`

## Tests

`tests/unit/test_pdeo_complement.py` — **17/17 verde**, ~1.6s. Cubre las 4 vistas + parser idempotente + mapeo PUC + acumulado MovimientoFinanciero.

Tests preexistentes rojos no introducidos por este PR: `test_permissions.py::test_wrong_role_denied_importar`, `test_sidebar_modulos.py` (placeholders reemplazados por views_b1/b2 del sprint anterior), `test_views.py::test_importar_programacion_requires_role`, `test_usuarios.py::TestUsuarioModel::test_create_user`.

## Plan persistido

`SPRINTS/PLAN_2026-05-28_103_financiero_complemento.md` con inventario delta vs scope original del issue.

## NO incluido (sub-issue separado)

RBAC granular (`financiero.view_pyg`, etc) — migrar 5 vistas existentes de `ALL_ADMIN_ROLES` requiere reasignar perms en producción. Riesgo de regresión medio. Sub-issue después del merge.

## Smoke pendiente

Post-deploy con `/qa-prod Instelec` + journey cubriendo las 4 URLs autenticado como `qa_claude@instelec.com`.

Refs #103