### PR TITLE
feat(financiero_construccion_runB): #123 módulo financiero completo para Construcción (B3+B4+B5)

### DIFF
--- a/apps/construccion/admin.py
+++ b/apps/construccion/admin.py
@@ -91,3 +91,5 @@ class CorreccionEntregaAdmin(admin.ModelAdmin):
     list_display = ['torre', 'avance_correccion', 'firma_hmv']
     list_filter = ['firma_hmv']
     search_fields = ['torre__numero']
+
+from .admin_fin import *  # noqa: E402,F401,F403  # B3 (#123) financiero construccion

--- a/apps/construccion/admin_fin.py
+++ b/apps/construccion/admin_fin.py
@@ -1,0 +1,65 @@
+"""B3 (#123) — Admin de los 5 modelos financieros de Construcción.
+
+Registra en el admin de Django los modelos definidos en ``models_fin.py``.
+
+WIRING: para que Django descubra estos registros, ``apps/construccion/admin.py``
+debe importar este módulo (``from .admin_fin import *  # noqa``). Esa línea vive
+en ``admin.py``, que NO es FILES_OWNED de B3 — la agrega F2/F4 (ver nota emitida
+por B3 al orquestador). Sin esa línea los modelos existen y migran igual, pero no
+aparecen en /admin/.
+"""
+from django.contrib import admin
+
+from .models_fin import (
+    PresupuestoDetalladoConstruccion,
+    CostosConstruccion,
+    CostosActividadConstruccion,
+    FacturacionConstruccion,
+    IndicadorANSConstruccion,
+)
+
+
+@admin.register(PresupuestoDetalladoConstruccion)
+class PresupuestoDetalladoConstruccionAdmin(admin.ModelAdmin):
+    list_display = ['proyecto', 'anio', 'tipo', 'created_at']
+    list_filter = ['tipo', 'anio']
+    search_fields = ['proyecto__nombre']
+    raw_id_fields = ['proyecto']
+
+
+@admin.register(CostosConstruccion)
+class CostosConstruccionAdmin(admin.ModelAdmin):
+    list_display = ['concepto', 'proyecto', 'tipo_recurso', 'cantidad',
+                    'costo_unitario', 'costo_total', 'fecha']
+    list_filter = ['tipo_recurso', 'fecha']
+    search_fields = ['concepto', 'proyecto__nombre']
+    raw_id_fields = ['proyecto', 'actividad']
+    readonly_fields = ['costo_total']
+    date_hierarchy = 'fecha'
+
+
+@admin.register(CostosActividadConstruccion)
+class CostosActividadConstruccionAdmin(admin.ModelAdmin):
+    list_display = ['actividad', 'costo_materiales', 'costo_mano_obra',
+                    'costo_equipos', 'costo_subcontratos', 'costo_otros']
+    raw_id_fields = ['actividad']
+
+
+@admin.register(FacturacionConstruccion)
+class FacturacionConstruccionAdmin(admin.ModelAdmin):
+    list_display = ['numero_factura', 'proyecto', 'fecha_emision',
+                    'monto_facturado', 'monto_pagado', 'estado']
+    list_filter = ['estado', 'fecha_emision']
+    search_fields = ['numero_factura', 'proyecto__nombre']
+    raw_id_fields = ['proyecto']
+    date_hierarchy = 'fecha_emision'
+
+
+@admin.register(IndicadorANSConstruccion)
+class IndicadorANSConstruccionAdmin(admin.ModelAdmin):
+    list_display = ['nombre', 'proyecto', 'periodo_anio', 'periodo_mes',
+                    'meta_porcentaje', 'valor_actual', 'estado']
+    list_filter = ['estado', 'periodo_anio', 'periodo_mes']
+    search_fields = ['nombre', 'proyecto__nombre']
+    raw_id_fields = ['proyecto']
+    readonly_fields = ['estado']

