### PR TITLE
fix(#118): preview iframe PDF (X-Frame-Options sameorigin)

### DIFF
--- a/apps/campo/views_b6.py
+++ b/apps/campo/views_b6.py
@@ -25,13 +25,16 @@ import os
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import FileResponse, Http404
 from django.urls import path
+from django.utils.decorators import method_decorator
 from django.views import View
+from django.views.decorators.clickjacking import xframe_options_sameorigin
 
 from apps.core.mixins import RoleRequiredMixin
 
 from .models import Procedimiento
 
 
+@method_decorator(xframe_options_sameorigin, name='dispatch')
 class ProcedimientoDownloadView(LoginRequiredMixin, RoleRequiredMixin, View):
     """Proxy view que sirve un Procedimiento via storage backend.
 


### PR DESCRIPTION
Hotfix descubierto durante smoke de #118: el viewer del PDF mostraba área en blanco porque la response del download trae `X-Frame-Options: DENY` (Django middleware default), bloqueando el iframe del viewer.

Fix: decorar `ProcedimientoDownloadView` con `xframe_options_sameorigin`.

Verificado en logs: el iframe pide la URL del download, recibe el PDF de 6MB con HTTP 200, pero el browser rechaza renderizar por XFO. Captura del cliente: área de preview vacía pero header del archivo OK + botón Descargar funcional.

Relacionado #118.