### PR TITLE
fix(#95): STORAGES dict para Django 5.1 → uploads van a GCS

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -57,13 +57,20 @@ DATABASES['default']['CONN_HEALTH_CHECKS'] = True
 # =============================================================================
 # Google Cloud Storage
 # =============================================================================
-DEFAULT_FILE_STORAGE = 'storages.backends.gcloud.GoogleCloudStorage'
+# Django 5.x: STORAGES dict reemplaza DEFAULT_FILE_STORAGE / STATICFILES_STORAGE.
+# Mantener los legacy en paralelo no funciona — Django ignora silenciosamente
+# y cae a FileSystemStorage (efímero en Cloud Run). Issue #95.
+STORAGES = {
+    "default": {
+        "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+    },
+}
 GS_DEFAULT_ACL = 'publicRead'
 GS_QUERYSTRING_AUTH = False
 GS_FILE_OVERWRITE = False
-
-# Static files served by WhiteNoise
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 # =============================================================================
 # Cache Configuration


### PR DESCRIPTION
## Summary
- En Django 5.1, `DEFAULT_FILE_STORAGE` + `STATICFILES_STORAGE` legacy caen silenciosamente a `FileSystemStorage` cuando coexisten — el storage backend de GCS nunca se cargaba.
- Resultado: archivos subidos por `/campo/procedimientos/crear/` quedaban en `/app/media` efímero del container Cloud Run; bucket `gs://instelec-media` quedó completamente vacío durante 2 meses.
- Fix: migrar a `STORAGES` dict explícito (Django 5.x).

## Evidencia del bug
- BD `procedimientos_campo`: 5 registros con `archivo`, `tamanio` correcto (último PDF = 6.07 MB), pero `gsutil ls gs://instelec-media/` = 0 archivos / 0 B.
- Audit logs GCS: cero llamadas `storage.objects.create` desde Cloud Run.
- Endpoint `/campo/procedimientos/<uuid>/download/` → 200 con `Content-Length: 0` (FileSystemStorage abre archivo inexistente sin raise).

## Closes
#95 (CORS + STORAGES juntos destraban preview)