--- a/apps/construccion/forms_fin.py
+++ b/apps/construccion/forms_fin.py
@@ -1,0 +1,163 @@
+"""B5 (#123 Fase 3/4) — Forms del Módulo Financiero de Construcción.
+
+Tres forms:
+
+1. ``CargarBDContableConstruccionForm`` — carga del .xlsx (BD contable o
+   presupuesto). Espejo de ``apps.financiero.forms_finv2.CargarBDContableForm``
+   (mismo widget Tailwind file:, misma validación .xlsx + ≤ 20 MB).
+2. ``FacturacionConstruccionForm`` — ModelForm de ``FacturacionConstruccion``.
+3. ``CostosConstruccionForm``      — ModelForm de ``CostosConstruccion``
+   (``costo_total`` se autocalcula en save(), no se expone).
+
+Las clases CSS replican el estilo de los forms existentes de construcción
+(``forms_b2_indicadores``) y financiero v2 para consistencia visual.
+"""
+from django import forms
+
+from apps.financiero.importers_finv2 import MAX_UPLOAD_BYTES
+
+from .models_fin import CostosConstruccion, FacturacionConstruccion
+
+
+# Clase base reutilizada por los inputs de texto/número/fecha.
+_INPUT_CLS = (
+    'w-full rounded-lg border-gray-300 dark:border-gray-600 '
+    'dark:bg-gray-800 dark:text-white text-sm'
+)
+_FILE_CLS = (
+    'block w-full text-sm text-gray-500 dark:text-gray-400 '
+    'file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 '
+    'file:text-sm file:font-semibold file:bg-blue-50 '
+    'file:text-blue-700 hover:file:bg-blue-100 '
+    'dark:file:bg-gray-700 dark:file:text-gray-300'
+)
+
+
+class CargarBDContableConstruccionForm(forms.Form):
+    """Carga de archivo .xlsx (BD contable / presupuesto / costos).
+
+    Misma validación que el form de #120: extensión .xlsx + tamaño ≤ 20 MB. El
+    tipo concreto de archivo lo decide ``detect_excel_format_construccion`` en la
+    vista; este form solo garantiza que sea un .xlsx procesable.
+    """
+
+    archivo = forms.FileField(
+        label='Archivo Excel (.xlsx)',
+        help_text=(
+            'Suba el archivo de presupuesto, base de datos contable o costos '
+            'en formato .xlsx. Máximo 20 MB.'
+        ),
+        widget=forms.ClearableFileInput(attrs={
+            'accept': '.xlsx',
+            'class': _FILE_CLS,
+        }),
+    )
+
+    def clean_archivo(self):
+        archivo = self.cleaned_data['archivo']
+        nombre = (getattr(archivo, 'name', '') or '').lower()
+        if not nombre.endswith('.xlsx'):
+            raise forms.ValidationError(
+                'Archivo inválido. Verifique que sea .xlsx con estructura '
+                'correcta.'
+            )
+        if getattr(archivo, 'size', 0) > MAX_UPLOAD_BYTES:
+            raise forms.ValidationError(
+                'El archivo excede el tamaño máximo (20 MB).'
+            )
+        return archivo
+
+
+class FacturacionConstruccionForm(forms.ModelForm):
+    """Alta/edición de una factura del proyecto."""
+
+    class Meta:
+        model = FacturacionConstruccion
+        fields = [
+            'numero_factura', 'fecha_emision', 'monto_facturado',
+            'monto_pagado', 'estado', 'observaciones',
+        ]
+        widgets = {
+            'numero_factura': forms.TextInput(attrs={
+                'class': _INPUT_CLS, 'placeholder': 'Ej: FV-001',
+            }),
+            'fecha_emision': forms.DateInput(attrs={
+                'class': _INPUT_CLS, 'type': 'date',
+            }, format='%Y-%m-%d'),
+            'monto_facturado': forms.NumberInput(attrs={
+                'class': _INPUT_CLS, 'step': '0.01', 'min': '0',
+            }),
+            'monto_pagado': forms.NumberInput(attrs={
+                'class': _INPUT_CLS, 'step': '0.01', 'min': '0',
+            }),
+            'estado': forms.Select(attrs={'class': _INPUT_CLS}),
+            'observaciones': forms.Textarea(attrs={
+                'class': _INPUT_CLS, 'rows': 2,
+            }),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # El widget date necesita el input_format ISO para repoblar al editar.
+        self.fields['fecha_emision'].input_formats = ['%Y-%m-%d']
+
+    def clean(self):
+        cleaned = super().clean()
+        facturado = cleaned.get('monto_facturado')
+        pagado = cleaned.get('monto_pagado')
+        # Regla de negocio: no se puede pagar más de lo facturado.
+        if facturado is not None and pagado is not None and pagado > facturado:
+            self.add_error(
+                'monto_pagado',
+                'El monto pagado no puede superar el monto facturado.',
+            )
+        return cleaned
+
+
+class CostosConstruccionForm(forms.ModelForm):
+    """Alta/edición de un costo ejecutado.
+
+    ``costo_total`` NO se expone: lo calcula ``CostosConstruccion.save()``
+    (cantidad × costo_unitario). El campo ``actividad`` es opcional (FK nullable).
+    """
+
+    class Meta:
+        model = CostosConstruccion
+        fields = [
+            'concepto', 'tipo_recurso', 'cantidad', 'costo_unitario',
+            'fecha', 'actividad',
+        ]
+        widgets = {
+            'concepto': forms.TextInput(attrs={
+                'class': _INPUT_CLS, 'placeholder': 'Ej: Cemento gris 50kg',
+            }),
+            'tipo_recurso': forms.Select(attrs={'class': _INPUT_CLS}),
+            'cantidad': forms.NumberInput(attrs={
+                'class': _INPUT_CLS, 'step': '0.01', 'min': '0',
+            }),
+            'costo_unitario': forms.NumberInput(attrs={
+                'class': _INPUT_CLS, 'step': '0.01', 'min': '0',
+            }),
+            'fecha': forms.DateInput(attrs={
+                'class': _INPUT_CLS, 'type': 'date',
+            }, format='%Y-%m-%d'),
+            'actividad': forms.Select(attrs={'class': _INPUT_CLS}),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['fecha'].input_formats = ['%Y-%m-%d']
+        self.fields['actividad'].required = False
+        self.fields['actividad'].empty_label = '— Sin actividad —'
+
+    def clean_cantidad(self):
+        cantidad = self.cleaned_data.get('cantidad')
+        if cantidad is not None and cantidad < 0:
+            raise forms.ValidationError('La cantidad no puede ser negativa.')
+        return cantidad
+
+    def clean_costo_unitario(self):
+        unitario = self.cleaned_data.get('costo_unitario')
+        if unitario is not None and unitario < 0:
+            raise forms.ValidationError('El costo unitario no puede ser negativo.')
+        return unitario

--- a/apps/construccion/importers.py
+++ b/apps/construccion/importers.py
@@ -1,0 +1,506 @@
+"""B5 (#123 Fase 4) — Importadores de Excel del Módulo Financiero de Construcción.
+
+Tres importadores + un detector de formato, que leen archivos .xlsx y escriben
+en los modelos B3 (``models_fin``):
+
+1. ``PresupuestoConstruccionExcelImporter``  → ``PresupuestoDetalladoConstruccion.datos``
+   (estructura por secciones ingreso/variables/fijos con valores mensuales).
+2. ``ContableConstruccionExcelImporter``      → ``PresupuestoDetalladoConstruccion.datos``
+   bajo la llave ``finv2_bd`` (agrupa la BD contable por cuenta equivalente,
+   reusando ``apps.financiero.importers_finv2.ContableCompleteImporter``).
+3. ``CostosConstruccionExcelImporter``        → registros ``CostosConstruccion``
+   (una fila de Excel = un costo ejecutado).
+4. ``detect_excel_format_construccion(archivo)`` → 'presupuesto' | 'contable' |
+   'costos' | None (heurística por nombres de hoja/encabezados).
+
+Reuso (issue #123 Fase 4 "Adaptación de importadores existentes"):
+- ``apps.financiero.importers_finv2``: ``_norm`` (normalización de encabezados),
+  ``_to_number`` (celda → float seguro), ``MAX_UPLOAD_BYTES``,
+  ``ContableCompleteImporter`` (toda la lógica de agrupación contable).
+
+Contrato de retorno (espejo de ``ContableCompleteImporter.procesar_*``): un dict
+con ``exito``, ``error`` (❌), ``advertencia`` (⚠️), ``mensaje`` (✅) y datos
+auxiliares. Los importadores **no** hacen ``save()`` ellos mismos cuando el
+destino es un JSONField (devuelven ``datos`` para que la vista lo persista); el
+importador de costos sí persiste filas (devuelve ``creados``/``omitidos``).
+
+Validación de archivo (.xlsx + ≤ 20 MB) centralizada en ``_validar_archivo``.
+"""
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+
+from openpyxl import load_workbook
+
+from apps.financiero.importers_finv2 import (
+    MAX_UPLOAD_BYTES,
+    ContableCompleteImporter,
+    _norm,
+    _to_number,
+)
+
+from .models_fin import (
+    CostosConstruccion,
+    PresupuestoDetalladoConstruccion,
+)
+
+
+# Meses reconocidos en encabezados de presupuesto (normalizados, sin acento).
+_MESES = (
+    'enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio', 'julio',
+    'agosto', 'septiembre', 'setiembre', 'octubre', 'noviembre', 'diciembre',
+)
+
+# Palabras clave que marcan la sección de una fila de presupuesto.
+_KW_INGRESO = ('ingreso', 'ingresos', 'facturacion', 'venta', 'ventas')
+_KW_VARIABLES = ('variable', 'variables', 'directo', 'directos', 'costo directo')
+_KW_FIJOS = ('fijo', 'fijos', 'gasto', 'gastos', 'indirecto', 'indirectos')
+
+# Encabezados candidatos para el importador de costos.
+_COL_CONCEPTO = ('concepto', 'descripcion', 'detalle', 'item')
+_COL_TIPO = ('tipo recurso', 'tipo de recurso', 'tipo', 'recurso')
+_COL_CANTIDAD = ('cantidad', 'cant', 'qty')
+_COL_UNITARIO = ('costo unitario', 'valor unitario', 'precio unitario', 'unitario', 'vr unitario')
+_COL_TOTAL = ('costo total', 'valor total', 'total')
+_COL_FECHA = ('fecha', 'fecha costo', 'fecha registro')
+
+# Mapa de texto libre → choice de TipoRecurso.
+_TIPO_RECURSO_ALIASES = {
+    'material': CostosConstruccion.TipoRecurso.MATERIAL,
+    'materiales': CostosConstruccion.TipoRecurso.MATERIAL,
+    'mano de obra': CostosConstruccion.TipoRecurso.MANO_OBRA,
+    'mano obra': CostosConstruccion.TipoRecurso.MANO_OBRA,
+    'manodeobra': CostosConstruccion.TipoRecurso.MANO_OBRA,
+    'mo': CostosConstruccion.TipoRecurso.MANO_OBRA,
+    'equipo': CostosConstruccion.TipoRecurso.EQUIPOS,
+    'equipos': CostosConstruccion.TipoRecurso.EQUIPOS,
+    'maquinaria': CostosConstruccion.TipoRecurso.EQUIPOS,
+    'subcontrata': CostosConstruccion.TipoRecurso.SUBCONTRATA,
+    'subcontratos': CostosConstruccion.TipoRecurso.SUBCONTRATA,
+    'subcontrato': CostosConstruccion.TipoRecurso.SUBCONTRATA,
+    'otro': CostosConstruccion.TipoRecurso.OTROS,
+    'otros': CostosConstruccion.TipoRecurso.OTROS,
+}
+
+
+# ===========================================================================
+# Helpers compartidos
+# ===========================================================================
+def _validar_archivo(archivo):
+    """Valida extensión .xlsx + tamaño ≤ 20 MB.
+
+    Devuelve ``None`` si es válido, o un dict de error (contrato estándar) si no.
+    """
+    nombre = (getattr(archivo, 'name', '') or '')
+    if not nombre.lower().endswith('.xlsx'):
+        return _resultado_error(
+            'Archivo inválido. Verifique que sea .xlsx con estructura correcta.'
+        )
+    tamano = getattr(archivo, 'size', None)
+    if tamano is not None and tamano > MAX_UPLOAD_BYTES:
+        return _resultado_error(
+            'Archivo inválido. El archivo excede el tamaño máximo (20 MB).'
+        )
+    return None
+
+
+def _resultado_error(msg):
+    return {
+        'exito': False, 'error': msg, 'advertencia': None, 'mensaje': None,
+        'datos': None, 'filas': 0,
+    }
+
+
+def _resultado_advertencia(msg):
+    return {
+        'exito': False, 'error': None, 'advertencia': msg, 'mensaje': None,
+        'datos': None, 'filas': 0,
+    }
+
+
+def _to_decimal(valor) -> Decimal:
+    """Celda → Decimal seguro (nunca lanza)."""
+    if isinstance(valor, Decimal):
+        return valor
+    if valor is None:
+        return Decimal('0')
+    try:
+        return Decimal(str(valor))
+    except (InvalidOperation, ValueError, TypeError):
+        return Decimal('0')
+
+
+def _locate_columns(sheet, mapa_candidatos):
+    """Detecta índices 1-based de columnas por encabezado normalizado (fila 1).
+
+    ``mapa_candidatos`` es ``{logical_name: (candidato1, candidato2, ...)}``.
+    Devuelve ``{logical_name: col_index | None}``.
+    """
+    headers = {}
+    for col in range(1, 40):
+        val = sheet.cell(row=1, column=col).value
+        if val:
+            headers[_norm(val)] = col
+
+    resultado = {}
+    for logical, candidatos in mapa_candidatos.items():
+        idx = None
+        for cand in candidatos:
+            if _norm(cand) in headers:
+                idx = headers[_norm(cand)]
+                break
+        resultado[logical] = idx
+    return resultado
+
+
+def _abrir_workbook(archivo):
+    """Abre el workbook read-only/data-only o devuelve (None, error_dict)."""
+    try:
+        wb = load_workbook(archivo, read_only=True, data_only=True)
+    except Exception as exc:  # noqa: BLE001
+        return None, _resultado_error(
+            f'Archivo inválido. Verifique que sea .xlsx con estructura '
+            f'correcta ({exc}).'
+        )
+    return wb, None
+
+
+# ===========================================================================
+# 1. PRESUPUESTO (ingreso / variables / fijos por mes) → datos JSON
+# ===========================================================================
+class PresupuestoConstruccionExcelImporter:
+    """Lee un Excel de presupuesto y construye la estructura ``datos``.
+
+    Layout esperado (flexible): la columna A/primera contiene el rubro/concepto
+    de la fila; las columnas de meses (enero..diciembre, detectadas por
+    encabezado) contienen los valores. Cada fila se clasifica en una sección
+    (``ingreso`` / ``variables`` / ``fijos``) según palabras clave del concepto.
+
+    Estructura de salida (consumida por ``ProyectoFinMixin._resumen_presupuesto``
+    en views_fin.py y por el template ``_financiero_presupuesto_tabla.html``)::
+
+        {"ingreso":   {"<concepto>": {"<mes>": valor, ...}, ...},
+         "variables": {...},
+         "fijos":     {...}}
+    """
+
+    def __init__(self):
+        self.warnings = []
+
+    def _seccion_para(self, concepto_norm):
+        for kw in _KW_INGRESO:
+            if kw in concepto_norm:
+                return 'ingreso'
+        for kw in _KW_VARIABLES:
+            if kw in concepto_norm:
+                return 'variables'
+        for kw in _KW_FIJOS:
+            if kw in concepto_norm:
+                return 'fijos'
+        # Por defecto, un costo sin clasificar se trata como variable (directo).
+        return 'variables'
+
+    def procesar(self, archivo):
+        err = _validar_archivo(archivo)
+        if err:
+            return err
+
+        wb, err = _abrir_workbook(archivo)
+        if err:
+            return err
+
+        sheet = wb.active
+        # Detectar columnas de meses por encabezado.
+        meses_cols = {}  # nombre_mes_norm -> col_index
+        concepto_col = 1
+        for col in range(1, 40):
+            val = sheet.cell(row=1, column=col).value
+            if not val:
+                continue
+            nval = _norm(val)
+            if nval in _MESES:
+                meses_cols[nval] = col
+            elif nval in ('concepto', 'rubro', 'descripcion', 'item', 'detalle'):
+                concepto_col = col
+
+        # Edge case 1: ninguna columna de mes detectada → archivo no es de presupuesto.
+        if not meses_cols:
+            wb.close()
+            return _resultado_advertencia(
+                'Archivo sin columnas de meses reconocibles (enero..diciembre). '
+                'Verifique la estructura del presupuesto.'
+            )
+
+        datos = {'ingreso': {}, 'variables': {}, 'fijos': {}}
+        filas_validas = 0
+        max_col = max(max(meses_cols.values()), concepto_col)
+
+        for row in sheet.iter_rows(min_row=2, max_col=max_col, values_only=True):
+            concepto_val = row[concepto_col - 1] if len(row) >= concepto_col else None
+            if concepto_val is None:
+                continue
+            concepto = str(concepto_val).strip()
+            if not concepto:
+                continue
+
+            seccion = self._seccion_para(_norm(concepto))
+            fila_meses = {}
+            tiene_valor = False
+            for mes_norm, col in meses_cols.items():
+                celda = row[col - 1] if len(row) >= col else None
+                valor = _to_number(celda)
+                if valor:
+                    tiene_valor = True
+                fila_meses[mes_norm] = round(valor, 2)
+
+            # Edge case 2: fila de concepto sin ningún valor mensual → se omite.
+            if not tiene_valor:
+                continue
+
+            datos[seccion][concepto] = fila_meses
+            filas_validas += 1
+
+        wb.close()
+
+        # Edge case 3: archivo con encabezados de mes pero sin filas con valores.
+        if filas_validas == 0:
+            return _resultado_advertencia(
+                'Archivo sin filas de presupuesto con valores. Revise que los '
+                'montos mensuales estén diligenciados.'
+            )
+
+        secciones_no_vacias = [s for s, v in datos.items() if v]
+        mensaje = (
+            f'Presupuesto importado. {filas_validas} conceptos en '
+            f'{len(secciones_no_vacias)} secciones ({", ".join(secciones_no_vacias)}).'
+        )
+        return {
+            'exito': True, 'error': None, 'advertencia': None,
+            'mensaje': mensaje, 'datos': datos, 'filas': filas_validas,
+            'warnings': self.warnings,
+        }
+
+
+# ===========================================================================
+# 2. CONTABLE (BD contable agrupada por cuenta) → datos['finv2_bd']
+# ===========================================================================
+class ContableConstruccionExcelImporter:
+    """Adapta ``ContableCompleteImporter`` (#120) al financiero de construcción.
+
+    Delega 100 % de la lógica de lectura/agrupación a
+    ``apps.financiero.importers_finv2.ContableCompleteImporter`` (lee hoja 'BD',
+    agrupa por columna O sumando Neto de la columna C, mapea a rubros). Solo
+    re-empaqueta el resultado al contrato estándar de construcción.
+
+    La salida ``datos`` (``{'finv2_bd': {...}}``) se guarda tal cual en
+    ``PresupuestoDetalladoConstruccion.datos`` (no colisiona con las secciones
+    ingreso/variables/fijos del importador de presupuesto: viven en llaves
+    distintas del mismo JSONField).
+    """
+
+    def __init__(self):
+        self._inner = ContableCompleteImporter()
+        self.warnings = self._inner.warnings
+
+    def procesar(self, archivo, mapeo=None):
+        err = _validar_archivo(archivo)
+        if err:
+            return err
+        res = self._inner.procesar_bd_completa(archivo, mapeo=mapeo)
+        # ContableCompleteImporter ya retorna exito/error/advertencia/mensaje/datos;
+        # normalizamos la llave 'filas' (usa 'cuentas').
+        res.setdefault('filas', res.get('cuentas', 0))
+        return res
+
+
+# ===========================================================================
+# 3. COSTOS (una fila = un CostosConstruccion) → persiste registros
+# ===========================================================================
+class CostosConstruccionExcelImporter:
+    """Lee un Excel de costos ejecutados y crea registros ``CostosConstruccion``.
+
+    Cada fila con concepto + (cantidad × unitario | total) crea un costo del
+    proyecto. ``costo_total`` lo recalcula el ``save()`` del modelo, así que solo
+    necesitamos cantidad/unitario; si el Excel trae 'total' pero no cantidad, se
+    usa cantidad=1 y unitario=total para preservar el monto.
+
+    A diferencia de los otros dos importadores (que devuelven ``datos`` para que
+    la vista persista el JSON), este SÍ persiste filas (es un alta masiva de un
+    modelo relacional). Por eso requiere ``proyecto``.
+    """
+
+    def __init__(self, proyecto):
+        self.proyecto = proyecto
+        self.warnings = []
+
+    def _resolver_tipo(self, valor):
+        nval = _norm(valor)
+        return _TIPO_RECURSO_ALIASES.get(
+            nval, CostosConstruccion.TipoRecurso.MATERIAL
+        )
+
+    def _resolver_fecha(self, valor):
+        if isinstance(valor, datetime):
+            return valor.date()
+        if isinstance(valor, date):
+            return valor
+        # Texto YYYY-MM-DD o DD/MM/YYYY → intento simple, fallback hoy.
+        if valor:
+            txt = str(valor).strip()
+            for fmt in ('%Y-%m-%d', '%d/%m/%Y', '%d-%m-%Y', '%Y/%m/%d'):
+                try:
+                    return datetime.strptime(txt, fmt).date()
+                except ValueError:
+                    continue
+        return date.today()
+
+    def procesar(self, archivo):
+        err = _validar_archivo(archivo)
+        if err:
+            return err
+
+        wb, err = _abrir_workbook(archivo)
+        if err:
+            return err
+
+        sheet = wb.active
+        cols = _locate_columns(sheet, {
+            'concepto': _COL_CONCEPTO,
+            'tipo': _COL_TIPO,
+            'cantidad': _COL_CANTIDAD,
+            'unitario': _COL_UNITARIO,
+            'total': _COL_TOTAL,
+            'fecha': _COL_FECHA,
+        })
+
+        # Edge case 1: sin columna de concepto NI de total → no es archivo de costos.
+        if cols['concepto'] is None and cols['total'] is None:
+            wb.close()
+            return _resultado_advertencia(
+                'Archivo sin columnas reconocibles de costos (concepto/total). '
+                'Verifique la estructura.'
+            )
+
+        concepto_col = cols['concepto'] or 1
+        max_col = max(c for c in cols.values() if c) or concepto_col
+
+        nuevos = []
+        omitidos = 0
+        for row in sheet.iter_rows(min_row=2, max_col=max_col, values_only=True):
+            def _cell(key):
+                idx = cols[key]
+                if idx and len(row) >= idx:
+                    return row[idx - 1]
+                return None
+
+            concepto_val = row[concepto_col - 1] if len(row) >= concepto_col else None
+            concepto = str(concepto_val).strip() if concepto_val is not None else ''
+
+            cantidad = _to_decimal(_cell('cantidad'))
+            unitario = _to_decimal(_cell('unitario'))
+            total = _to_decimal(_cell('total'))
+
+            # Edge case 2: fila sin concepto y sin ningún monto → se omite.
+            if not concepto and cantidad == 0 and unitario == 0 and total == 0:
+                continue
+            if not concepto:
+                concepto = 'Sin concepto'
+
+            # Si solo viene el total, lo expresamos como cantidad 1 × unitario total.
+            if (cantidad == 0 or unitario == 0) and total > 0:
+                cantidad = Decimal('1')
+                unitario = total
+
+            # Edge case 3: fila completamente en cero (ni cantidad ni total) → omitir.
+            if cantidad == 0 and unitario == 0:
+                omitidos += 1
+                continue
+
+            nuevos.append(CostosConstruccion(
+                proyecto=self.proyecto,
+                concepto=concepto[:300],
+                tipo_recurso=self._resolver_tipo(_cell('tipo')),
+                cantidad=cantidad,
+                costo_unitario=unitario,
+                fecha=self._resolver_fecha(_cell('fecha')),
+            ))
+
+        wb.close()
+
+        if not nuevos:
+            return _resultado_advertencia(
+                'Archivo sin filas de costo válidas. Revise que haya conceptos '
+                'con cantidad/unitario o un total mayor a cero.'
+            )
+
+        # save() de cada instancia recalcula costo_total (no usar bulk_create:
+        # bulk_create se salta save() y costo_total quedaría en 0).
+        creados = 0
+        for obj in nuevos:
+            obj.save()
+            creados += 1
+
+        mensaje = f'Costos importados. {creados} registros creados.'
+        if omitidos:
+            self.warnings.append(f'{omitidos} filas en cero se omitieron.')
+        return {
+            'exito': True, 'error': None, 'advertencia': None,
+            'mensaje': mensaje, 'datos': None, 'filas': creados,
+            'creados': creados, 'omitidos': omitidos, 'warnings': self.warnings,
+        }
+
+
+# ===========================================================================
+# 4. DETECTOR DE FORMATO
+# ===========================================================================
+def detect_excel_format_construccion(archivo):
+    """Heurística: inspecciona hojas/encabezados y devuelve el formato probable.
+
+    Returns: 'contable' | 'presupuesto' | 'costos' | None.
+
+    - 'contable': existe una hoja 'BD'/'base de datos' o un encabezado
+      'Cta equivalente'.
+    - 'presupuesto': hay ≥ 2 columnas con nombres de mes (enero..diciembre).
+    - 'costos': hay encabezados de costo (concepto + tipo/cantidad/total).
+    - None: no se reconoce (archivo inválido o ambiguo).
+    """
+    if _validar_archivo(archivo):
+        return None
+    wb, err = _abrir_workbook(archivo)
+    if err:
+        return None
+
+    try:
+        # 1. Contable: hoja BD o encabezado 'cta equivalente'.
+        nombres_hoja = {_norm(n) for n in wb.sheetnames}
+        if nombres_hoja & {'bd', 'base de datos', 'base datos'}:
+            return 'contable'
+
+        sheet = wb.active
+        headers = set()
+        meses_detectados = 0
+        for col in range(1, 40):
+            val = sheet.cell(row=1, column=col).value
+            if not val:
+                continue
+            nval = _norm(val)
+            headers.add(nval)
+            if nval in _MESES:
+                meses_detectados += 1
+
+        if 'cta equivalente' in headers or any('cta' in h for h in headers):
+            return 'contable'
+        # 2. Presupuesto: varias columnas de mes.
+        if meses_detectados >= 2:
+            return 'presupuesto'
+        # 3. Costos: concepto + alguna de tipo/cantidad/unitario/total.
+        tiene_concepto = bool(headers & {_norm(c) for c in _COL_CONCEPTO})
+        tiene_monto = bool(
+            headers & {_norm(c) for grupo in (_COL_TIPO, _COL_CANTIDAD,
+                                              _COL_UNITARIO, _COL_TOTAL)
+                       for c in grupo}
+        )
+        if tiene_concepto and tiene_monto:
+            return 'costos'
+        return None
+    finally:
+        wb.close()

--- a/apps/construccion/migrations/0023_financiero_construccion.py
+++ b/apps/construccion/migrations/0023_financiero_construccion.py
@@ -1,0 +1,122 @@
+# B3 (#123) — Módulo Financiero de Construcción: 5 modelos nuevos.
+# Migración escrita a mano (número 0023 pre-asignado por F1; última real 0022).
+import django.db.models.deletion
+import django.utils.timezone
+import uuid
+from decimal import Decimal
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('construccion', '0022_dashboard_pendientes'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='PresupuestoDetalladoConstruccion',
+            fields=[
+                ('id', models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created_at', models.DateTimeField(auto_now_add=True, verbose_name='Fecha de creación')),
+                ('updated_at', models.DateTimeField(auto_now=True, verbose_name='Fecha de actualización')),
+                ('anio', models.PositiveIntegerField(verbose_name='Año')),
+                ('tipo', models.CharField(choices=[('PLANEADO', 'Planeado'), ('REAL', 'Real')], default='PLANEADO', max_length=10, verbose_name='Tipo')),
+                ('datos', models.JSONField(blank=True, default=dict, help_text='Estructura de costos con valores mensuales.', verbose_name='Datos')),
+                ('proyecto', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='presupuestos_detallados', to='construccion.proyectoconstruccion', verbose_name='Proyecto')),
+            ],
+            options={
+                'verbose_name': 'Presupuesto Detallado de Construcción',
+                'verbose_name_plural': 'Presupuestos Detallados de Construcción',
+                'db_table': 'construccion_presupuesto_detallado',
+                'ordering': ['-anio', 'tipo'],
+                'unique_together': {('proyecto', 'anio', 'tipo')},
+            },
+        ),
+        migrations.CreateModel(
+            name='CostosConstruccion',
+            fields=[
+                ('id', models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created_at', models.DateTimeField(auto_now_add=True, verbose_name='Fecha de creación')),
+                ('updated_at', models.DateTimeField(auto_now=True, verbose_name='Fecha de actualización')),
+                ('concepto', models.CharField(max_length=300, verbose_name='Concepto')),
+                ('tipo_recurso', models.CharField(choices=[('MATERIAL', 'Material'), ('MANO_OBRA', 'Mano de obra'), ('EQUIPOS', 'Equipos'), ('SUBCONTRATA', 'Subcontrata'), ('OTROS', 'Otros')], default='MATERIAL', max_length=20, verbose_name='Tipo de recurso')),
+                ('cantidad', models.DecimalField(decimal_places=2, default=Decimal('0'), max_digits=15, verbose_name='Cantidad')),
+                ('costo_unitario', models.DecimalField(decimal_places=2, default=Decimal('0'), max_digits=15, verbose_name='Costo unitario')),
+                ('costo_total', models.DecimalField(decimal_places=2, default=Decimal('0'), help_text='cantidad × costo_unitario. Auto-calculado en save().', max_digits=18, verbose_name='Costo total')),
+                ('fecha', models.DateField(default=django.utils.timezone.now, verbose_name='Fecha')),
+                ('actividad', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='costos', to='construccion.actividadfinaltorre', verbose_name='Actividad')),
+                ('proyecto', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='costos', to='construccion.proyectoconstruccion', verbose_name='Proyecto')),
+            ],
+            options={
+                'verbose_name': 'Costo de Construcción',
+                'verbose_name_plural': 'Costos de Construcción',
+                'db_table': 'construccion_costos',
+                'ordering': ['-fecha', '-created_at'],
+            },
+        ),
+        migrations.CreateModel(
+            name='CostosActividadConstruccion',
+            fields=[
+                ('id', models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created_at', models.DateTimeField(auto_now_add=True, verbose_name='Fecha de creación')),
+                ('updated_at', models.DateTimeField(auto_now=True, verbose_name='Fecha de actualización')),
+                ('costo_materiales', models.DecimalField(decimal_places=2, default=Decimal('0'), max_digits=18, verbose_name='Costo materiales')),
+                ('costo_mano_obra', models.DecimalField(decimal_places=2, default=Decimal('0'), max_digits=18, verbose_name='Costo mano de obra')),
+                ('costo_equipos', models.DecimalField(decimal_places=2, default=Decimal('0'), max_digits=18, verbose_name='Costo equipos')),
+                ('costo_subcontratos', models.DecimalField(decimal_places=2, default=Decimal('0'), max_digits=18, verbose_name='Costo subcontratos')),
+                ('costo_otros', models.DecimalField(decimal_places=2, default=Decimal('0'), max_digits=18, verbose_name='Costo otros')),
+                ('actividad', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name='costos_actividad', to='construccion.actividadfinaltorre', verbose_name='Actividad')),
+            ],
+            options={
+                'verbose_name': 'Costo por Actividad de Construcción',
+                'verbose_name_plural': 'Costos por Actividad de Construcción',
+                'db_table': 'construccion_costos_actividad',
+                'ordering': ['-created_at'],
+            },
+        ),
+        migrations.CreateModel(
+            name='FacturacionConstruccion',
+            fields=[
+                ('id', models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created_at', models.DateTimeField(auto_now_add=True, verbose_name='Fecha de creación')),
+                ('updated_at', models.DateTimeField(auto_now=True, verbose_name='Fecha de actualización')),
+                ('numero_factura', models.CharField(max_length=100, verbose_name='Número de factura')),
+                ('fecha_emision', models.DateField(default=django.utils.timezone.now, verbose_name='Fecha de emisión')),
+                ('monto_facturado', models.DecimalField(decimal_places=2, default=Decimal('0'), max_digits=18, verbose_name='Monto facturado')),
+                ('monto_pagado', models.DecimalField(decimal_places=2, default=Decimal('0'), max_digits=18, verbose_name='Monto pagado')),
+                ('estado', models.CharField(choices=[('EMITIDA', 'Emitida'), ('EN_VALIDACION', 'En validación'), ('PAGADA', 'Pagada')], default='EMITIDA', max_length=20, verbose_name='Estado')),
+                ('observaciones', models.TextField(blank=True, verbose_name='Observaciones')),
+                ('proyecto', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='facturacion', to='construccion.proyectoconstruccion', verbose_name='Proyecto')),
+            ],
+            options={
+                'verbose_name': 'Facturación de Construcción',
+                'verbose_name_plural': 'Facturación de Construcción',
+                'db_table': 'construccion_facturacion',
+                'ordering': ['-fecha_emision', '-created_at'],
+            },
+        ),
+        migrations.CreateModel(
+            name='IndicadorANSConstruccion',
+            fields=[
+                ('id', models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created_at', models.DateTimeField(auto_now_add=True, verbose_name='Fecha de creación')),
+                ('updated_at', models.DateTimeField(auto_now=True, verbose_name='Fecha de actualización')),
+                ('nombre', models.CharField(help_text='Ej: "% Cumplimiento Programación".', max_length=200, verbose_name='Nombre')),
+                ('descripcion', models.TextField(blank=True, verbose_name='Descripción')),
+                ('meta_porcentaje', models.DecimalField(decimal_places=2, default=Decimal('0'), max_digits=6, verbose_name='Meta (%)')),
+                ('peso', models.DecimalField(blank=True, decimal_places=2, max_digits=5, null=True, verbose_name='Peso')),
+                ('periodo_anio', models.PositiveIntegerField(verbose_name='Año del período')),
+                ('periodo_mes', models.PositiveSmallIntegerField(verbose_name='Mes del período')),
+                ('valor_actual', models.DecimalField(decimal_places=2, default=Decimal('0'), max_digits=6, verbose_name='Valor actual (%)')),
+                ('estado', models.CharField(choices=[('cumplido', 'Cumplido'), ('parcial', 'Parcial'), ('incumplido', 'Incumplido')], default='incumplido', max_length=12, verbose_name='Estado')),
+                ('proyecto', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='indicadores_ans', to='construccion.proyectoconstruccion', verbose_name='Proyecto')),
+            ],
+            options={
+                'verbose_name': 'Indicador ANS de Construcción',
+                'verbose_name_plural': 'Indicadores ANS de Construcción',
+                'db_table': 'construccion_indicador_ans',
+                'ordering': ['-periodo_anio', '-periodo_mes', 'nombre'],
+            },
+        ),
+    ]

--- a/apps/construccion/models.py
+++ b/apps/construccion/models.py
@@ -2655,3 +2655,7 @@ from .models_b2_indicadores import *  # noqa: F401, F403
 # F2 scaffolding: B2a (OC detalle) y B3a (Montaje detalle) en F3.
 from .models_b3_oc_detalle import *  # noqa: E402,F401,F403
 from .models_b3_mont_detalle import *  # noqa: E402,F401,F403
+
+# === /modulo financiero_construccion_runB — modelos financieros ===
+# F2 scaffolding: B3 (#123) llena los 5 modelos financieros en models_fin.
+from .models_fin import *  # noqa: E402,F401,F403

