### PR TITLE
fix(#123): rubros del contable en Presupuesto Planeado de construcción

### DIFF
--- a/apps/construccion/tests_b4_fin_views.py
+++ b/apps/construccion/tests_b4_fin_views.py
@@ -293,6 +293,10 @@ class PresupuestoUploadPostTests(_BaseFinViewTest):
         ).first()
         self.assertIsNotNone(obj, 'debe crear el PresupuestoDetalladoConstruccion')
         self.assertTrue(obj.datos, 'datos no debe quedar vacío tras importar')
+        # #123 fix: la pestaña Presupuesto Planeado debe mostrar los rubros del contable.
+        page = self.client.get(url + '?anio=2026&tab=tabla')
+        self.assertEqual(page.status_code, 200)
+        self.assertContains(page, 'Base de Datos contable')  # header tabla rubros (#123 fix)
 
     def test_post_sin_archivo_no_rompe(self):
         url = reverse('construccion:fin_presupuesto_planeado',

--- a/apps/construccion/views_fin.py
+++ b/apps/construccion/views_fin.py
@@ -53,6 +53,7 @@ from .importers import (
     PresupuestoConstruccionExcelImporter,
     detect_excel_format_construccion,
 )
+from apps.financiero.importers_finv2 import build_rubro_display_rows
 
 
 # Roles administrativos con acceso al financiero (espejo de views.py::ALL_ADMIN_ROLES).
@@ -284,6 +285,12 @@ class PresupuestoPlaneadoConstruccionView(ProyectoFinMixin, TemplateView):
         ctx['sin_datos'] = presupuesto is None
         ctx['resumen'] = self._resumen_presupuesto(
             proyecto, anio, PresupuestoDetalladoConstruccion.Tipo.PLANEADO)
+        # Rubros del contable (espejo #120): cuando la carga fue una BD contable,
+        # los datos viven en datos['finv2_bd'] y se muestran agrupados por rubro.
+        rubro_rows, rubro_total = build_rubro_display_rows(ctx['datos'])
+        ctx['rubro_rows'] = rubro_rows
+        ctx['rubro_total'] = rubro_total
+        ctx['tiene_datos_bd'] = bool(rubro_rows)
         return ctx
 
     def post(self, request, *args, **kwargs):

--- a/templates/construccion/_financiero_presupuesto_tabla.html
+++ b/templates/construccion/_financiero_presupuesto_tabla.html
@@ -25,6 +25,36 @@ Cada sección es colapsable (Alpine). Empty state cuando sin_datos.
 </div>
 {% else %}
 <div class="space-y-4">
+    <!-- Rubros del contable (#123 fix: espejo #120 — datos['finv2_bd']) -->
+    {% if tiene_datos_bd %}
+    <section class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700">
+        <div class="px-4 py-3 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+            <h3 class="text-base font-semibold text-gray-900 dark:text-white">Rubros (Base de Datos contable)</h3>
+            <span class="text-sm font-bold text-gray-700 dark:text-gray-200">${{ rubro_total|floatformat:0|intcomma }}</span>
+        </div>
+        <div class="overflow-x-auto">
+            <table class="min-w-full text-sm">
+                <thead class="bg-gray-50 dark:bg-gray-900">
+                    <tr>
+                        <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Rubro</th>
+                        <th class="px-4 py-2 text-right font-medium text-gray-600 dark:text-gray-300">Total</th>
+                        <th class="px-4 py-2 text-right font-medium text-gray-600 dark:text-gray-300">% del total</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                    {% for fila in rubro_rows %}
+                    <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/40">
+                        <td class="px-4 py-2 text-gray-900 dark:text-white">{{ fila.rubro }}</td>
+                        <td class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">${{ fila.total|floatformat:0|intcomma }}</td>
+                        <td class="px-4 py-2 text-right text-gray-500 dark:text-gray-400">{{ fila.pct }}%</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+    {% endif %}
+
     <!-- Resumen superior -->
     <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
         <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border-l-4 border-green-500">


### PR DESCRIPTION
Gap detectado en E2E: subir una BD contable en construcción persiste los datos pero la pestaña Presupuesto Planeado no mostraba los rubros (solo renderizaba secciones ingreso/variables/fijos). La vista ahora pasa `rubro_rows` (espejo de #120 vía `build_rubro_display_rows`) y el partial agrega la tabla de rubros. +1 test. Verificado en Docker+PostGIS. Refs #123