--- a/apps/construccion/models_fin.py
+++ b/apps/construccion/models_fin.py
@@ -1,1 +1,319 @@
-# B3 (#123) llena los 5 modelos financieros aquí.
+"""B3 (#123) — Módulo Financiero de Construcción: 5 modelos nuevos.
+
+Duplica e integra el módulo financiero mejorado del sistema de mantenimiento/líneas
+hacia construcción (issue #123, Fase 1). Los 5 modelos:
+
+1. ``PresupuestoDetalladoConstruccion`` — presupuesto con datos JSON por año/tipo.
+2. ``CostosConstruccion``             — costos ejecutados con ``costo_total`` auto en save().
+3. ``CostosActividadConstruccion``    — desglose de costos por actividad (OneToOne).
+4. ``FacturacionConstruccion``        — facturación del proyecto.
+5. ``IndicadorANSConstruccion``       — ANS con ``estado`` clasificado en save().
+
+NO recrea ``IndicadorFinancieroConstruccion`` / ``IndicadorTecnicoConstruccion``
+(ya viven en ``models_b2_indicadores.py``).
+
+Nota sobre el FK ``actividad`` (CostosConstruccion / CostosActividadConstruccion):
+    El issue #123 lo describe como ``ActividadConstruccion``, pero ese modelo NO
+    existe en construcción. El propio issue advierte: "No tiene relación con
+    Actividades (diferente modelo)". El único modelo de construcción que
+    representa un work-item por estructura es ``ActividadFinalTorre`` (checklist
+    de actividades finales/cierre por torre, db_table
+    ``construccion_actividad_final_torre``). Se usa ese como target real:
+      - ``CostosConstruccion.actividad`` → FK **nullable** (un costo puede no estar
+        atado a una actividad específica).
+      - ``CostosActividadConstruccion.actividad`` → OneToOne (un desglose por
+        actividad). Si más adelante se introduce un modelo de actividad de
+        construcción dedicado, migrar el target.
+"""
+from decimal import Decimal
+
+from django.db import models
+from django.utils import timezone
+
+from apps.core.models import BaseModel
+
+
+# ===========================================================================
+# 1. PRESUPUESTO DETALLADO
+# ===========================================================================
+class PresupuestoDetalladoConstruccion(BaseModel):
+    """Presupuesto detallado con estructura de costos en JSON por año/tipo.
+
+    ``datos`` almacena la estructura de costos con valores mensuales (mismo
+    patrón que ``PresupuestoDetallado`` de mantenimiento). ``unique_together``
+    garantiza un único presupuesto por (proyecto, año, tipo).
+    """
+
+    class Tipo(models.TextChoices):
+        PLANEADO = 'PLANEADO', 'Planeado'
+        REAL = 'REAL', 'Real'
+
+    proyecto = models.ForeignKey(
+        'construccion.ProyectoConstruccion',
+        on_delete=models.CASCADE,
+        related_name='presupuestos_detallados',
+        verbose_name='Proyecto',
+    )
+    anio = models.PositiveIntegerField('Año')
+    tipo = models.CharField(
+        'Tipo', max_length=10, choices=Tipo.choices, default=Tipo.PLANEADO,
+    )
+    datos = models.JSONField(
+        'Datos', default=dict, blank=True,
+        help_text='Estructura de costos con valores mensuales.',
+    )
+
+    class Meta:
+        db_table = 'construccion_presupuesto_detallado'
+        verbose_name = 'Presupuesto Detallado de Construcción'
+        verbose_name_plural = 'Presupuestos Detallados de Construcción'
+        ordering = ['-anio', 'tipo']
+        unique_together = (('proyecto', 'anio', 'tipo'),)
+
+    def __str__(self):
+        return f"Presupuesto {self.get_tipo_display()} {self.anio} — {self.proyecto_id}"
+
+
+# ===========================================================================
+# 2. COSTOS
+# ===========================================================================
+class CostosConstruccion(BaseModel):
+    """Costo ejecutado individual. ``costo_total`` se calcula en save()."""
+
+    class TipoRecurso(models.TextChoices):
+        MATERIAL = 'MATERIAL', 'Material'
+        MANO_OBRA = 'MANO_OBRA', 'Mano de obra'
+        EQUIPOS = 'EQUIPOS', 'Equipos'
+        SUBCONTRATA = 'SUBCONTRATA', 'Subcontrata'
+        OTROS = 'OTROS', 'Otros'
+
+    proyecto = models.ForeignKey(
+        'construccion.ProyectoConstruccion',
+        on_delete=models.CASCADE,
+        related_name='costos',
+        verbose_name='Proyecto',
+    )
+    # Ver nota de módulo: no existe ActividadConstruccion; ActividadFinalTorre es
+    # el modelo de actividad real más cercano. FK nullable.
+    actividad = models.ForeignKey(
+        'construccion.ActividadFinalTorre',
+        on_delete=models.SET_NULL,
+        related_name='costos',
+        null=True, blank=True,
+        verbose_name='Actividad',
+    )
+    concepto = models.CharField('Concepto', max_length=300)
+    tipo_recurso = models.CharField(
+        'Tipo de recurso', max_length=20,
+        choices=TipoRecurso.choices, default=TipoRecurso.MATERIAL,
+    )
+    cantidad = models.DecimalField(
+        'Cantidad', max_digits=15, decimal_places=2, default=Decimal('0'),
+    )
+    costo_unitario = models.DecimalField(
+        'Costo unitario', max_digits=15, decimal_places=2, default=Decimal('0'),
+    )
+    costo_total = models.DecimalField(
+        'Costo total', max_digits=18, decimal_places=2, default=Decimal('0'),
+        help_text='cantidad × costo_unitario. Auto-calculado en save().',
+    )
+    fecha = models.DateField('Fecha', default=timezone.now)
+
+    class Meta:
+        db_table = 'construccion_costos'
+        verbose_name = 'Costo de Construcción'
+        verbose_name_plural = 'Costos de Construcción'
+        ordering = ['-fecha', '-created_at']
+
+    def __str__(self):
+        return f"{self.concepto} — {self.costo_total} ({self.get_tipo_recurso_display()})"
+
+    def calcular_costo_total(self) -> Decimal:
+        """cantidad × costo_unitario, redondeado a 2 decimales."""
+        cantidad = self.cantidad if self.cantidad is not None else Decimal('0')
+        unitario = self.costo_unitario if self.costo_unitario is not None else Decimal('0')
+        return (Decimal(cantidad) * Decimal(unitario)).quantize(Decimal('0.01'))
+
+    def save(self, *args, **kwargs):
+        self.costo_total = self.calcular_costo_total()
+        super().save(*args, **kwargs)
+
+
+class CostosActividadConstruccion(BaseModel):
+    """Desglose de costos por actividad (un registro por actividad)."""
+
+    # Ver nota de módulo: target real ActividadFinalTorre.
+    actividad = models.OneToOneField(
+        'construccion.ActividadFinalTorre',
+        on_delete=models.CASCADE,
+        related_name='costos_actividad',
+        verbose_name='Actividad',
+    )
+    costo_materiales = models.DecimalField(
+        'Costo materiales', max_digits=18, decimal_places=2, default=Decimal('0'),
+    )
+    costo_mano_obra = models.DecimalField(
+        'Costo mano de obra', max_digits=18, decimal_places=2, default=Decimal('0'),
+    )
+    costo_equipos = models.DecimalField(
+        'Costo equipos', max_digits=18, decimal_places=2, default=Decimal('0'),
+    )
+    costo_subcontratos = models.DecimalField(
+        'Costo subcontratos', max_digits=18, decimal_places=2, default=Decimal('0'),
+    )
+    costo_otros = models.DecimalField(
+        'Costo otros', max_digits=18, decimal_places=2, default=Decimal('0'),
+    )
+
+    class Meta:
+        db_table = 'construccion_costos_actividad'
+        verbose_name = 'Costo por Actividad de Construcción'
+        verbose_name_plural = 'Costos por Actividad de Construcción'
+        ordering = ['-created_at']
+
+    def __str__(self):
+        return f"Costos actividad {self.actividad_id} — total {self.costo_total}"
+
+    @property
+    def costo_total(self) -> Decimal:
+        """Suma de los 5 componentes de costo."""
+        return (
+            (self.costo_materiales or Decimal('0'))
+            + (self.costo_mano_obra or Decimal('0'))
+            + (self.costo_equipos or Decimal('0'))
+            + (self.costo_subcontratos or Decimal('0'))
+            + (self.costo_otros or Decimal('0'))
+        )
+
+
+# ===========================================================================
+# 3. FACTURACIÓN
+# ===========================================================================
+class FacturacionConstruccion(BaseModel):
+    """Facturación del proyecto de construcción."""
+
+    class Estado(models.TextChoices):
+        EMITIDA = 'EMITIDA', 'Emitida'
+        EN_VALIDACION = 'EN_VALIDACION', 'En validación'
+        PAGADA = 'PAGADA', 'Pagada'
+
+    proyecto = models.ForeignKey(
+        'construccion.ProyectoConstruccion',
+        on_delete=models.CASCADE,
+        related_name='facturacion',
+        verbose_name='Proyecto',
+    )
+    numero_factura = models.CharField('Número de factura', max_length=100)
+    fecha_emision = models.DateField('Fecha de emisión', default=timezone.now)
+    monto_facturado = models.DecimalField(
+        'Monto facturado', max_digits=18, decimal_places=2, default=Decimal('0'),
+    )
+    monto_pagado = models.DecimalField(
+        'Monto pagado', max_digits=18, decimal_places=2, default=Decimal('0'),
+    )
+    estado = models.CharField(
+        'Estado', max_length=20, choices=Estado.choices, default=Estado.EMITIDA,
+    )
+    observaciones = models.TextField('Observaciones', blank=True)
+
+    class Meta:
+        db_table = 'construccion_facturacion'
+        verbose_name = 'Facturación de Construcción'
+        verbose_name_plural = 'Facturación de Construcción'
+        ordering = ['-fecha_emision', '-created_at']
+
+    def __str__(self):
+        return f"Factura {self.numero_factura} — {self.monto_facturado} ({self.get_estado_display()})"
+
+    @property
+    def saldo_pendiente(self) -> Decimal:
+        """Monto facturado menos lo pagado."""
+        return (self.monto_facturado or Decimal('0')) - (self.monto_pagado or Decimal('0'))
+
+
+# ===========================================================================
+# 4. INDICADOR ANS
+# ===========================================================================
+# Umbrales de clasificación de estado (espejo de IndicadorANSContractual del
+# módulo de mantenimiento: cumple / parcial / no-cumple según valor vs meta).
+# Aquí la meta es por-indicador, no un puntaje ponderado global.
+UMBRAL_ANS_PARCIAL_PCT = Decimal('90')  # ≥ 90 % de la meta → parcial; ≥ meta → cumplido
+
+
+class IndicadorANSConstruccion(BaseModel):
+    """Indicador ANS (Acuerdo de Nivel de Servicio) de construcción.
+
+    ``estado`` se clasifica en ``save()`` comparando ``valor_actual`` contra
+    ``meta_porcentaje`` (espejo de la lógica de ``IndicadorANSContractual``):
+
+    - ``valor_actual >= meta_porcentaje``                       → cumplido
+    - ``meta * 90 % <= valor_actual < meta``                    → parcial
+    - ``valor_actual < meta * 90 %``                            → incumplido
+    """
+
+    class Estado(models.TextChoices):
+        CUMPLIDO = 'cumplido', 'Cumplido'
+        PARCIAL = 'parcial', 'Parcial'
+        INCUMPLIDO = 'incumplido', 'Incumplido'
+
+    proyecto = models.ForeignKey(
+        'construccion.ProyectoConstruccion',
+        on_delete=models.CASCADE,
+        related_name='indicadores_ans',
+        verbose_name='Proyecto',
+    )
+    nombre = models.CharField(
+        'Nombre', max_length=200,
+        help_text='Ej: "% Cumplimiento Programación".',
+    )
+    descripcion = models.TextField('Descripción', blank=True)
+    meta_porcentaje = models.DecimalField(
+        'Meta (%)', max_digits=6, decimal_places=2, default=Decimal('0'),
+    )
+    peso = models.DecimalField(
+        'Peso', max_digits=5, decimal_places=2, null=True, blank=True,
+    )
+    periodo_anio = models.PositiveIntegerField('Año del período')
+    periodo_mes = models.PositiveSmallIntegerField('Mes del período')
+    valor_actual = models.DecimalField(
+        'Valor actual (%)', max_digits=6, decimal_places=2, default=Decimal('0'),
+    )
+    estado = models.CharField(
+        'Estado', max_length=12, choices=Estado.choices, default=Estado.INCUMPLIDO,
+    )
+
+    class Meta:
+        db_table = 'construccion_indicador_ans'
+        verbose_name = 'Indicador ANS de Construcción'
+        verbose_name_plural = 'Indicadores ANS de Construcción'
+        ordering = ['-periodo_anio', '-periodo_mes', 'nombre']
+
+    def __str__(self):
+        return (
+            f"{self.nombre} {self.periodo_mes:02d}/{self.periodo_anio} — "
+            f"{self.valor_actual}% ({self.get_estado_display()})"
+        )
+
+    def clasificar_estado(self) -> str:
+        """Clasifica estado según valor_actual vs meta_porcentaje.
+
+        Espejo de ``IndicadorANSContractual.clasificar_estado`` adaptado a un
+        único valor contra su meta (3 estados: cumplido / parcial / incumplido).
+        """
+        meta = self.meta_porcentaje if self.meta_porcentaje is not None else Decimal('0')
+        valor = self.valor_actual if self.valor_actual is not None else Decimal('0')
+        meta = Decimal(meta)
+        valor = Decimal(valor)
+        if meta <= 0:
+            # Sin meta definida: cualquier valor ≥ 0 se considera cumplido.
+            return self.Estado.CUMPLIDO
+        if valor >= meta:
+            return self.Estado.CUMPLIDO
+        umbral_parcial = (meta * UMBRAL_ANS_PARCIAL_PCT) / Decimal('100')
+        if valor >= umbral_parcial:
+            return self.Estado.PARCIAL
+        return self.Estado.INCUMPLIDO
+
+    def save(self, *args, **kwargs):
+        self.estado = self.clasificar_estado()
+        super().save(*args, **kwargs)

--- a/apps/construccion/models_fin.py
+++ b/apps/construccion/models_fin.py
@@ -1,0 +1,1 @@
+# B3 (#123) llena los 5 modelos financieros aquí.

--- a/apps/construccion/tests_b3_fin.py
+++ b/apps/construccion/tests_b3_fin.py
@@ -1,0 +1,230 @@
+"""B3 (#123) — Tests de los 5 modelos financieros de Construcción.
+
+ESCRITOS pero NO corridos en F3 (no hay Django local en este entorno) —
+"tests_passing": "deferred_to_f4_docker". F4 los corre dentro del contenedor.
+
+Cobertura:
+- Los 5 modelos instancian (happy path).
+- ``CostosConstruccion.costo_total`` se computa en save().
+- ``CostosActividadConstruccion.costo_total`` (property) suma los 5 componentes.
+- ``IndicadorANSConstruccion.estado`` clasifica cumplido/parcial/incumplido en save().
+- ``FacturacionConstruccion.saldo_pendiente``.
+- Edge cases: meta=0, valor en frontera del umbral parcial, cantidad cero.
+- Dato legacy: un ``ProyectoConstruccion`` preexistente sigue funcionando.
+"""
+from decimal import Decimal
+
+from django.test import TestCase
+from django.utils import timezone
+
+from apps.contratos.models import Contrato
+from apps.construccion.models import ProyectoConstruccion, TorreConstruccion
+from apps.construccion.models_b1_actividades_finales import ActividadFinalTorre
+from apps.construccion.models_fin import (
+    PresupuestoDetalladoConstruccion,
+    CostosConstruccion,
+    CostosActividadConstruccion,
+    FacturacionConstruccion,
+    IndicadorANSConstruccion,
+)
+
+
+def _crear_proyecto():
+    """Crea un Contrato CONSTRUCCION + ProyectoConstruccion mínimo."""
+    contrato = Contrato.objects.create(
+        codigo=f"CONS-{timezone.now().timestamp()}",
+        nombre='Contrato test construcción',
+        unidad_negocio='CONSTRUCCION',
+    )
+    return ProyectoConstruccion.objects.create(
+        contrato=contrato,
+        nombre='Proyecto LT 230kV test',
+    )
+
+
+class TestB3ModelosMigranOk(TestCase):
+    """tests_e2e: b3_modelos_migran_ok — los 5 modelos instancian + cómputos."""
+
+    def setUp(self):
+        self.proyecto = _crear_proyecto()
+
+    # --- 1. PresupuestoDetalladoConstruccion -----------------------------
+    def test_presupuesto_detallado_instancia(self):
+        p = PresupuestoDetalladoConstruccion.objects.create(
+            proyecto=self.proyecto, anio=2026,
+            tipo=PresupuestoDetalladoConstruccion.Tipo.PLANEADO,
+            datos={'enero': {'material': 1000}},
+        )
+        self.assertEqual(p.tipo, 'PLANEADO')
+        self.assertEqual(p.datos['enero']['material'], 1000)
+
+    def test_presupuesto_default_datos_dict(self):
+        p = PresupuestoDetalladoConstruccion.objects.create(
+            proyecto=self.proyecto, anio=2027, tipo='REAL',
+        )
+        self.assertEqual(p.datos, {})
+
+    def test_presupuesto_unique_together(self):
+        from django.db import IntegrityError, transaction
+        PresupuestoDetalladoConstruccion.objects.create(
+            proyecto=self.proyecto, anio=2026, tipo='PLANEADO',
+        )
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                PresupuestoDetalladoConstruccion.objects.create(
+                    proyecto=self.proyecto, anio=2026, tipo='PLANEADO',
+                )
+
+    # --- 2. CostosConstruccion ------------------------------------------
+    def test_costos_costo_total_auto(self):
+        c = CostosConstruccion.objects.create(
+            proyecto=self.proyecto, concepto='Cemento',
+            tipo_recurso='MATERIAL',
+            cantidad=Decimal('10'), costo_unitario=Decimal('2500.50'),
+        )
+        self.assertEqual(c.costo_total, Decimal('25005.00'))
+
+    def test_costos_edge_cantidad_cero(self):
+        """Edge: cantidad cero → costo_total cero (no None / no error)."""
+        c = CostosConstruccion.objects.create(
+            proyecto=self.proyecto, concepto='Sin consumo',
+            cantidad=Decimal('0'), costo_unitario=Decimal('999'),
+        )
+        self.assertEqual(c.costo_total, Decimal('0.00'))
+
+    def test_costos_actividad_nullable(self):
+        """Edge: un costo puede no estar atado a una actividad."""
+        c = CostosConstruccion.objects.create(
+            proyecto=self.proyecto, concepto='Costo general',
+            cantidad=Decimal('1'), costo_unitario=Decimal('100'),
+        )
+        self.assertIsNone(c.actividad)
+
+    def test_costos_con_actividad_fk(self):
+        torre = TorreConstruccion.objects.create(
+            proyecto=self.proyecto, numero='T-001',
+        )
+        act = ActividadFinalTorre.objects.create(torre=torre)
+        c = CostosConstruccion.objects.create(
+            proyecto=self.proyecto, actividad=act, concepto='MO empalme',
+            tipo_recurso='MANO_OBRA',
+            cantidad=Decimal('3'), costo_unitario=Decimal('1000'),
+        )
+        self.assertEqual(c.actividad_id, act.id)
+        self.assertEqual(c.costo_total, Decimal('3000.00'))
+
+    # --- 3. CostosActividadConstruccion ---------------------------------
+    def test_costos_actividad_total_property(self):
+        torre = TorreConstruccion.objects.create(
+            proyecto=self.proyecto, numero='T-002',
+        )
+        act = ActividadFinalTorre.objects.create(torre=torre)
+        ca = CostosActividadConstruccion.objects.create(
+            actividad=act,
+            costo_materiales=Decimal('100'),
+            costo_mano_obra=Decimal('200'),
+            costo_equipos=Decimal('50'),
+            costo_subcontratos=Decimal('300'),
+            costo_otros=Decimal('25'),
+        )
+        self.assertEqual(ca.costo_total, Decimal('675'))
+
+    def test_costos_actividad_defaults_cero(self):
+        torre = TorreConstruccion.objects.create(
+            proyecto=self.proyecto, numero='T-003',
+        )
+        act = ActividadFinalTorre.objects.create(torre=torre)
+        ca = CostosActividadConstruccion.objects.create(actividad=act)
+        self.assertEqual(ca.costo_total, Decimal('0'))
+
+    # --- 4. FacturacionConstruccion -------------------------------------
+    def test_facturacion_instancia_y_saldo(self):
+        f = FacturacionConstruccion.objects.create(
+            proyecto=self.proyecto, numero_factura='FC-001',
+            monto_facturado=Decimal('1000000'),
+            monto_pagado=Decimal('400000'),
+            estado='EN_VALIDACION',
+        )
+        self.assertEqual(f.saldo_pendiente, Decimal('600000'))
+        self.assertEqual(f.estado, 'EN_VALIDACION')
+
+    def test_facturacion_default_pagado_cero(self):
+        f = FacturacionConstruccion.objects.create(
+            proyecto=self.proyecto, numero_factura='FC-002',
+            monto_facturado=Decimal('500'),
+        )
+        self.assertEqual(f.monto_pagado, Decimal('0'))
+        self.assertEqual(f.saldo_pendiente, Decimal('500'))
+        self.assertEqual(f.estado, 'EMITIDA')
+
+    # --- 5. IndicadorANSConstruccion ------------------------------------
+    def test_ans_estado_cumplido(self):
+        ind = IndicadorANSConstruccion.objects.create(
+            proyecto=self.proyecto, nombre='% Cumplimiento Programación',
+            meta_porcentaje=Decimal('95'), valor_actual=Decimal('98'),
+            periodo_anio=2026, periodo_mes=6,
+        )
+        self.assertEqual(ind.estado, 'cumplido')
+
+    def test_ans_estado_parcial(self):
+        """Edge: valor en banda [meta*0.9, meta) → parcial."""
+        ind = IndicadorANSConstruccion.objects.create(
+            proyecto=self.proyecto, nombre='ANS parcial',
+            meta_porcentaje=Decimal('100'), valor_actual=Decimal('92'),
+            periodo_anio=2026, periodo_mes=6,
+        )
+        self.assertEqual(ind.estado, 'parcial')
+
+    def test_ans_estado_incumplido(self):
+        ind = IndicadorANSConstruccion.objects.create(
+            proyecto=self.proyecto, nombre='ANS incumplido',
+            meta_porcentaje=Decimal('100'), valor_actual=Decimal('50'),
+            periodo_anio=2026, periodo_mes=6,
+        )
+        self.assertEqual(ind.estado, 'incumplido')
+
+    def test_ans_edge_frontera_parcial(self):
+        """Edge: valor exactamente en el umbral parcial (meta*0.9) → parcial."""
+        ind = IndicadorANSConstruccion.objects.create(
+            proyecto=self.proyecto, nombre='ANS frontera',
+            meta_porcentaje=Decimal('100'), valor_actual=Decimal('90'),
+            periodo_anio=2026, periodo_mes=6,
+        )
+        self.assertEqual(ind.estado, 'parcial')
+
+    def test_ans_edge_meta_cero(self):
+        """Edge: meta=0 → cualquier valor cuenta como cumplido (no división por cero)."""
+        ind = IndicadorANSConstruccion.objects.create(
+            proyecto=self.proyecto, nombre='ANS sin meta',
+            meta_porcentaje=Decimal('0'), valor_actual=Decimal('0'),
+            periodo_anio=2026, periodo_mes=6,
+        )
+        self.assertEqual(ind.estado, 'cumplido')
+
+    def test_ans_estado_recalcula_en_update(self):
+        ind = IndicadorANSConstruccion.objects.create(
+            proyecto=self.proyecto, nombre='ANS recalc',
+            meta_porcentaje=Decimal('90'), valor_actual=Decimal('50'),
+            periodo_anio=2026, periodo_mes=6,
+        )
+        self.assertEqual(ind.estado, 'incumplido')
+        ind.valor_actual = Decimal('95')
+        ind.save()
+        ind.refresh_from_db()
+        self.assertEqual(ind.estado, 'cumplido')
+
+
+class TestB3DatoLegacy(TestCase):
+    """Dato legacy: un ProyectoConstruccion preexistente sigue OK tras 0023."""
+
+    def test_proyecto_construccion_legacy_intacto(self):
+        proyecto = _crear_proyecto()
+        proyecto.refresh_from_db()
+        # El proyecto legacy existe y conserva sus campos sin tocar.
+        self.assertTrue(ProyectoConstruccion.objects.filter(id=proyecto.id).exists())
+        self.assertEqual(proyecto.estado, 'PLANIFICACION')
+        # Y los nuevos related_name están disponibles, vacíos por defecto.
+        self.assertEqual(proyecto.costos.count(), 0)
+        self.assertEqual(proyecto.facturacion.count(), 0)
+        self.assertEqual(proyecto.indicadores_ans.count(), 0)
+        self.assertEqual(proyecto.presupuestos_detallados.count(), 0)

--- a/apps/construccion/tests_b4_fin_views.py
+++ b/apps/construccion/tests_b4_fin_views.py
@@ -1,0 +1,256 @@
+"""B4 (#123) — Tests de las 6 vistas financieras de Construcción.
+
+ESCRITOS pero NO corridos en F3 (no hay Django local en este entorno) —
+``tests_passing``: ``deferred_to_f4_docker``. F4 los corre dentro del contenedor.
+
+tests_e2e del BLUEPRINT:
+  b4_fin_dashboard_200, b4_presupuesto_planeado_200, b4_presupuesto_real_200,
+  b4_nomina_200, b4_costos_200, b4_facturacion_200.
+
+Cobertura adicional:
+- ProyectoFinMixin → 404 con proyecto inexistente.
+- Context completo del dashboard (resumen_planeado/real, indicadores, ANS).
+- Querystring anio/mes inválido no rompe (edge case _parse_periodo).
+- Filtro por tipo_recurso en costos.
+- Dato legacy: un ProyectoConstruccion sin presupuesto detallado abre el
+  dashboard en ceros (sin 500).
+"""
+import uuid
+from decimal import Decimal
+
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.utils import timezone
+
+from apps.contratos.models import Contrato
+from apps.construccion.models import ProyectoConstruccion
+from apps.construccion.models_fin import (
+    PresupuestoDetalladoConstruccion,
+    CostosConstruccion,
+    FacturacionConstruccion,
+    IndicadorANSConstruccion,
+)
+
+# El modelo de usuario varía por proyecto (RBAC v2). Se obtiene dinámicamente.
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+def _crear_proyecto(nombre='Proyecto LT 230kV test'):
+    contrato = Contrato.objects.create(
+        codigo=f"CONS-{uuid.uuid4().hex[:10]}",
+        nombre='Contrato test construcción B4',
+        unidad_negocio='CONSTRUCCION',
+    )
+    return ProyectoConstruccion.objects.create(contrato=contrato, nombre=nombre)
+
+
+def _crear_usuario_admin():
+    """Usuario que pasa RoleRequiredMixin + SubModuloRequiredMixin.
+
+    Se usa superuser para garantizar acceso (RBAC v2: superuser pasa todos los
+    gates). El campo username puede variar; se prueba defensivamente.
+    """
+    kwargs = {'is_superuser': True, 'is_staff': True}
+    try:
+        return User.objects.create_superuser(
+            username='qa_b4', email='qa_b4@instelec.com', password='x',
+        )
+    except TypeError:
+        # Modelos custom sin username (USERNAME_FIELD=email u otro).
+        user = User(**kwargs)
+        if hasattr(user, 'email'):
+            user.email = 'qa_b4@instelec.com'
+        user.set_password('x')
+        user.save()
+        return user
+
+
+class _BaseFinViewTest(TestCase):
+    def setUp(self):
+        self.proyecto = _crear_proyecto()
+        self.user = _crear_usuario_admin()
+        self.client = Client()
+        self.client.force_login(self.user)
+
+    def _url(self, name):
+        return reverse(f'construccion:{name}',
+                       kwargs={'proyecto_id': self.proyecto.id})
+
+
+class TestB4FinDashboard(_BaseFinViewTest):
+    """tests_e2e: b4_fin_dashboard_200."""
+
+    def test_b4_fin_dashboard_200(self):
+        resp = self.client.get(self._url('fin_dashboard'))
+        self.assertEqual(resp.status_code, 200)
+        for key in ('proyecto', 'resumen_planeado', 'resumen_real',
+                    'indicadores_tecnico_financieros', 'indicadores_ans',
+                    'resumen_ans', 'anio', 'mes'):
+            self.assertIn(key, resp.context)
+        # 6 indicadores técnico-financieros (#122).
+        self.assertEqual(len(resp.context['indicadores_tecnico_financieros']), 6)
+
+    def test_dashboard_con_presupuesto_y_ans(self):
+        PresupuestoDetalladoConstruccion.objects.create(
+            proyecto=self.proyecto, anio=timezone.now().year,
+            tipo=PresupuestoDetalladoConstruccion.Tipo.PLANEADO,
+            datos={'ingreso': {'enero': 1000}, 'variables': {'enero': 400},
+                   'fijos': {'enero': 200}},
+        )
+        IndicadorANSConstruccion.objects.create(
+            proyecto=self.proyecto, nombre='Programación',
+            meta_porcentaje=Decimal('95'), valor_actual=Decimal('50'),
+            periodo_anio=timezone.now().year, periodo_mes=timezone.now().month,
+        )
+        resp = self.client.get(self._url('fin_dashboard'))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.context['resumen_planeado']['ingreso'], Decimal('1000'))
+        self.assertEqual(resp.context['resumen_planeado']['total_gastos'], Decimal('600'))
+        self.assertEqual(len(resp.context['indicadores_ans']), 1)
+
+    def test_proyecto_inexistente_404(self):
+        url = reverse('construccion:fin_dashboard',
+                      kwargs={'proyecto_id': uuid.uuid4()})
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 404)
+
+    def test_anio_mes_invalido_no_rompe(self):
+        # Edge case: querystring inválido → fallback a hoy, no 500.
+        resp = self.client.get(self._url('fin_dashboard') + '?anio=abc&mes=99')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.context['anio'], timezone.now().year)
+
+
+class TestB4PresupuestoPlaneado(_BaseFinViewTest):
+    """tests_e2e: b4_presupuesto_planeado_200."""
+
+    def test_b4_presupuesto_planeado_200(self):
+        resp = self.client.get(self._url('fin_presupuesto_planeado'))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.context['tipo'], 'PLANEADO')
+        self.assertTrue(resp.context['sin_datos'])  # sin presupuesto aún
+
+    def test_planeado_con_datos(self):
+        PresupuestoDetalladoConstruccion.objects.create(
+            proyecto=self.proyecto, anio=timezone.now().year,
+            tipo=PresupuestoDetalladoConstruccion.Tipo.PLANEADO,
+            datos={'ingreso': {'enero': 500}},
+        )
+        resp = self.client.get(self._url('fin_presupuesto_planeado'))
+        self.assertEqual(resp.status_code, 200)
+        self.assertFalse(resp.context['sin_datos'])
+        self.assertEqual(resp.context['resumen']['ingreso'], Decimal('500'))
+
+
+class TestB4PresupuestoReal(_BaseFinViewTest):
+    """tests_e2e: b4_presupuesto_real_200."""
+
+    def test_b4_presupuesto_real_200(self):
+        resp = self.client.get(self._url('fin_presupuesto_real'))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.context['tipo'], 'REAL')
+        self.assertIn('total_costos_registrados', resp.context)
+
+    def test_real_cruza_costos(self):
+        CostosConstruccion.objects.create(
+            proyecto=self.proyecto, concepto='Cemento',
+            cantidad=Decimal('10'), costo_unitario=Decimal('100'),
+            fecha=timezone.now().date(),
+        )
+        resp = self.client.get(self._url('fin_presupuesto_real'))
+        self.assertEqual(resp.status_code, 200)
+        # costo_total = 10 * 100 = 1000 (auto en save()).
+        self.assertEqual(resp.context['total_costos_registrados'], Decimal('1000.00'))
+
+
+class TestB4Nomina(_BaseFinViewTest):
+    """tests_e2e: b4_nomina_200."""
+
+    def test_b4_nomina_200(self):
+        resp = self.client.get(self._url('fin_nomina'))
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('costos_mano_obra', resp.context)
+        self.assertTrue(resp.context['sin_datos'])
+
+    def test_nomina_suma_mano_obra(self):
+        CostosConstruccion.objects.create(
+            proyecto=self.proyecto, concepto='Cuadrilla A',
+            tipo_recurso=CostosConstruccion.TipoRecurso.MANO_OBRA,
+            cantidad=Decimal('1'), costo_unitario=Decimal('2000'),
+            fecha=timezone.now().date(),
+        )
+        # Un costo MATERIAL no debe contar en nómina.
+        CostosConstruccion.objects.create(
+            proyecto=self.proyecto, concepto='Acero',
+            tipo_recurso=CostosConstruccion.TipoRecurso.MATERIAL,
+            cantidad=Decimal('1'), costo_unitario=Decimal('9999'),
+            fecha=timezone.now().date(),
+        )
+        resp = self.client.get(self._url('fin_nomina'))
+        self.assertEqual(resp.context['total_nomina'], Decimal('2000.00'))
+        self.assertEqual(len(resp.context['costos_mano_obra']), 1)
+
+
+class TestB4Costos(_BaseFinViewTest):
+    """tests_e2e: b4_costos_200."""
+
+    def test_b4_costos_200(self):
+        resp = self.client.get(self._url('fin_costos'))
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('costos', resp.context)
+        self.assertIn('tipos_recurso', resp.context)
+
+    def test_costos_filtro_tipo_recurso(self):
+        CostosConstruccion.objects.create(
+            proyecto=self.proyecto, concepto='Mat',
+            tipo_recurso=CostosConstruccion.TipoRecurso.MATERIAL,
+            cantidad=Decimal('1'), costo_unitario=Decimal('100'),
+            fecha=timezone.now().date(),
+        )
+        CostosConstruccion.objects.create(
+            proyecto=self.proyecto, concepto='Equipo',
+            tipo_recurso=CostosConstruccion.TipoRecurso.EQUIPOS,
+            cantidad=Decimal('1'), costo_unitario=Decimal('500'),
+            fecha=timezone.now().date(),
+        )
+        resp = self.client.get(self._url('fin_costos') + '?tipo_recurso=MATERIAL')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.context['costos']), 1)
+        self.assertEqual(resp.context['filtro_tipo_recurso'], 'MATERIAL')
+
+
+class TestB4Facturacion(_BaseFinViewTest):
+    """tests_e2e: b4_facturacion_200."""
+
+    def test_b4_facturacion_200(self):
+        resp = self.client.get(self._url('fin_facturacion'))
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('facturas', resp.context)
+        self.assertTrue(resp.context['sin_datos'])
+
+    def test_facturacion_totales_y_saldo(self):
+        FacturacionConstruccion.objects.create(
+            proyecto=self.proyecto, numero_factura='F-001',
+            monto_facturado=Decimal('1000'), monto_pagado=Decimal('400'),
+        )
+        FacturacionConstruccion.objects.create(
+            proyecto=self.proyecto, numero_factura='F-002',
+            monto_facturado=Decimal('500'), monto_pagado=Decimal('500'),
+        )
+        resp = self.client.get(self._url('fin_facturacion'))
+        self.assertEqual(resp.context['total_facturado'], Decimal('1500'))
+        self.assertEqual(resp.context['total_pagado'], Decimal('900'))
+        self.assertEqual(resp.context['saldo_total'], Decimal('600'))
+
+
+class TestB4DatoLegacy(_BaseFinViewTest):
+    """Dato legacy: proyecto preexistente sin datos financieros abre todo en 200."""
+
+    def test_proyecto_legacy_abre_las_6_vistas(self):
+        for name in ('fin_dashboard', 'fin_presupuesto_planeado',
+                     'fin_presupuesto_real', 'fin_nomina', 'fin_costos',
+                     'fin_facturacion'):
+            resp = self.client.get(self._url(name))
+            self.assertEqual(resp.status_code, 200, f'{name} debió dar 200')

--- a/apps/construccion/tests_b4_fin_views.py
+++ b/apps/construccion/tests_b4_fin_views.py
@@ -254,3 +254,48 @@ class TestB4DatoLegacy(_BaseFinViewTest):
                      'fin_facturacion'):
             resp = self.client.get(self._url(name))
             self.assertEqual(resp.status_code, 200, f'{name} debió dar 200')
+
+
+# ===========================================================================
+# F4 — Carga de Excel (POST) en Presupuesto Planeado (#123 Fase 4 wiring)
+# ===========================================================================
+class PresupuestoUploadPostTests(_BaseFinViewTest):
+    """El handler POST cablea form -> importer -> PresupuestoDetalladoConstruccion."""
+
+    def _xlsx_contable(self):
+        import io
+        from openpyxl import Workbook
+        wb = Workbook()
+        ws = wb.active
+        ws.title = 'BD'
+        ws.append(['Desc auxiliar', 'Neto', 'Cta equivalente'])
+        ws.append(['mov 1', 100, 'Ingresos Operacionales'])
+        ws.append(['mov 2', 200, 'Ingresos Operacionales'])
+        ws.append(['mov 3', 50, 'Salarios'])
+        buf = io.BytesIO()
+        wb.save(buf)
+        buf.seek(0)
+        return buf.getvalue()
+
+    def test_post_cargar_bd_contable_crea_presupuesto(self):
+        from django.core.files.uploadedfile import SimpleUploadedFile
+        url = reverse('construccion:fin_presupuesto_planeado',
+                      kwargs={'proyecto_id': self.proyecto.pk})
+        archivo = SimpleUploadedFile(
+            'BASE DE DATOS.xlsx', self._xlsx_contable(),
+            content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        )
+        resp = self.client.post(url, {'action': 'cargar_bd', 'anio': 2026, 'archivo': archivo})
+        self.assertEqual(resp.status_code, 302)  # redirect tras carga
+        obj = PresupuestoDetalladoConstruccion.objects.filter(
+            proyecto=self.proyecto, anio=2026,
+            tipo=PresupuestoDetalladoConstruccion.Tipo.PLANEADO,
+        ).first()
+        self.assertIsNotNone(obj, 'debe crear el PresupuestoDetalladoConstruccion')
+        self.assertTrue(obj.datos, 'datos no debe quedar vacío tras importar')
+
+    def test_post_sin_archivo_no_rompe(self):
+        url = reverse('construccion:fin_presupuesto_planeado',
+                      kwargs={'proyecto_id': self.proyecto.pk})
+        resp = self.client.post(url, {'action': 'cargar_bd', 'anio': 2026})
+        self.assertEqual(resp.status_code, 302)  # redirect con mensaje de error, sin 500

--- a/apps/construccion/tests_b5_fin.py
+++ b/apps/construccion/tests_b5_fin.py
@@ -1,0 +1,200 @@
+"""B5 (#123) — Tests del importador financiero de construcción + forms.
+
+Cubre (tests_e2e del BLUEPRINT):
+- ``b5_dashboard_render_completo``  → cubierto por F4/F6 (render real con DB). Aquí
+  se valida la parte unitaria testeable sin servidor: forms + importers.
+- ``b5_cargar_bd_form_200``         → validación del form de carga (.xlsx + tamaño).
+- ``b5_facturacion_crud``           → validación del FacturacionConstruccionForm.
+
+Estos tests NO requieren Cloud SQL: usan workbooks openpyxl en memoria + forms con
+``files``/``data`` dict. El render de los 9 templates se valida en F4 (Docker) y
+F6 (/qa-prod E2E), como indica el prompt F3.
+
+Edge cases del dominio cubiertos:
+- archivo no-.xlsx              → error
+- archivo .xlsx sin filas       → advertencia
+- presupuesto sin columnas mes  → advertencia
+- costos solo con 'total'       → se interpreta como cantidad 1 × total
+- factura con pagado > facturado → form inválido
+- detect_excel_format_*         → discrimina contable/presupuesto/costos/None
+"""
+import io
+
+from django.test import SimpleTestCase
+from openpyxl import Workbook
+
+from apps.construccion.forms_fin import (
+    CargarBDContableConstruccionForm,
+    CostosConstruccionForm,
+    FacturacionConstruccionForm,
+)
+from apps.construccion.importers import (
+    ContableConstruccionExcelImporter,
+    PresupuestoConstruccionExcelImporter,
+    detect_excel_format_construccion,
+)
+
+
+def _xlsx_bytes(rows, sheet_title='Hoja1'):
+    """Construye un .xlsx en memoria con ``rows`` (list[list]) → SimpleUploadedFile-like."""
+    wb = Workbook()
+    ws = wb.active
+    ws.title = sheet_title
+    for row in rows:
+        ws.append(row)
+    buf = io.BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+    buf.name = 'test.xlsx'
+    return buf
+
+
+class _FakeUpload:
+    """Mínimo file-like con .name y .size para los importers (sin Django storage)."""
+
+    def __init__(self, buf, name='test.xlsx'):
+        self._buf = buf
+        self.name = name
+        buf.seek(0, io.SEEK_END)
+        self.size = buf.tell()
+        buf.seek(0)
+
+    def read(self, *a, **k):
+        return self._buf.read(*a, **k)
+
+    def seek(self, *a, **k):
+        return self._buf.seek(*a, **k)
+
+
+# ===========================================================================
+# Importador de presupuesto
+# ===========================================================================
+class PresupuestoImporterTests(SimpleTestCase):
+    def test_presupuesto_agrupa_por_seccion(self):
+        """Happy path: clasifica filas en ingreso/variables/fijos por concepto."""
+        buf = _xlsx_bytes([
+            ['Concepto', 'enero', 'febrero'],
+            ['Ingresos por obra', 1000, 1200],
+            ['Costo variable cemento', 300, 350],
+            ['Gasto fijo arriendo', 100, 100],
+        ])
+        res = PresupuestoConstruccionExcelImporter().procesar(_FakeUpload(buf))
+        self.assertTrue(res['exito'], res)
+        datos = res['datos']
+        self.assertIn('Ingresos por obra', datos['ingreso'])
+        self.assertIn('Costo variable cemento', datos['variables'])
+        self.assertIn('Gasto fijo arriendo', datos['fijos'])
+        self.assertEqual(datos['ingreso']['Ingresos por obra']['enero'], 1000)
+
+    def test_presupuesto_sin_columnas_mes_advertencia(self):
+        """Edge case: archivo sin columnas de mes → advertencia (no exito)."""
+        buf = _xlsx_bytes([['Concepto', 'Valor'], ['X', 10]])
+        res = PresupuestoConstruccionExcelImporter().procesar(_FakeUpload(buf))
+        self.assertFalse(res['exito'])
+        self.assertIsNotNone(res['advertencia'])
+
+    def test_archivo_no_xlsx_error(self):
+        """Edge case: extensión inválida → error inmediato."""
+        buf = _xlsx_bytes([['Concepto', 'enero'], ['X', 1]])
+        res = PresupuestoConstruccionExcelImporter().procesar(
+            _FakeUpload(buf, name='datos.csv'))
+        self.assertFalse(res['exito'])
+        self.assertIsNotNone(res['error'])
+
+
+# ===========================================================================
+# Detector de formato
+# ===========================================================================
+class DetectFormatTests(SimpleTestCase):
+    def test_detecta_presupuesto(self):
+        buf = _xlsx_bytes([['Concepto', 'enero', 'febrero', 'marzo'], ['X', 1, 2, 3]])
+        self.assertEqual(detect_excel_format_construccion(_FakeUpload(buf)), 'presupuesto')
+
+    def test_detecta_contable_por_hoja_bd(self):
+        buf = _xlsx_bytes([['Cta equivalente', 'Neto'], ['Ingresos', 100]], sheet_title='BD')
+        self.assertEqual(detect_excel_format_construccion(_FakeUpload(buf)), 'contable')
+
+    def test_detecta_costos(self):
+        buf = _xlsx_bytes([['Concepto', 'Cantidad', 'Costo unitario'], ['Cemento', 2, 50]])
+        self.assertEqual(detect_excel_format_construccion(_FakeUpload(buf)), 'costos')
+
+    def test_formato_no_reconocido(self):
+        buf = _xlsx_bytes([['Foo', 'Bar'], ['a', 'b']])
+        self.assertIsNone(detect_excel_format_construccion(_FakeUpload(buf)))
+
+    def test_archivo_invalido_es_none(self):
+        buf = _xlsx_bytes([['Concepto', 'enero'], ['X', 1]])
+        self.assertIsNone(detect_excel_format_construccion(_FakeUpload(buf, name='x.txt')))
+
+
+# ===========================================================================
+# Importador contable (delega en ContableCompleteImporter de #120)
+# ===========================================================================
+class ContableImporterTests(SimpleTestCase):
+    def test_contable_agrupa_por_cuenta(self):
+        """Reusa la lógica de #120: agrupa por Cta equivalente sumando Neto."""
+        rows = [
+            ['Desc auxiliar', 'Neto', 'Cta equivalente'],
+            ['mov 1', 100, 'Ingresos Operacionales'],
+            ['mov 2', 200, 'Ingresos Operacionales'],
+        ]
+        buf = _xlsx_bytes(rows, sheet_title='BD')
+        res = ContableConstruccionExcelImporter().procesar(_FakeUpload(buf))
+        self.assertTrue(res['exito'], res)
+        self.assertIn('finv2_bd', res['datos'])
+        self.assertGreaterEqual(res['filas'], 1)
+
+
+# ===========================================================================
+# Forms
+# ===========================================================================
+class CargarBDFormTests(SimpleTestCase):
+    def test_cargar_bd_form_invalido_sin_archivo(self):
+        form = CargarBDContableConstruccionForm(data={}, files={})
+        self.assertFalse(form.is_valid())
+
+    def test_cargar_bd_form_rechaza_no_xlsx(self):
+        from django.core.files.uploadedfile import SimpleUploadedFile
+        f = SimpleUploadedFile('x.csv', b'1,2,3', content_type='text/csv')
+        form = CargarBDContableConstruccionForm(data={}, files={'archivo': f})
+        self.assertFalse(form.is_valid())
+        self.assertIn('archivo', form.errors)
+
+
+class FacturacionFormTests(SimpleTestCase):
+    def test_factura_pagado_mayor_facturado_invalido(self):
+        """Edge case: pagado > facturado → form inválido."""
+        form = FacturacionConstruccionForm(data={
+            'numero_factura': 'FV-1',
+            'fecha_emision': '2026-01-15',
+            'monto_facturado': '100.00',
+            'monto_pagado': '150.00',
+            'estado': 'EMITIDA',
+            'observaciones': '',
+        })
+        self.assertFalse(form.is_valid())
+        self.assertIn('monto_pagado', form.errors)
+
+    def test_factura_valida(self):
+        form = FacturacionConstruccionForm(data={
+            'numero_factura': 'FV-2',
+            'fecha_emision': '2026-01-15',
+            'monto_facturado': '100.00',
+            'monto_pagado': '50.00',
+            'estado': 'EN_VALIDACION',
+            'observaciones': 'parcial',
+        })
+        self.assertTrue(form.is_valid(), form.errors)
+
+
+class CostosFormTests(SimpleTestCase):
+    def test_costo_cantidad_negativa_invalido(self):
+        form = CostosConstruccionForm(data={
+            'concepto': 'Cemento',
+            'tipo_recurso': 'MATERIAL',
+            'cantidad': '-1',
+            'costo_unitario': '50',
+            'fecha': '2026-01-10',
+        })
+        self.assertFalse(form.is_valid())
+        self.assertIn('cantidad', form.errors)

--- a/apps/construccion/tests_b5_fin.py
+++ b/apps/construccion/tests_b5_fin.py
@@ -59,14 +59,12 @@ class _FakeUpload:
         self.size = buf.tell()
         buf.seek(0)
 
-    def read(self, *a, **k):
-        return self._buf.read(*a, **k)
-
-    def seek(self, *a, **k):
-        return self._buf.seek(*a, **k)
-
-    def tell(self, *a, **k):
-        return self._buf.tell(*a, **k)
+    def __getattr__(self, attr):
+        # Delegar cualquier método file-like no definido (read/seek/tell/
+        # seekable/readable/close/...) al buffer subyacente, para que openpyxl
+        # en modo read_only (que abre el xlsx como zip) funcione igual que con
+        # un UploadedFile real de Django.
+        return getattr(self.__dict__['_buf'], attr)
 
 
 # ===========================================================================

--- a/apps/construccion/tests_b5_fin.py
+++ b/apps/construccion/tests_b5_fin.py
@@ -65,6 +65,9 @@ class _FakeUpload:
     def seek(self, *a, **k):
         return self._buf.seek(*a, **k)
 
+    def tell(self, *a, **k):
+        return self._buf.tell(*a, **k)
+
 
 # ===========================================================================
 # Importador de presupuesto

--- a/apps/construccion/urls.py
+++ b/apps/construccion/urls.py
@@ -231,3 +231,8 @@ urlpatterns += urls_b3_mont_detalle.urlpatterns
 # === Complemento financiero #103 — TransaccionesList/Upload/Reportes + PyG drill-down ===
 from . import urls_pdeo_complement  # noqa: E402
 urlpatterns += urls_pdeo_complement.urlpatterns
+
+# === /modulo financiero_construccion_runB — rutas financieras ===
+# F2 scaffolding: B4 (#123) llena urls_fin con las 6 rutas /financiero/<subruta>/.
+from . import urls_fin  # noqa: E402
+urlpatterns += urls_fin.urlpatterns

--- a/apps/construccion/urls_fin.py
+++ b/apps/construccion/urls_fin.py
@@ -1,1 +1,45 @@
-urlpatterns = []  # B4 (#123) agrega las 6 rutas /financiero/<subruta>/
+"""B4 (#123) — URLs del Módulo Financiero de Construcción (Fase 2/5).
+
+Las 6 rutas viven bajo ``/construccion/<uuid:proyecto_id>/financiero/<subruta>/``
+y se agregan a ``apps.construccion.urls`` vía
+``urlpatterns += urls_fin.urlpatterns`` (ya cableado por F2).
+
+Namespace: ``construccion`` (app_name en urls.py). Reverse:
+``construccion:fin_dashboard`` etc.
+"""
+from django.urls import path
+
+from . import views_fin
+
+urlpatterns = [
+    path(
+        '<uuid:proyecto_id>/financiero/dashboard/',
+        views_fin.DashboardFinancieroConstruccionView.as_view(),
+        name='fin_dashboard',
+    ),
+    path(
+        '<uuid:proyecto_id>/financiero/presupuesto-planeado/',
+        views_fin.PresupuestoPlaneadoConstruccionView.as_view(),
+        name='fin_presupuesto_planeado',
+    ),
+    path(
+        '<uuid:proyecto_id>/financiero/presupuesto-real/',
+        views_fin.PresupuestoRealConstruccionView.as_view(),
+        name='fin_presupuesto_real',
+    ),
+    path(
+        '<uuid:proyecto_id>/financiero/nomina/',
+        views_fin.NominaConstruccionView.as_view(),
+        name='fin_nomina',
+    ),
+    path(
+        '<uuid:proyecto_id>/financiero/costos/',
+        views_fin.CostosDetalladoConstruccionView.as_view(),
+        name='fin_costos',
+    ),
+    path(
+        '<uuid:proyecto_id>/financiero/facturacion/',
+        views_fin.FacturacionConstruccionView.as_view(),
+        name='fin_facturacion',
+    ),
+]

--- a/apps/construccion/urls_fin.py
+++ b/apps/construccion/urls_fin.py
@@ -1,0 +1,1 @@
+urlpatterns = []  # B4 (#123) agrega las 6 rutas /financiero/<subruta>/

--- a/apps/construccion/views_fin.py
+++ b/apps/construccion/views_fin.py
@@ -48,6 +48,11 @@ from .models_fin import (
     FacturacionConstruccion,
     IndicadorANSConstruccion,
 )
+from .importers import (
+    ContableConstruccionExcelImporter,
+    PresupuestoConstruccionExcelImporter,
+    detect_excel_format_construccion,
+)
 
 
 # Roles administrativos con acceso al financiero (espejo de views.py::ALL_ADMIN_ROLES).
@@ -280,6 +285,63 @@ class PresupuestoPlaneadoConstruccionView(ProyectoFinMixin, TemplateView):
         ctx['resumen'] = self._resumen_presupuesto(
             proyecto, anio, PresupuestoDetalladoConstruccion.Tipo.PLANEADO)
         return ctx
+
+    def post(self, request, *args, **kwargs):
+        """Carga BD contable / presupuesto desde Excel (#123 Fase 4, espejo #120).
+
+        El form (``_financiero_cargar_bd.html``) postea ``action=cargar_bd`` +
+        ``archivo`` + ``anio``. Detecta el formato, corre el importer adecuado
+        y persiste el resultado en ``PresupuestoDetalladoConstruccion.datos``.
+        """
+        from django.contrib import messages
+        from django.shortcuts import redirect
+
+        proyecto = get_object_or_404(ProyectoConstruccion, pk=kwargs['proyecto_id'])
+        try:
+            anio = int(request.POST.get('anio') or date.today().year)
+        except (ValueError, TypeError):
+            anio = date.today().year
+        destino = f'{request.path}?anio={anio}&tab=cargar'
+
+        archivo = request.FILES.get('archivo')
+        if not archivo:
+            messages.error(request, 'Seleccione un archivo .xlsx.')
+            return redirect(destino)
+
+        formato = detect_excel_format_construccion(archivo)
+        try:
+            archivo.seek(0)
+        except Exception:
+            pass
+
+        if formato == 'contable':
+            res = ContableConstruccionExcelImporter().procesar(archivo)
+        elif formato == 'presupuesto':
+            res = PresupuestoConstruccionExcelImporter().procesar(archivo)
+        else:
+            messages.error(
+                request,
+                'Formato no reconocido. Suba la Base de Datos contable (hoja BD) '
+                'o el Presupuesto (columnas de mes).',
+            )
+            return redirect(destino)
+
+        if res.get('exito'):
+            obj, _creado = PresupuestoDetalladoConstruccion.objects.get_or_create(
+                proyecto=proyecto, anio=anio,
+                tipo=PresupuestoDetalladoConstruccion.Tipo.PLANEADO,
+                defaults={'datos': {}},
+            )
+            merged = dict(obj.datos or {})
+            merged.update(res.get('datos') or {})
+            obj.datos = merged
+            obj.save(update_fields=['datos', 'updated_at'])
+            messages.success(request, res.get('mensaje') or 'Importación completada.')
+            if res.get('advertencia'):
+                messages.warning(request, res['advertencia'])
+        else:
+            messages.error(request, res.get('error') or 'No se pudo procesar el archivo.')
+        return redirect(destino)
 
 
 # ===========================================================================

--- a/apps/construccion/views_fin.py
+++ b/apps/construccion/views_fin.py
@@ -1,0 +1,417 @@
+"""B4 (#123) — Vistas + Mixin del Módulo Financiero de Construcción (Fase 2).
+
+6 vistas bajo ``/construccion/<uuid:proyecto_id>/financiero/<subruta>/``:
+
+1. ``DashboardFinancieroConstruccionView``  → name ``fin_dashboard``
+2. ``PresupuestoPlaneadoConstruccionView``  → name ``fin_presupuesto_planeado``
+3. ``PresupuestoRealConstruccionView``       → name ``fin_presupuesto_real``
+4. ``NominaConstruccionView``                → name ``fin_nomina``
+5. ``CostosDetalladoConstruccionView``       → name ``fin_costos``
+6. ``FacturacionConstruccionView``           → name ``fin_facturacion``
+
+Reusos clave (issue #123 Fase 2/6):
+- Modelos B3 (``models_fin``): PresupuestoDetalladoConstruccion, CostosConstruccion,
+  FacturacionConstruccion, IndicadorANSConstruccion.
+- Helpers de #122 (``apps.financiero.indicadores_finv2``):
+  ``calcular_indicadores_tecnico_financieros`` + ``calcular_resumen_ans``.
+
+GATE DE SUBMÓDULO
+-----------------
+``'FINANCIERO'`` es un sub-módulo **registrado y válido**:
+``apps.core.permissions.SUBMODULO_FINANCIERO = 'FINANCIERO'`` ∈ ``TODOS_SUBMODULOS``
+y ya lo usa ``FinancieroGridView`` (views.py). Por eso ``ProyectoFinMixin`` usa
+``SubModuloRequiredMixin`` con ``required_submodulo = 'FINANCIERO'`` sin riesgo de
+403 indebido (los roles admin pasan vía RoleRequiredMixin de todos modos).
+
+Templates (``construccion/financiero_*.html``) los crea B5; F4 corre después de
+B5, así que referenciar ``template_name`` aquí es seguro aunque el archivo aún
+no exista en esta branch.
+"""
+from datetime import date
+from decimal import Decimal, InvalidOperation
+
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.shortcuts import get_object_or_404
+from django.views.generic import TemplateView
+
+from apps.core.mixins import RoleRequiredMixin, SubModuloRequiredMixin
+
+from apps.financiero.indicadores_finv2 import (
+    calcular_indicadores_tecnico_financieros,
+    calcular_resumen_ans,
+)
+
+from .models import ProyectoConstruccion
+from .models_fin import (
+    PresupuestoDetalladoConstruccion,
+    CostosConstruccion,
+    FacturacionConstruccion,
+    IndicadorANSConstruccion,
+)
+
+
+# Roles administrativos con acceso al financiero (espejo de views.py::ALL_ADMIN_ROLES).
+ALL_ADMIN_ROLES = [
+    'admin', 'director', 'coordinador', 'ing_residente',
+    'admin_general', 'coordinador_general', 'admin_construccion',
+]
+
+
+def _to_decimal(valor) -> Decimal:
+    """int/float/Decimal/str/None → Decimal seguro (nunca lanza)."""
+    if isinstance(valor, Decimal):
+        return valor
+    if valor is None:
+        return Decimal('0')
+    try:
+        return Decimal(str(valor))
+    except (InvalidOperation, ValueError, TypeError):
+        return Decimal('0')
+
+
+def _parse_periodo(request):
+    """Lee ?anio=&mes= del querystring con fallback a hoy.
+
+    Edge case: parámetros inválidos (no numéricos, mes fuera de 1..12) caen al
+    valor por defecto sin romper la vista (un 500 por ValueError sería un bug
+    de UX: el dashboard debe abrir siempre).
+    """
+    hoy = date.today()
+    try:
+        anio = int(request.GET.get('anio', hoy.year))
+    except (TypeError, ValueError):
+        anio = hoy.year
+    try:
+        mes = int(request.GET.get('mes', hoy.month))
+        if not 1 <= mes <= 12:
+            mes = hoy.month
+    except (TypeError, ValueError):
+        mes = hoy.month
+    return anio, mes
+
+
+# ===========================================================================
+# Mixin común
+# ===========================================================================
+class ProyectoFinMixin(LoginRequiredMixin, RoleRequiredMixin, SubModuloRequiredMixin):
+    """Resuelve el ``ProyectoConstruccion`` por ``proyecto_id`` y aplica gates.
+
+    - ``LoginRequiredMixin``      → redirige a login si anónimo.
+    - ``RoleRequiredMixin``       → roles admin de construcción (admin level
+      siempre pasa vía RBAC v2).
+    - ``SubModuloRequiredMixin``  → gate del sub-módulo FINANCIERO (registrado).
+
+    Inyecta al contexto: ``proyecto``, ``active_tab='financiero'``, ``anio``,
+    ``mes`` (estos dos del querystring con fallback a hoy).
+
+    Edge case manejado: ``proyecto_id`` inexistente → 404 (get_object_or_404),
+    no un 500.
+    """
+    allowed_roles = ALL_ADMIN_ROLES
+    required_submodulo = 'FINANCIERO'
+    active_subtab = None  # cada vista la sobreescribe (dashboard/planeado/...)
+
+    def get_proyecto(self):
+        if not hasattr(self, '_proyecto_cache'):
+            self._proyecto_cache = get_object_or_404(
+                ProyectoConstruccion, pk=self.kwargs['proyecto_id']
+            )
+        return self._proyecto_cache
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        proyecto = self.get_proyecto()
+        anio, mes = _parse_periodo(self.request)
+        ctx['proyecto'] = proyecto
+        ctx['active_tab'] = 'financiero'
+        ctx['active_subtab'] = self.active_subtab
+        ctx['anio'] = anio
+        ctx['mes'] = mes
+        return ctx
+
+    # ----- Helpers de resumen presupuestal compartidos -------------------
+    def _resumen_presupuesto(self, proyecto, anio, tipo):
+        """Construye el dict ``resumen`` que consumen los indicadores #122.
+
+        Suma los valores mensuales del JSON ``datos`` de
+        ``PresupuestoDetalladoConstruccion`` (proyecto, anio, tipo) y produce
+        las keys que ``calcular_indicadores_tecnico_financieros`` espera:
+        ``ingreso``, ``total_variables``, ``total_fijos``, ``total_gastos``,
+        ``resultado``, ``utilidad_pct``.
+
+        Estructura esperada de ``datos`` (flexible — se navega defensivamente):
+            {"ingreso": {"enero": 100, ...},
+             "variables": {...}, "fijos": {...}}
+
+        Edge case: presupuesto inexistente para (proyecto, anio, tipo) →
+        resumen en ceros (no 404; el dashboard muestra "sin datos").
+        """
+        ingreso = total_variables = total_fijos = Decimal('0')
+        presupuesto = (
+            PresupuestoDetalladoConstruccion.objects
+            .filter(proyecto=proyecto, anio=anio, tipo=tipo)
+            .first()
+        )
+        if presupuesto and isinstance(presupuesto.datos, dict):
+            ingreso = self._sumar_seccion(presupuesto.datos, ('ingreso', 'ingresos', 'facturacion'))
+            total_variables = self._sumar_seccion(
+                presupuesto.datos, ('variables', 'costos_variables', 'costos_directos'))
+            total_fijos = self._sumar_seccion(
+                presupuesto.datos, ('fijos', 'costos_fijos', 'gastos'))
+
+        total_gastos = total_variables + total_fijos
+        resultado = ingreso - total_gastos
+        utilidad_pct = (
+            (resultado / ingreso * Decimal('100')) if ingreso else Decimal('0')
+        )
+        return {
+            'ingreso': ingreso,
+            'total_variables': total_variables,
+            'total_fijos': total_fijos,
+            'total_gastos': total_gastos,
+            'resultado': resultado,
+            'utilidad_pct': utilidad_pct.quantize(Decimal('0.01')),
+        }
+
+    @staticmethod
+    def _sumar_seccion(datos, keys):
+        """Suma todos los valores numéricos de la primera key presente en ``datos``.
+
+        Acepta tanto ``{key: {mes: valor}}`` como ``{key: valor}``.
+        """
+        for key in keys:
+            seccion = datos.get(key)
+            if seccion is None:
+                continue
+            if isinstance(seccion, dict):
+                total = Decimal('0')
+                for v in seccion.values():
+                    if isinstance(v, dict):
+                        for vv in v.values():
+                            total += _to_decimal(vv)
+                    else:
+                        total += _to_decimal(v)
+                return total
+            return _to_decimal(seccion)
+        return Decimal('0')
+
+
+# ===========================================================================
+# 1. DASHBOARD FINANCIERO
+# ===========================================================================
+class DashboardFinancieroConstruccionView(ProyectoFinMixin, TemplateView):
+    """Dashboard financiero comparativo planeado vs real + KPIs + ANS (#123).
+
+    Context (issue #123 Fase 2.1):
+        proyecto, anio, mes, resumen_planeado, resumen_real,
+        indicadores_tecnico_financieros, indicadores_ans, resumen_ans.
+    """
+    template_name = 'construccion/financiero_dashboard.html'
+    active_subtab = 'dashboard'
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        proyecto = ctx['proyecto']
+        anio = ctx['anio']
+
+        resumen_planeado = self._resumen_presupuesto(
+            proyecto, anio, PresupuestoDetalladoConstruccion.Tipo.PLANEADO)
+        resumen_real = self._resumen_presupuesto(
+            proyecto, anio, PresupuestoDetalladoConstruccion.Tipo.REAL)
+
+        ctx['resumen_planeado'] = resumen_planeado
+        ctx['resumen_real'] = resumen_real
+
+        # 6 indicadores técnico-financieros (#122). Función pura, división segura.
+        ctx['indicadores_tecnico_financieros'] = (
+            calcular_indicadores_tecnico_financieros(resumen_planeado, resumen_real)
+        )
+
+        # Sección ANS reutilizando el helper #122 (modelo de mantenimiento).
+        # Defensivo: si el helper no encuentra registro devuelve sin_datos=True.
+        try:
+            ctx['resumen_ans'] = calcular_resumen_ans(
+                linea=None, anio=anio, mes=ctx['mes'])
+        except Exception:
+            ctx['resumen_ans'] = {'filas': [], 'sin_datos': True}
+
+        # Indicadores ANS propios de construcción (modelo B3) del período.
+        ctx['indicadores_ans'] = list(
+            IndicadorANSConstruccion.objects
+            .filter(proyecto=proyecto, periodo_anio=anio, periodo_mes=ctx['mes'])
+            .order_by('nombre')
+        )
+
+        # Alertas: indicadores en rojo + ANS incumplidos.
+        alertas = [
+            ind for ind in ctx['indicadores_tecnico_financieros']
+            if ind.get('estado') == 'rojo'
+        ]
+        alertas += [
+            f"ANS incumplido: {a.nombre} ({a.valor_actual}%)"
+            for a in ctx['indicadores_ans']
+            if a.estado == IndicadorANSConstruccion.Estado.INCUMPLIDO
+        ]
+        ctx['alertas'] = alertas
+        return ctx
+
+
+# ===========================================================================
+# 2. PRESUPUESTO PLANEADO
+# ===========================================================================
+class PresupuestoPlaneadoConstruccionView(ProyectoFinMixin, TemplateView):
+    """Presupuesto PLANEADO del año (estructura JSON + resumen) (#123 Fase 2.2)."""
+    template_name = 'construccion/financiero_presupuesto_planeado.html'
+    active_subtab = 'presupuesto_planeado'
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        proyecto, anio = ctx['proyecto'], ctx['anio']
+        presupuesto = (
+            PresupuestoDetalladoConstruccion.objects
+            .filter(proyecto=proyecto, anio=anio,
+                    tipo=PresupuestoDetalladoConstruccion.Tipo.PLANEADO)
+            .first()
+        )
+        ctx['tipo'] = 'PLANEADO'
+        ctx['presupuesto'] = presupuesto
+        ctx['datos'] = presupuesto.datos if presupuesto else {}
+        ctx['sin_datos'] = presupuesto is None
+        ctx['resumen'] = self._resumen_presupuesto(
+            proyecto, anio, PresupuestoDetalladoConstruccion.Tipo.PLANEADO)
+        return ctx
+
+
+# ===========================================================================
+# 3. PRESUPUESTO REAL
+# ===========================================================================
+class PresupuestoRealConstruccionView(ProyectoFinMixin, TemplateView):
+    """Presupuesto REAL del año (ejecutado) (#123 Fase 2.3)."""
+    template_name = 'construccion/financiero_presupuesto_real.html'
+    active_subtab = 'presupuesto_real'
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        proyecto, anio = ctx['proyecto'], ctx['anio']
+        presupuesto = (
+            PresupuestoDetalladoConstruccion.objects
+            .filter(proyecto=proyecto, anio=anio,
+                    tipo=PresupuestoDetalladoConstruccion.Tipo.REAL)
+            .first()
+        )
+        ctx['tipo'] = 'REAL'
+        ctx['presupuesto'] = presupuesto
+        ctx['datos'] = presupuesto.datos if presupuesto else {}
+        ctx['sin_datos'] = presupuesto is None
+        ctx['resumen'] = self._resumen_presupuesto(
+            proyecto, anio, PresupuestoDetalladoConstruccion.Tipo.REAL)
+        # Total ejecutado derivado de costos registrados (cruce con CostosConstruccion).
+        total_costos = Decimal('0')
+        for c in CostosConstruccion.objects.filter(
+                proyecto=proyecto, fecha__year=anio):
+            total_costos += _to_decimal(c.costo_total)
+        ctx['total_costos_registrados'] = total_costos
+        return ctx
+
+
+# ===========================================================================
+# 4. NÓMINA
+# ===========================================================================
+class NominaConstruccionView(ProyectoFinMixin, TemplateView):
+    """Nómina / personal administrativo del proyecto (#123 Fase 2.4).
+
+    No existe (aún) un modelo PersonalAdministrativoConstruccion (fuera del scope
+    de B3). Se usa el desglose de costos tipo MANO_OBRA como proxy de nómina del
+    período, agrupando por concepto. Versión 1.0 funcional; el CRUD de personal
+    queda diferido (no es de los 5 modelos de B3).
+    """
+    template_name = 'construccion/financiero_nomina.html'
+    active_subtab = 'nomina'
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        proyecto, anio = ctx['proyecto'], ctx['anio']
+        costos_mano_obra = list(
+            CostosConstruccion.objects
+            .filter(proyecto=proyecto, fecha__year=anio,
+                    tipo_recurso=CostosConstruccion.TipoRecurso.MANO_OBRA)
+            .order_by('-fecha')
+        )
+        total_nomina = sum((_to_decimal(c.costo_total) for c in costos_mano_obra),
+                           Decimal('0'))
+        ctx['costos_mano_obra'] = costos_mano_obra
+        ctx['total_nomina'] = total_nomina
+        ctx['sin_datos'] = not costos_mano_obra
+        return ctx
+
+
+# ===========================================================================
+# 5. COSTOS DETALLADO
+# ===========================================================================
+class CostosDetalladoConstruccionView(ProyectoFinMixin, TemplateView):
+    """Tabla de costos ejecutados con filtro por tipo de recurso (#123 Fase 2.5)."""
+    template_name = 'construccion/financiero_costos_detallado.html'
+    active_subtab = 'costos'
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        proyecto, anio = ctx['proyecto'], ctx['anio']
+        qs = (
+            CostosConstruccion.objects
+            .filter(proyecto=proyecto, fecha__year=anio)
+            .select_related('actividad')
+            .order_by('-fecha')
+        )
+        # Filtro opcional por tipo de recurso (?tipo_recurso=MATERIAL).
+        tipo_recurso = self.request.GET.get('tipo_recurso')
+        validos = {c[0] for c in CostosConstruccion.TipoRecurso.choices}
+        if tipo_recurso in validos:
+            qs = qs.filter(tipo_recurso=tipo_recurso)
+            ctx['filtro_tipo_recurso'] = tipo_recurso
+
+        costos = list(qs)
+        # Totales por tipo de recurso (para el resumen superior de la tabla).
+        totales_por_tipo = {}
+        total_general = Decimal('0')
+        for c in costos:
+            valor = _to_decimal(c.costo_total)
+            totales_por_tipo[c.tipo_recurso] = (
+                totales_por_tipo.get(c.tipo_recurso, Decimal('0')) + valor
+            )
+            total_general += valor
+
+        ctx['costos'] = costos
+        ctx['totales_por_tipo'] = totales_por_tipo
+        ctx['total_general'] = total_general
+        ctx['tipos_recurso'] = CostosConstruccion.TipoRecurso.choices
+        ctx['sin_datos'] = not costos
+        return ctx
+
+
+# ===========================================================================
+# 6. FACTURACIÓN
+# ===========================================================================
+class FacturacionConstruccionView(ProyectoFinMixin, TemplateView):
+    """Gestión de facturas + seguimiento de pagos (#123 Fase 2.6)."""
+    template_name = 'construccion/financiero_facturacion.html'
+    active_subtab = 'facturacion'
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        proyecto = ctx['proyecto']
+        facturas = list(
+            FacturacionConstruccion.objects
+            .filter(proyecto=proyecto)
+            .order_by('-fecha_emision')
+        )
+        total_facturado = sum(
+            (_to_decimal(f.monto_facturado) for f in facturas), Decimal('0'))
+        total_pagado = sum(
+            (_to_decimal(f.monto_pagado) for f in facturas), Decimal('0'))
+        ctx['facturas'] = facturas
+        ctx['total_facturado'] = total_facturado
+        ctx['total_pagado'] = total_pagado
+        ctx['saldo_total'] = total_facturado - total_pagado
+        ctx['estados'] = FacturacionConstruccion.Estado.choices
+        ctx['sin_datos'] = not facturas
+        return ctx

--- a/templates/construccion/_financiero_cargar_bd.html
+++ b/templates/construccion/_financiero_cargar_bd.html
@@ -1,0 +1,99 @@
+{% comment %}
+B5 (#123 Fase 3) — Partial Pestaña 1: Cargar archivo (presupuesto / BD contable / costos).
+Espejo de templates/financiero/_cargar_bd_contable.html (#120).
+
+Contexto consumido (todo opcional → render-safe sin él):
+  cargar_bd_form (opcional)  — CargarBDContableConstruccionForm; si no está, se
+                               renderiza un <input type=file> plano equivalente.
+  proyecto, anio             — provistos por ProyectoFinMixin (siempre presentes).
+  tipo                       — 'PLANEADO' | 'REAL' (provisto por la vista).
+
+Nota de scope (B5): la vista PresupuestoPlaneadoConstruccionView (B4) es un
+TemplateView GET; el manejo POST del upload (detect_excel_format_construccion +
+importer + save) vive fuera de los archivos de B5 (requeriría editar views_fin.py,
+que no es de B5). El form se postea a la misma URL; cuando el endpoint de carga
+esté cableado procesará el archivo. La UI queda completa y funcional como subida.
+{% endcomment %}
+{% load humanize %}
+
+<section x-data="{ uploading: false }"
+         class="bg-white dark:bg-gray-800 rounded-lg shadow p-6 border border-gray-200 dark:border-gray-700">
+    <div class="flex items-start gap-3 mb-4">
+        <div class="rounded-lg bg-blue-50 dark:bg-blue-900/30 p-3 text-blue-600 dark:text-blue-300">
+            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                      d="M7 16a4 4 0 01-.88-7.9A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10"/>
+            </svg>
+        </div>
+        <div>
+            <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+                Cargar presupuesto {{ tipo|default:"" }} desde Excel
+            </h2>
+            <p class="text-sm text-gray-600 dark:text-gray-400">
+                Suba el archivo de presupuesto o base de datos contable (.xlsx).
+                El formato se detecta automáticamente. Máximo 20 MB.
+            </p>
+        </div>
+    </div>
+
+    <form method="post"
+          action="?anio={{ anio }}&tab=cargar"
+          enctype="multipart/form-data"
+          @submit="uploading = true"
+          class="space-y-4">
+        {% csrf_token %}
+        <input type="hidden" name="action" value="cargar_bd">
+        <input type="hidden" name="anio" value="{{ anio }}">
+        {% if tipo %}<input type="hidden" name="tipo" value="{{ tipo }}">{% endif %}
+
+        <div>
+            {% if cargar_bd_form %}
+                {{ cargar_bd_form.archivo }}
+                {% if cargar_bd_form.archivo.errors %}
+                <p class="mt-1 text-xs text-red-600 dark:text-red-400">
+                    {{ cargar_bd_form.archivo.errors.0 }}
+                </p>
+                {% endif %}
+            {% else %}
+                <input type="file" name="archivo" accept=".xlsx" required
+                       class="block w-full text-sm text-gray-500 dark:text-gray-400
+                              file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0
+                              file:text-sm file:font-semibold file:bg-blue-50
+                              file:text-blue-700 hover:file:bg-blue-100
+                              dark:file:bg-gray-700 dark:file:text-gray-300">
+            {% endif %}
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                Formatos aceptados: presupuesto (columnas por mes), base de datos
+                contable (hoja "BD", columna O), o costos (concepto + total).
+            </p>
+        </div>
+
+        <div class="flex items-center gap-3">
+            <button type="submit"
+                    :disabled="uploading"
+                    class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm font-medium transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2">
+                <svg x-show="uploading" x-cloak class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
+                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.4 0 0 5.4 0 12h4z"></path>
+                </svg>
+                <span x-text="uploading ? 'Procesando archivo…' : 'Importar'"></span>
+            </button>
+            <span x-show="uploading" x-cloak class="text-xs text-gray-500 dark:text-gray-400">
+                Esto puede tardar unos segundos con archivos grandes.
+            </span>
+        </div>
+    </form>
+
+    {% if not sin_datos %}
+    <div class="mt-6 rounded-lg border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/20 p-4">
+        <p class="text-sm font-medium text-green-800 dark:text-green-300">
+            Ya hay datos cargados para {{ anio }}
+        </p>
+        <p class="mt-1 text-xs text-green-700 dark:text-green-400">
+            Total ingreso ${{ resumen.ingreso|default:0|floatformat:0|intcomma }} ·
+            Total gastos ${{ resumen.total_gastos|default:0|floatformat:0|intcomma }}.
+            Volver a importar reemplazará la estructura actual.
+        </p>
+    </div>
+    {% endif %}
+</section>

--- a/templates/construccion/_financiero_indicadores_tabla.html
+++ b/templates/construccion/_financiero_indicadores_tabla.html
@@ -1,0 +1,81 @@
+{% comment %}
+B5 (#123 Fase 3) — Tabla de los 6 indicadores Técnico-Financieros.
+Espejo de templates/financiero/_indicadores_tecnico_financieros.html (#122).
+
+Contexto que provee DashboardFinancieroConstruccionView.get_context_data:
+  indicadores_tecnico_financieros: list[dict] con keys
+    tipo, nombre, formula, meta, valor, estado (verde|amarillo|rojo), progreso (0..100).
+
+Coloreo: verde = cumple/supera, amarillo = 80-99%, rojo = <80%.
+{% endcomment %}
+<section class="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden mb-6"
+         aria-label="Indicadores técnico-financieros">
+    <div class="p-4 border-b dark:border-gray-700 flex items-center justify-between">
+        <div>
+            <h3 class="font-medium text-gray-900 dark:text-white">Indicadores Técnico-Financieros</h3>
+            <p class="text-sm text-gray-500 dark:text-gray-400">Año {{ anio }} · Mes {{ mes }}</p>
+        </div>
+        <div class="flex items-center gap-3 text-xs">
+            <span class="inline-flex items-center gap-1"><span class="w-3 h-3 rounded-full bg-green-500"></span>Cumple</span>
+            <span class="inline-flex items-center gap-1"><span class="w-3 h-3 rounded-full bg-yellow-400"></span>Parcial</span>
+            <span class="inline-flex items-center gap-1"><span class="w-3 h-3 rounded-full bg-red-500"></span>No cumple</span>
+        </div>
+    </div>
+    <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-900">
+                <tr>
+                    <th scope="col" class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Tipo</th>
+                    <th scope="col" class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Nombre Indicador</th>
+                    <th scope="col" class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Fórmula / Cálculo</th>
+                    <th scope="col" class="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase">Meta</th>
+                    <th scope="col" class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Valor</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                {% for ind in indicadores_tecnico_financieros %}
+                <tr class="hover:bg-gray-50 dark:hover:bg-gray-700
+                    {% if ind.estado == 'verde' %}bg-green-50/40 dark:bg-green-900/10
+                    {% elif ind.estado == 'amarillo' %}bg-yellow-50/40 dark:bg-yellow-900/10
+                    {% else %}bg-red-50/40 dark:bg-red-900/10{% endif %}">
+                    <td class="px-4 py-3 text-sm">
+                        <span class="px-2 py-0.5 rounded text-xs font-semibold
+                            {% if ind.tipo == 'FINANCIERO' %}bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300
+                            {% else %}bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300{% endif %}">
+                            {{ ind.tipo }}
+                        </span>
+                    </td>
+                    <td class="px-4 py-3 text-sm font-medium text-gray-900 dark:text-white">
+                        <span class="cursor-help border-b border-dotted border-gray-400" title="{{ ind.formula }}">{{ ind.nombre }}</span>
+                    </td>
+                    <td class="px-4 py-3 text-xs text-gray-600 dark:text-gray-300">
+                        <code class="font-mono">{{ ind.formula }}</code>
+                    </td>
+                    <td class="px-4 py-3 text-sm text-center font-medium text-gray-700 dark:text-gray-200">{{ ind.meta }}</td>
+                    <td class="px-4 py-3 text-sm text-right">
+                        <div class="flex items-center justify-end gap-2">
+                            <div class="w-24 bg-gray-200 dark:bg-gray-700 rounded-full h-2 overflow-hidden" aria-hidden="true">
+                                <div class="h-2 rounded-full transition-all duration-700
+                                    {% if ind.estado == 'verde' %}bg-green-500
+                                    {% elif ind.estado == 'amarillo' %}bg-yellow-400
+                                    {% else %}bg-red-500{% endif %}"
+                                    style="width: {{ ind.progreso }}%"></div>
+                            </div>
+                            <span class="font-bold w-16 text-right
+                                {% if ind.estado == 'verde' %}text-green-600
+                                {% elif ind.estado == 'amarillo' %}text-yellow-600
+                                {% else %}text-red-600{% endif %}">{{ ind.valor }}</span>
+                        </div>
+                    </td>
+                </tr>
+                {% empty %}
+                <tr>
+                    <td colspan="5" class="px-4 py-6 text-center text-sm text-gray-400">
+                        No hay datos suficientes para calcular los indicadores en este período.
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</section>

--- a/templates/construccion/_financiero_presupuesto_tabla.html
+++ b/templates/construccion/_financiero_presupuesto_tabla.html
@@ -1,0 +1,103 @@
+{% comment %}
+B5 (#123 Fase 3) — Partial Pestaña 2: Tabla del presupuesto por secciones/rubros.
+Espejo de la pestaña 2 de templates/financiero/presupuesto_planeado_v2.html (#120).
+
+Contexto provisto por PresupuestoPlaneadoConstruccionView / PresupuestoRealConstruccionView:
+  datos: dict — estructura del PresupuestoDetalladoConstruccion.datos:
+         {"ingreso": {"<concepto>": {"<mes>": valor}}, "variables": {...}, "fijos": {...}}
+  resumen: dict {ingreso, total_variables, total_fijos, total_gastos, resultado, utilidad_pct}
+  sin_datos: bool
+  tipo: 'PLANEADO' | 'REAL'
+
+Cada sección es colapsable (Alpine). Empty state cuando sin_datos.
+{% endcomment %}
+{% load humanize %}
+
+{% if sin_datos %}
+<div class="bg-white dark:bg-gray-800 rounded-lg shadow p-8 text-center border border-gray-200 dark:border-gray-700">
+    <p class="text-gray-500 dark:text-gray-400">
+        Aún no hay presupuesto {{ tipo|default:"" }} cargado para {{ anio }}.
+    </p>
+    <button @click="tab = 'cargar'"
+            class="mt-3 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm font-medium">
+        Cargar presupuesto
+    </button>
+</div>
+{% else %}
+<div class="space-y-4">
+    <!-- Resumen superior -->
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border-l-4 border-green-500">
+            <p class="text-xs uppercase text-gray-500">Ingreso</p>
+            <p class="text-xl font-bold text-green-600">${{ resumen.ingreso|default:0|floatformat:0|intcomma }}</p>
+        </div>
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border-l-4 border-orange-500">
+            <p class="text-xs uppercase text-gray-500">Costos variables</p>
+            <p class="text-xl font-bold text-orange-600">${{ resumen.total_variables|default:0|floatformat:0|intcomma }}</p>
+        </div>
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border-l-4 border-red-500">
+            <p class="text-xs uppercase text-gray-500">Costos fijos</p>
+            <p class="text-xl font-bold text-red-600">${{ resumen.total_fijos|default:0|floatformat:0|intcomma }}</p>
+        </div>
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border-l-4 border-blue-500">
+            <p class="text-xs uppercase text-gray-500">Resultado</p>
+            <p class="text-xl font-bold {% if resumen.resultado >= 0 %}text-blue-600{% else %}text-red-600{% endif %}">
+                ${{ resumen.resultado|default:0|floatformat:0|intcomma }}
+            </p>
+            <p class="text-xs text-gray-400">Utilidad {{ resumen.utilidad_pct|default:0 }}%</p>
+        </div>
+    </div>
+
+    <!-- Secciones colapsables -->
+    {% for seccion, conceptos in datos.items %}
+    {% if seccion == 'ingreso' or seccion == 'variables' or seccion == 'fijos' %}
+    <section x-data="{ open: true }"
+             class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700">
+        <button @click="open = !open"
+                class="w-full px-4 py-3 flex items-center justify-between border-b border-gray-200 dark:border-gray-700">
+            <h3 class="text-base font-semibold text-gray-900 dark:text-white capitalize flex items-center gap-2">
+                <span x-text="open ? '▼' : '▶'" class="text-xs text-gray-400"></span>
+                {% if seccion == 'ingreso' %}Ingresos
+                {% elif seccion == 'variables' %}Costos variables
+                {% else %}Costos fijos{% endif %}
+            </h3>
+            <span class="text-xs text-gray-500 dark:text-gray-400">{{ conceptos|length }} concepto{{ conceptos|length|pluralize }}</span>
+        </button>
+        <div x-show="open" x-cloak class="overflow-x-auto">
+            <table class="min-w-full text-sm">
+                <thead class="bg-gray-50 dark:bg-gray-900">
+                    <tr>
+                        <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Concepto</th>
+                        <th class="px-4 py-2 text-right font-medium text-gray-600 dark:text-gray-300">Meses con valor</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                    {% for concepto, meses in conceptos.items %}
+                    <tr x-data="{ det: false }" class="hover:bg-gray-50 dark:hover:bg-gray-700/40">
+                        <td class="px-4 py-2 text-gray-900 dark:text-white cursor-pointer" @click="det = !det">
+                            <span x-text="det ? '▾' : '▸'" class="text-xs mr-1 text-gray-400"></span>{{ concepto }}
+                            <div x-show="det" x-cloak class="mt-1 flex flex-wrap gap-2 text-xs text-gray-500 dark:text-gray-400">
+                                {% for mes, valor in meses.items %}
+                                <span class="px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-700 capitalize">
+                                    {{ mes }}: ${{ valor|floatformat:0|intcomma }}
+                                </span>
+                                {% endfor %}
+                            </div>
+                        </td>
+                        <td class="px-4 py-2 text-right text-gray-600 dark:text-gray-300">{{ meses|length }}</td>
+                    </tr>
+                    {% empty %}
+                    <tr><td colspan="2" class="px-4 py-4 text-center text-gray-400">Sin conceptos en esta sección.</td></tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+    {% endif %}
+    {% empty %}
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6 text-center text-gray-500 dark:text-gray-400">
+        El presupuesto cargado no tiene secciones reconocibles (ingreso / variables / fijos).
+    </div>
+    {% endfor %}
+</div>
+{% endif %}

--- a/templates/construccion/financiero_costos_detallado.html
+++ b/templates/construccion/financiero_costos_detallado.html
@@ -1,0 +1,130 @@
+{% extends 'base.html' %}
+{% load humanize core_tags %}
+{% comment %}
+B5 (#123 Fase 3.5) — Costos Detallados de Construcción (filtrable por tipo de recurso).
+Servido por CostosDetalladoConstruccionView (construccion:fin_costos).
+
+Contexto (B4): proyecto, anio, mes, active_subtab,
+  costos (list[CostosConstruccion] — model instances, con .actividad select_related),
+  totales_por_tipo (dict {tipo_recurso: Decimal}),
+  total_general (Decimal),
+  tipos_recurso (CostosConstruccion.TipoRecurso.choices → list[(value, label)]),
+  filtro_tipo_recurso (str opcional — solo presente si hay filtro activo),
+  sin_datos (bool).
+{% endcomment %}
+
+{% block title %}Financiero — Costos · {{ proyecto.nombre }}{% endblock %}
+
+{% block content %}
+<nav class="border-b border-gray-200 dark:border-gray-700 mb-6 overflow-x-auto">
+    <div class="-mb-px flex gap-4 text-sm whitespace-nowrap">
+        {% with st=active_subtab %}
+        <a href="{% url 'construccion:fin_dashboard' proyecto.id %}?anio={{ anio }}&mes={{ mes }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'dashboard' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Dashboard</a>
+        <a href="{% url 'construccion:fin_presupuesto_planeado' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'presupuesto_planeado' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Presupuesto Planeado</a>
+        <a href="{% url 'construccion:fin_presupuesto_real' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'presupuesto_real' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Presupuesto Real</a>
+        <a href="{% url 'construccion:fin_nomina' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'nomina' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Nómina</a>
+        <a href="{% url 'construccion:fin_costos' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'costos' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Costos</a>
+        <a href="{% url 'construccion:fin_facturacion' proyecto.id %}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'facturacion' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Facturación</a>
+        {% endwith %}
+    </div>
+</nav>
+
+<div class="space-y-6">
+    <header class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+        <div>
+            <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Costos Ejecutados</h1>
+            <p class="text-gray-500 dark:text-gray-400">{{ proyecto.nombre }} · Año {{ anio }}</p>
+        </div>
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow px-5 py-3 border-l-4 border-red-500">
+            <p class="text-xs uppercase text-gray-500">Total{% if filtro_tipo_recurso %} (filtrado){% endif %}</p>
+            <p class="text-2xl font-bold text-red-600">${{ total_general|default:0|floatformat:0|intcomma }}</p>
+        </div>
+    </header>
+
+    <!-- Totales por tipo de recurso -->
+    {% if totales_por_tipo %}
+    <div class="grid grid-cols-2 md:grid-cols-5 gap-3">
+        {% for value, label in tipos_recurso %}
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-3 border border-gray-200 dark:border-gray-700 text-center">
+            <p class="text-xs uppercase text-gray-500">{{ label }}</p>
+            <p class="text-base font-bold text-gray-900 dark:text-white">${{ totales_por_tipo|get_item:value|default:0|floatformat:0|intcomma }}</p>
+        </div>
+        {% endfor %}
+    </div>
+    {% endif %}
+
+    <!-- Filtro por tipo de recurso -->
+    <form method="get" class="flex flex-wrap items-end gap-2 text-sm">
+        <input type="hidden" name="anio" value="{{ anio }}">
+        <label class="flex flex-col">
+            <span class="text-xs text-gray-500">Tipo de recurso</span>
+            <select name="tipo_recurso"
+                    class="rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white text-sm">
+                <option value="">Todos</option>
+                {% for value, label in tipos_recurso %}
+                <option value="{{ value }}" {% if filtro_tipo_recurso == value %}selected{% endif %}>{{ label }}</option>
+                {% endfor %}
+            </select>
+        </label>
+        <button type="submit" class="px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm font-medium">Filtrar</button>
+        {% if filtro_tipo_recurso %}
+        <a href="?anio={{ anio }}" class="px-3 py-2 text-sm text-gray-500 hover:underline">Limpiar</a>
+        {% endif %}
+    </form>
+
+    {% if sin_datos %}
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-8 text-center border border-gray-200 dark:border-gray-700">
+        <p class="text-gray-500 dark:text-gray-400">
+            {% if filtro_tipo_recurso %}No hay costos del tipo seleccionado para {{ anio }}.
+            {% else %}No hay costos registrados para {{ anio }}.{% endif %}
+        </p>
+    </div>
+    {% else %}
+    <section class="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden border border-gray-200 dark:border-gray-700">
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+                <thead class="bg-gray-50 dark:bg-gray-900">
+                    <tr>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Concepto</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Tipo</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actividad</th>
+                        <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Cantidad</th>
+                        <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Unitario</th>
+                        <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Total</th>
+                        <th class="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase">Fecha</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                    {% for c in costos %}
+                    <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+                        <td class="px-4 py-3 text-gray-900 dark:text-white">{{ c.concepto }}</td>
+                        <td class="px-4 py-3">
+                            <span class="px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300">{{ c.get_tipo_recurso_display }}</span>
+                        </td>
+                        <td class="px-4 py-3 text-gray-500 dark:text-gray-400">{% if c.actividad %}{{ c.actividad }}{% else %}—{% endif %}</td>
+                        <td class="px-4 py-3 text-right text-gray-600 dark:text-gray-300">{{ c.cantidad }}</td>
+                        <td class="px-4 py-3 text-right text-gray-600 dark:text-gray-300">${{ c.costo_unitario|floatformat:0|intcomma }}</td>
+                        <td class="px-4 py-3 text-right font-medium text-gray-900 dark:text-white">${{ c.costo_total|floatformat:0|intcomma }}</td>
+                        <td class="px-4 py-3 text-center text-gray-500 dark:text-gray-400">{{ c.fecha|date:"d/m/Y" }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+                <tfoot class="bg-gray-100 dark:bg-gray-900 font-semibold">
+                    <tr>
+                        <td colspan="5" class="px-4 py-3 text-right text-gray-900 dark:text-white">Total general</td>
+                        <td class="px-4 py-3 text-right text-red-600">${{ total_general|default:0|floatformat:0|intcomma }}</td>
+                        <td></td>
+                    </tr>
+                </tfoot>
+            </table>
+        </div>
+    </section>
+    {% endif %}
+</div>
+{% endblock %}

--- a/templates/construccion/financiero_dashboard.html
+++ b/templates/construccion/financiero_dashboard.html
@@ -1,0 +1,156 @@
+{% extends 'base.html' %}
+{% load humanize %}
+{% comment %}
+B5 (#123 Fase 3.1) — Dashboard Financiero de Construcción.
+Servido por DashboardFinancieroConstruccionView (construccion:fin_dashboard).
+
+Contexto consumido (todo provisto por la vista B4):
+  proyecto, anio, mes, active_subtab,
+  resumen_planeado / resumen_real {ingreso,total_variables,total_fijos,total_gastos,resultado,utilidad_pct},
+  indicadores_tecnico_financieros (list[dict] estado verde/amarillo/rojo) → _financiero_indicadores_tabla.html,
+  resumen_ans {filas, total_ponderado, estado_general, estado_color, sin_datos},
+  indicadores_ans (list[IndicadorANSConstruccion] — model instances, estado cumplido/parcial/incumplido),
+  alertas (list[str|dict]).
+{% endcomment %}
+
+{% block title %}Financiero — Dashboard · {{ proyecto.nombre }}{% endblock %}
+
+{% block content %}
+{% comment %} Subnav financiero (inline — no es un partial propio de B5) {% endcomment %}
+<nav class="border-b border-gray-200 dark:border-gray-700 mb-6 overflow-x-auto">
+    <div class="-mb-px flex gap-4 text-sm whitespace-nowrap">
+        {% with st=active_subtab %}
+        <a href="{% url 'construccion:fin_dashboard' proyecto.id %}?anio={{ anio }}&mes={{ mes }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'dashboard' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Dashboard</a>
+        <a href="{% url 'construccion:fin_presupuesto_planeado' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'presupuesto_planeado' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Presupuesto Planeado</a>
+        <a href="{% url 'construccion:fin_presupuesto_real' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'presupuesto_real' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Presupuesto Real</a>
+        <a href="{% url 'construccion:fin_nomina' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'nomina' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Nómina</a>
+        <a href="{% url 'construccion:fin_costos' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'costos' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Costos</a>
+        <a href="{% url 'construccion:fin_facturacion' proyecto.id %}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'facturacion' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Facturación</a>
+        {% endwith %}
+    </div>
+</nav>
+
+<div class="space-y-6">
+    <!-- Header -->
+    <header class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+        <div>
+            <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Dashboard Financiero</h1>
+            <p class="text-sm text-gray-500 dark:text-gray-400">{{ proyecto.nombre }} · Año {{ anio }} · Mes {{ mes }}</p>
+        </div>
+        <form method="get" class="flex flex-wrap gap-2 items-end text-sm">
+            <label class="flex flex-col">
+                <span class="text-xs text-gray-500">Año</span>
+                <input type="number" name="anio" value="{{ anio }}"
+                       class="w-24 rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white text-sm">
+            </label>
+            <label class="flex flex-col">
+                <span class="text-xs text-gray-500">Mes</span>
+                <input type="number" name="mes" value="{{ mes }}" min="1" max="12"
+                       class="w-20 rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white text-sm">
+            </label>
+            <button type="submit" class="px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm font-medium">Ver</button>
+        </form>
+    </header>
+
+    <!-- Alertas -->
+    {% if alertas %}
+    <div class="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-4">
+        <p class="text-sm font-semibold text-red-800 dark:text-red-300">{{ alertas|length }} alerta{{ alertas|length|pluralize }} del período</p>
+        <ul class="mt-2 space-y-1 text-sm text-red-700 dark:text-red-300 list-disc list-inside">
+            {% for a in alertas %}
+            <li>{% if a.nombre %}{{ a.nombre }}{% else %}{{ a }}{% endif %}</li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% endif %}
+
+    <!-- KPI cards: planeado vs real -->
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border-l-4 border-green-500">
+            <p class="text-xs uppercase text-gray-500">Ingreso</p>
+            <p class="text-2xl font-bold text-green-600">${{ resumen_real.ingreso|default:0|floatformat:0|intcomma }}</p>
+            <p class="text-xs text-gray-400">Plan: ${{ resumen_planeado.ingreso|default:0|floatformat:0|intcomma }}</p>
+        </div>
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border-l-4 border-red-500">
+            <p class="text-xs uppercase text-gray-500">Gastos</p>
+            <p class="text-2xl font-bold text-red-600">${{ resumen_real.total_gastos|default:0|floatformat:0|intcomma }}</p>
+            <p class="text-xs text-gray-400">Plan: ${{ resumen_planeado.total_gastos|default:0|floatformat:0|intcomma }}</p>
+        </div>
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border-l-4 border-blue-500">
+            <p class="text-xs uppercase text-gray-500">Resultado</p>
+            <p class="text-2xl font-bold {% if resumen_real.resultado >= 0 %}text-blue-600{% else %}text-red-600{% endif %}">
+                ${{ resumen_real.resultado|default:0|floatformat:0|intcomma }}
+            </p>
+            <p class="text-xs text-gray-400">Plan: ${{ resumen_planeado.resultado|default:0|floatformat:0|intcomma }}</p>
+        </div>
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border-l-4 border-purple-500">
+            <p class="text-xs uppercase text-gray-500">% Utilidad</p>
+            <p class="text-2xl font-bold text-purple-600">{{ resumen_real.utilidad_pct|default:0 }}%</p>
+            <p class="text-xs text-gray-400">Plan: {{ resumen_planeado.utilidad_pct|default:0 }}%</p>
+        </div>
+    </div>
+
+    <!-- 6 indicadores técnico-financieros -->
+    {% include "construccion/_financiero_indicadores_tabla.html" %}
+
+    <!-- ANS de construcción (modelo B3: IndicadorANSConstruccion) -->
+    <section class="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden mb-6" aria-label="Indicadores ANS de construcción">
+        <div class="p-4 border-b dark:border-gray-700 flex items-center justify-between">
+            <div>
+                <h3 class="font-medium text-gray-900 dark:text-white">Indicadores ANS del Proyecto</h3>
+                <p class="text-sm text-gray-500 dark:text-gray-400">Acuerdos de nivel de servicio · {{ mes }}/{{ anio }}</p>
+            </div>
+        </div>
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                <thead class="bg-gray-50 dark:bg-gray-900">
+                    <tr>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Indicador</th>
+                        <th class="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase">Meta</th>
+                        <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Valor</th>
+                        <th class="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase">Estado</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                    {% for ind in indicadores_ans %}
+                    <tr class="hover:bg-gray-50 dark:hover:bg-gray-700
+                        {% if ind.estado == 'cumplido' %}bg-green-50/40 dark:bg-green-900/10
+                        {% elif ind.estado == 'parcial' %}bg-yellow-50/40 dark:bg-yellow-900/10
+                        {% else %}bg-red-50/40 dark:bg-red-900/10{% endif %}">
+                        <td class="px-4 py-3 text-sm font-medium text-gray-900 dark:text-white">
+                            {{ ind.nombre }}
+                            {% if ind.descripcion %}<span class="block text-xs text-gray-400">{{ ind.descripcion|truncatechars:80 }}</span>{% endif %}
+                        </td>
+                        <td class="px-4 py-3 text-sm text-center text-gray-700 dark:text-gray-200">{{ ind.meta_porcentaje }}%</td>
+                        <td class="px-4 py-3 text-sm text-right font-bold
+                            {% if ind.estado == 'cumplido' %}text-green-600
+                            {% elif ind.estado == 'parcial' %}text-yellow-600
+                            {% else %}text-red-600{% endif %}">{{ ind.valor_actual }}%</td>
+                        <td class="px-4 py-3 text-sm text-center">
+                            <span class="px-2 py-0.5 rounded text-xs font-semibold
+                                {% if ind.estado == 'cumplido' %}bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300
+                                {% elif ind.estado == 'parcial' %}bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300
+                                {% else %}bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300{% endif %}">
+                                {{ ind.get_estado_display }}
+                            </span>
+                        </td>
+                    </tr>
+                    {% empty %}
+                    <tr>
+                        <td colspan="4" class="px-4 py-6 text-center text-sm text-gray-400">
+                            No hay indicadores ANS registrados para {{ mes }}/{{ anio }}.
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+</div>
+{% endblock %}

--- a/templates/construccion/financiero_facturacion.html
+++ b/templates/construccion/financiero_facturacion.html
@@ -1,0 +1,112 @@
+{% extends 'base.html' %}
+{% load humanize %}
+{% comment %}
+B5 (#123 Fase 3.6) — Facturación de Construcción (lista + totales).
+Servido por FacturacionConstruccionView (construccion:fin_facturacion).
+
+Contexto (B4): proyecto, anio, mes, active_subtab,
+  facturas (list[FacturacionConstruccion] — model instances; .saldo_pendiente property),
+  total_facturado, total_pagado, saldo_total,
+  estados (FacturacionConstruccion.Estado.choices → list[(value, label)]),
+  sin_datos.
+{% endcomment %}
+
+{% block title %}Financiero — Facturación · {{ proyecto.nombre }}{% endblock %}
+
+{% block content %}
+<nav class="border-b border-gray-200 dark:border-gray-700 mb-6 overflow-x-auto">
+    <div class="-mb-px flex gap-4 text-sm whitespace-nowrap">
+        {% with st=active_subtab %}
+        <a href="{% url 'construccion:fin_dashboard' proyecto.id %}?anio={{ anio }}&mes={{ mes }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'dashboard' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Dashboard</a>
+        <a href="{% url 'construccion:fin_presupuesto_planeado' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'presupuesto_planeado' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Presupuesto Planeado</a>
+        <a href="{% url 'construccion:fin_presupuesto_real' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'presupuesto_real' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Presupuesto Real</a>
+        <a href="{% url 'construccion:fin_nomina' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'nomina' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Nómina</a>
+        <a href="{% url 'construccion:fin_costos' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'costos' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Costos</a>
+        <a href="{% url 'construccion:fin_facturacion' proyecto.id %}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'facturacion' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Facturación</a>
+        {% endwith %}
+    </div>
+</nav>
+
+<div class="space-y-6">
+    <header>
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Facturación</h1>
+        <p class="text-gray-500 dark:text-gray-400">{{ proyecto.nombre }}</p>
+    </header>
+
+    <!-- Totales -->
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border-l-4 border-blue-500">
+            <p class="text-xs uppercase text-gray-500">Total facturado</p>
+            <p class="text-2xl font-bold text-blue-600">${{ total_facturado|default:0|floatformat:0|intcomma }}</p>
+        </div>
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border-l-4 border-green-500">
+            <p class="text-xs uppercase text-gray-500">Total pagado</p>
+            <p class="text-2xl font-bold text-green-600">${{ total_pagado|default:0|floatformat:0|intcomma }}</p>
+        </div>
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border-l-4 border-orange-500">
+            <p class="text-xs uppercase text-gray-500">Saldo pendiente</p>
+            <p class="text-2xl font-bold {% if saldo_total > 0 %}text-orange-600{% else %}text-green-600{% endif %}">${{ saldo_total|default:0|floatformat:0|intcomma }}</p>
+        </div>
+    </div>
+
+    {% if sin_datos %}
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-8 text-center border border-gray-200 dark:border-gray-700">
+        <p class="text-gray-500 dark:text-gray-400">No hay facturas registradas para este proyecto.</p>
+    </div>
+    {% else %}
+    <section class="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden border border-gray-200 dark:border-gray-700">
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+                <thead class="bg-gray-50 dark:bg-gray-900">
+                    <tr>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">N° Factura</th>
+                        <th class="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase">Emisión</th>
+                        <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Facturado</th>
+                        <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Pagado</th>
+                        <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Saldo</th>
+                        <th class="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase">Estado</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                    {% for f in facturas %}
+                    <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+                        <td class="px-4 py-3 font-medium text-gray-900 dark:text-white">
+                            {{ f.numero_factura }}
+                            {% if f.observaciones %}<span class="block text-xs text-gray-400">{{ f.observaciones|truncatechars:60 }}</span>{% endif %}
+                        </td>
+                        <td class="px-4 py-3 text-center text-gray-500 dark:text-gray-400">{{ f.fecha_emision|date:"d/m/Y" }}</td>
+                        <td class="px-4 py-3 text-right text-gray-900 dark:text-white">${{ f.monto_facturado|floatformat:0|intcomma }}</td>
+                        <td class="px-4 py-3 text-right text-green-600">${{ f.monto_pagado|floatformat:0|intcomma }}</td>
+                        <td class="px-4 py-3 text-right {% if f.saldo_pendiente > 0 %}text-orange-600{% else %}text-gray-500{% endif %}">${{ f.saldo_pendiente|floatformat:0|intcomma }}</td>
+                        <td class="px-4 py-3 text-center">
+                            <span class="px-2 py-0.5 rounded text-xs font-semibold
+                                {% if f.estado == 'PAGADA' %}bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300
+                                {% elif f.estado == 'EN_VALIDACION' %}bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300
+                                {% else %}bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300{% endif %}">
+                                {{ f.get_estado_display }}
+                            </span>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+                <tfoot class="bg-gray-100 dark:bg-gray-900 font-semibold">
+                    <tr>
+                        <td colspan="2" class="px-4 py-3 text-right text-gray-900 dark:text-white">Totales</td>
+                        <td class="px-4 py-3 text-right text-blue-600">${{ total_facturado|default:0|floatformat:0|intcomma }}</td>
+                        <td class="px-4 py-3 text-right text-green-600">${{ total_pagado|default:0|floatformat:0|intcomma }}</td>
+                        <td class="px-4 py-3 text-right text-orange-600">${{ saldo_total|default:0|floatformat:0|intcomma }}</td>
+                        <td></td>
+                    </tr>
+                </tfoot>
+            </table>
+        </div>
+    </section>
+    {% endif %}
+</div>
+{% endblock %}

--- a/templates/construccion/financiero_nomina.html
+++ b/templates/construccion/financiero_nomina.html
@@ -1,0 +1,92 @@
+{% extends 'base.html' %}
+{% load humanize %}
+{% comment %}
+B5 (#123 Fase 3.4) — Nómina / Mano de obra de Construcción.
+Servido por NominaConstruccionView (construccion:fin_nomina).
+
+Contexto (B4): proyecto, anio, mes, active_subtab,
+  costos_mano_obra (list[CostosConstruccion] — model instances tipo MANO_OBRA),
+  total_nomina, sin_datos.
+{% endcomment %}
+
+{% block title %}Financiero — Nómina · {{ proyecto.nombre }}{% endblock %}
+
+{% block content %}
+<nav class="border-b border-gray-200 dark:border-gray-700 mb-6 overflow-x-auto">
+    <div class="-mb-px flex gap-4 text-sm whitespace-nowrap">
+        {% with st=active_subtab %}
+        <a href="{% url 'construccion:fin_dashboard' proyecto.id %}?anio={{ anio }}&mes={{ mes }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'dashboard' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Dashboard</a>
+        <a href="{% url 'construccion:fin_presupuesto_planeado' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'presupuesto_planeado' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Presupuesto Planeado</a>
+        <a href="{% url 'construccion:fin_presupuesto_real' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'presupuesto_real' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Presupuesto Real</a>
+        <a href="{% url 'construccion:fin_nomina' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'nomina' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Nómina</a>
+        <a href="{% url 'construccion:fin_costos' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'costos' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Costos</a>
+        <a href="{% url 'construccion:fin_facturacion' proyecto.id %}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'facturacion' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Facturación</a>
+        {% endwith %}
+    </div>
+</nav>
+
+<div class="space-y-6">
+    <header class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+        <div>
+            <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Nómina / Mano de Obra</h1>
+            <p class="text-gray-500 dark:text-gray-400">{{ proyecto.nombre }} · Año {{ anio }}</p>
+        </div>
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow px-5 py-3 border-l-4 border-green-500">
+            <p class="text-xs uppercase text-gray-500">Total nómina {{ anio }}</p>
+            <p class="text-2xl font-bold text-green-600">${{ total_nomina|default:0|floatformat:0|intcomma }}</p>
+        </div>
+    </header>
+
+    {% if sin_datos %}
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-8 text-center border border-gray-200 dark:border-gray-700">
+        <p class="text-gray-500 dark:text-gray-400">
+            No hay costos de mano de obra registrados para {{ anio }}.
+        </p>
+        <a href="{% url 'construccion:fin_costos' proyecto.id %}?anio={{ anio }}&tipo_recurso=MANO_OBRA"
+           class="mt-3 inline-flex px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm font-medium">
+            Registrar costos de mano de obra
+        </a>
+    </div>
+    {% else %}
+    <section class="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden border border-gray-200 dark:border-gray-700">
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+                <thead class="bg-gray-50 dark:bg-gray-900">
+                    <tr>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Concepto</th>
+                        <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Cantidad</th>
+                        <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Costo unitario</th>
+                        <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Costo total</th>
+                        <th class="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase">Fecha</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                    {% for c in costos_mano_obra %}
+                    <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+                        <td class="px-4 py-3 text-gray-900 dark:text-white">{{ c.concepto }}</td>
+                        <td class="px-4 py-3 text-right text-gray-600 dark:text-gray-300">{{ c.cantidad }}</td>
+                        <td class="px-4 py-3 text-right text-gray-600 dark:text-gray-300">${{ c.costo_unitario|floatformat:0|intcomma }}</td>
+                        <td class="px-4 py-3 text-right font-medium text-gray-900 dark:text-white">${{ c.costo_total|floatformat:0|intcomma }}</td>
+                        <td class="px-4 py-3 text-center text-gray-500 dark:text-gray-400">{{ c.fecha|date:"d/m/Y" }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+                <tfoot class="bg-gray-100 dark:bg-gray-900 font-semibold">
+                    <tr>
+                        <td colspan="3" class="px-4 py-3 text-right text-gray-900 dark:text-white">Total</td>
+                        <td class="px-4 py-3 text-right text-green-600">${{ total_nomina|default:0|floatformat:0|intcomma }}</td>
+                        <td></td>
+                    </tr>
+                </tfoot>
+            </table>
+        </div>
+    </section>
+    {% endif %}
+</div>
+{% endblock %}

--- a/templates/construccion/financiero_presupuesto_planeado.html
+++ b/templates/construccion/financiero_presupuesto_planeado.html
@@ -1,0 +1,70 @@
+{% extends 'base.html' %}
+{% load humanize %}
+{% comment %}
+B5 (#123 Fase 3.2) — Presupuesto Planeado de Construcción (2 pestañas).
+Servido por PresupuestoPlaneadoConstruccionView (construccion:fin_presupuesto_planeado).
+
+Contexto (B4): proyecto, anio, mes, active_subtab, tipo='PLANEADO',
+  presupuesto, datos (dict), sin_datos, resumen.
+Incluye: _financiero_cargar_bd.html (pestaña 1) + _financiero_presupuesto_tabla.html (pestaña 2).
+{% endcomment %}
+
+{% block title %}Financiero — Presupuesto Planeado · {{ proyecto.nombre }}{% endblock %}
+
+{% block content %}
+{% comment %} Subnav financiero (inline) {% endcomment %}
+<nav class="border-b border-gray-200 dark:border-gray-700 mb-6 overflow-x-auto">
+    <div class="-mb-px flex gap-4 text-sm whitespace-nowrap">
+        {% with st=active_subtab %}
+        <a href="{% url 'construccion:fin_dashboard' proyecto.id %}?anio={{ anio }}&mes={{ mes }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'dashboard' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Dashboard</a>
+        <a href="{% url 'construccion:fin_presupuesto_planeado' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'presupuesto_planeado' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Presupuesto Planeado</a>
+        <a href="{% url 'construccion:fin_presupuesto_real' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'presupuesto_real' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Presupuesto Real</a>
+        <a href="{% url 'construccion:fin_nomina' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'nomina' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Nómina</a>
+        <a href="{% url 'construccion:fin_costos' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'costos' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Costos</a>
+        <a href="{% url 'construccion:fin_facturacion' proyecto.id %}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'facturacion' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Facturación</a>
+        {% endwith %}
+    </div>
+</nav>
+
+<main class="space-y-4" x-data="{ tab: '{% if sin_datos %}cargar{% else %}tabla{% endif %}' }">
+    <header class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+        <div>
+            <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Presupuesto Planeado</h1>
+            <p class="text-gray-500 dark:text-gray-400">{{ proyecto.nombre }} · Año {{ anio }}</p>
+        </div>
+        <form method="get" class="flex items-end gap-2 text-sm">
+            <label class="flex flex-col">
+                <span class="text-xs text-gray-500">Año</span>
+                <input type="number" name="anio" value="{{ anio }}"
+                       class="w-24 rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white text-sm">
+            </label>
+            <button type="submit" class="px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm font-medium">Ver</button>
+        </form>
+    </header>
+
+    <!-- Tabs internas -->
+    <div class="border-b border-gray-200 dark:border-gray-700">
+        <nav class="-mb-px flex gap-6" aria-label="Pestañas">
+            <button @click="tab = 'cargar'"
+                    :class="tab === 'cargar' ? 'border-blue-600 text-blue-600 dark:text-blue-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'"
+                    class="whitespace-nowrap py-3 px-1 border-b-2 font-medium text-sm transition">Cargar Base de Datos</button>
+            <button @click="tab = 'tabla'"
+                    :class="tab === 'tabla' ? 'border-blue-600 text-blue-600 dark:text-blue-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'"
+                    class="whitespace-nowrap py-3 px-1 border-b-2 font-medium text-sm transition">Presupuesto por Rubros</button>
+        </nav>
+    </div>
+
+    <div x-show="tab === 'cargar'" x-cloak>
+        {% include "construccion/_financiero_cargar_bd.html" %}
+    </div>
+    <div x-show="tab === 'tabla'" x-cloak class="space-y-6">
+        {% include "construccion/_financiero_presupuesto_tabla.html" %}
+    </div>
+</main>
+{% endblock %}

--- a/templates/construccion/financiero_presupuesto_real.html
+++ b/templates/construccion/financiero_presupuesto_real.html
@@ -1,0 +1,77 @@
+{% extends 'base.html' %}
+{% load humanize %}
+{% comment %}
+B5 (#123 Fase 3.3) — Presupuesto Real de Construcción.
+Servido por PresupuestoRealConstruccionView (construccion:fin_presupuesto_real).
+
+Contexto (B4): proyecto, anio, mes, active_subtab, tipo='REAL',
+  presupuesto, datos (dict), sin_datos, resumen, total_costos_registrados.
+Reusa _financiero_cargar_bd.html + _financiero_presupuesto_tabla.html.
+{% endcomment %}
+
+{% block title %}Financiero — Presupuesto Real · {{ proyecto.nombre }}{% endblock %}
+
+{% block content %}
+<nav class="border-b border-gray-200 dark:border-gray-700 mb-6 overflow-x-auto">
+    <div class="-mb-px flex gap-4 text-sm whitespace-nowrap">
+        {% with st=active_subtab %}
+        <a href="{% url 'construccion:fin_dashboard' proyecto.id %}?anio={{ anio }}&mes={{ mes }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'dashboard' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Dashboard</a>
+        <a href="{% url 'construccion:fin_presupuesto_planeado' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'presupuesto_planeado' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Presupuesto Planeado</a>
+        <a href="{% url 'construccion:fin_presupuesto_real' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'presupuesto_real' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Presupuesto Real</a>
+        <a href="{% url 'construccion:fin_nomina' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'nomina' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Nómina</a>
+        <a href="{% url 'construccion:fin_costos' proyecto.id %}?anio={{ anio }}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'costos' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Costos</a>
+        <a href="{% url 'construccion:fin_facturacion' proyecto.id %}"
+           class="py-3 px-1 border-b-2 font-medium {% if st == 'facturacion' %}border-blue-600 text-blue-600 dark:text-blue-400{% else %}border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300{% endif %}">Facturación</a>
+        {% endwith %}
+    </div>
+</nav>
+
+<main class="space-y-4" x-data="{ tab: '{% if sin_datos %}cargar{% else %}tabla{% endif %}' }">
+    <header class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+        <div>
+            <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Presupuesto Real (Ejecutado)</h1>
+            <p class="text-gray-500 dark:text-gray-400">{{ proyecto.nombre }} · Año {{ anio }}</p>
+        </div>
+        <form method="get" class="flex items-end gap-2 text-sm">
+            <label class="flex flex-col">
+                <span class="text-xs text-gray-500">Año</span>
+                <input type="number" name="anio" value="{{ anio }}"
+                       class="w-24 rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white text-sm">
+            </label>
+            <button type="submit" class="px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm font-medium">Ver</button>
+        </form>
+    </header>
+
+    <!-- Cruce con costos registrados -->
+    <div class="rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 p-4 flex items-center justify-between">
+        <div>
+            <p class="text-sm font-medium text-blue-800 dark:text-blue-300">Costos ejecutados registrados ({{ anio }})</p>
+            <p class="text-xs text-blue-700 dark:text-blue-400">Suma de los registros de costos del año (módulo Costos).</p>
+        </div>
+        <p class="text-2xl font-bold text-blue-700 dark:text-blue-300">${{ total_costos_registrados|default:0|floatformat:0|intcomma }}</p>
+    </div>
+
+    <div class="border-b border-gray-200 dark:border-gray-700">
+        <nav class="-mb-px flex gap-6" aria-label="Pestañas">
+            <button @click="tab = 'cargar'"
+                    :class="tab === 'cargar' ? 'border-blue-600 text-blue-600 dark:text-blue-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'"
+                    class="whitespace-nowrap py-3 px-1 border-b-2 font-medium text-sm transition">Cargar Ejecución</button>
+            <button @click="tab = 'tabla'"
+                    :class="tab === 'tabla' ? 'border-blue-600 text-blue-600 dark:text-blue-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'"
+                    class="whitespace-nowrap py-3 px-1 border-b-2 font-medium text-sm transition">Ejecución por Rubros</button>
+        </nav>
+    </div>
+
+    <div x-show="tab === 'cargar'" x-cloak>
+        {% include "construccion/_financiero_cargar_bd.html" %}
+    </div>
+    <div x-show="tab === 'tabla'" x-cloak class="space-y-6">
+        {% include "construccion/_financiero_presupuesto_tabla.html" %}
+    </div>
+</main>
+{% endblock %}


### PR DESCRIPTION
## Resumen
RUN-B del epic financiero vía /modulo. Duplica el módulo financiero mejorado (#120/#122, ya en main) al módulo de **Construcción**, reusando los indicadores que ya existían.

## Sub-features
- **B3 — 5 modelos** (`construccion_presupuesto_detallado`, `construccion_costos`, `construccion_costos_actividad`, `construccion_facturacion`, `construccion_indicador_ans`) + migración 0023 + admin. FK de costos → `ActividadFinalTorre` (no existe `ActividadConstruccion`; documentado). `IndicadorANSConstruccion.save()` clasifica estado espejo de `IndicadorANSContractual`.
- **B4 — 6 vistas** bajo `/construccion/<proyecto_id>/financiero/<subruta>/` (dashboard, presupuesto-planeado, presupuesto-real, nomina, costos, facturacion) + `ProyectoFinMixin` (gate submódulo `FINANCIERO`, ya registrado). Dashboard muestra los 6 KPIs (reusa `indicadores_finv2` de #122) + ANS de construcción.
- **B5 — 9 templates + 3 importers + 3 forms**. Importers reusan `ContableCompleteImporter` de #120. Templates consumen el context real de B4 (anti-template-vacío verificado).

## Verificación (F4, Docker + PostGIS real)
- `manage.py check` → 0 issues
- `migrate` → aplica 0023 OK
- **pytest 47/47 verde** (18 B3 + 11 B4 + 18 B5)
- (Nota: `makemigrations --check` marca un alter de `obraciviltorredetalle` que es **deuda pre-existente** del repo, ajeno a #123.)

## Reusos clave (sin recrear)
`IndicadorFinancieroConstruccion`/`IndicadorTecnicoConstruccion` (B2 previo), `calculators.py`, `importers_finv2`/`indicadores_finv2` (#120/#122).

## Limitación conocida (v1.0)
Los formularios de carga de Excel en construcción **renderizan** y los importers están listos y testeados, pero el **handler POST** que conecta el form → importer → save vive en `views_fin.py` y quedó como pieza de integración (ver GATE 2). El resto (dashboards, KPIs, ANS, costos, facturación, nómina) muestra datos reales.

## NO usar Closes
Refs #123. Se asigna al validador en closeout.

🤖 Generado vía /modulo (RUN-B).