### PR TITLE
fix(#100): torres como T-{n} + orden numérico ascendente

### DIFF
--- a/apps/actividades/views.py
+++ b/apps/actividades/views.py
@@ -1104,7 +1104,7 @@ class BuscarAvisoSAPView(LoginRequiredMixin, View):
             'linea_id': str(actividad.linea_id),
             'linea_nombre': f"{actividad.linea.codigo} - {actividad.linea.nombre}",
             'torre_id': str(actividad.torre_id) if actividad.torre_id else '',
-            'torre_numero': actividad.torre.numero if actividad.torre else '',
+            'torre_numero': actividad.torre.numero_display if actividad.torre else '',
             'cuadrilla_id': str(actividad.cuadrilla_id) if actividad.cuadrilla_id else '',
             'orden_sap': actividad.orden_sap or '',
             'pt_sap': actividad.pt_sap or '',

--- a/apps/construccion/models.py
+++ b/apps/construccion/models.py
@@ -367,16 +367,30 @@ class TorreConstruccion(BaseModel):
         unique_together = [['proyecto', 'numero']]
         ordering = ['numero']
 
+    @property
+    def numero_display(self):
+        """Etiqueta normalizada de la estructura (#100): torres → T-{n},
+        postes → P-{n}, formatos no estándar intactos. Reusa la lógica de
+        ``apps.lineas.models.Torre.normalizar_numero``."""
+        from apps.lineas.models import Torre
+        return Torre.normalizar_numero(self.numero)
+
+    @property
+    def orden_numerico(self):
+        """Parte numérica de ``numero`` para orden ascendente (#100)."""
+        import re
+        m = re.search(r'\d+', self.numero or '')
+        return int(m.group()) if m else 10 ** 9
+
     def __str__(self):
-        # B1.1 — formato uniforme T{numero}. Para variantes con proyecto usar
-        # `codigo_display` (e.g. en exports, breadcrumbs cross-proyecto).
-        return f"T{self.numero}"
+        # #100 — etiqueta normalizada uniforme (T-{n} para torres).
+        return self.numero_display
 
     @property
     def codigo_display(self):
         """Variante con proyecto para casos donde se necesita desambiguar
         (e.g. listados cross-proyecto, exports a Excel)."""
-        return f"T{self.numero} ({self.proyecto.nombre})"
+        return f"{self.numero_display} ({self.proyecto.nombre})"
 
     # === Habilitación paralela por torre (#67) ===
     @property

--- a/apps/construccion/views.py
+++ b/apps/construccion/views.py
@@ -6,10 +6,24 @@ from django.views.generic import ListView, DetailView, CreateView, UpdateView, D
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse_lazy
 from django.shortcuts import get_object_or_404, redirect
-from django.db.models import Q
+from django.db.models import Q, IntegerField, Value, F, Func
+from django.db.models.functions import Cast, NullIf
 
 from apps.core.mixins import RoleRequiredMixin, SubModuloRequiredMixin
 from apps.contratos.models import Contrato
+
+
+def ordenar_torres_construccion(qs):
+    """Orden numérico ascendente por la parte numérica de ``numero`` (#100:
+    evita T-1, T-10, T-2). Formatos sin número quedan al final."""
+    return qs.annotate(
+        _solo_digitos=Func(
+            F('numero'), Value(r'[^0-9]'), Value(''), Value('g'),
+            function='regexp_replace',
+        ),
+    ).annotate(
+        _num_ord=Cast(NullIf(F('_solo_digitos'), Value('')), IntegerField()),
+    ).order_by(F('_num_ord').asc(nulls_last=True), 'numero')
 from .forms import (
     ContratoForm, PataObraForm, FaseTorreMontajeForm, FaseTorreTendidoForm,
     SocialPredialForm, AmbientalTorreForm,
@@ -89,7 +103,7 @@ class TorresListView(LoginRequiredMixin, RoleRequiredMixin, ListView):
         proyecto_id = self.kwargs.get('proyecto_id')
         qs = TorreConstruccion.objects.filter(proyecto_id=proyecto_id)
         qs = filtrar_torres_por_cuadrilla(qs, self.request.user)
-        return qs.order_by('numero')
+        return ordenar_torres_construccion(qs)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -173,7 +187,7 @@ class SeguimientoDiarioView(LoginRequiredMixin, RoleRequiredMixin, TemplateView)
         context = super().get_context_data(**kwargs)
         proyecto_id = self.kwargs.get('proyecto_id')
         proyecto = get_object_or_404(ProyectoConstruccion, id=proyecto_id)
-        torres = TorreConstruccion.objects.filter(proyecto=proyecto).order_by('numero')
+        torres = ordenar_torres_construccion(TorreConstruccion.objects.filter(proyecto=proyecto))
 
         context['proyecto'] = proyecto
         context['torres'] = torres
@@ -195,7 +209,7 @@ class SocialPredialView(LoginRequiredMixin, RoleRequiredMixin, TemplateView):
         ctx = super().get_context_data(**kwargs)
         proyecto = get_object_or_404(ProyectoConstruccion,
                                      id=self.kwargs['proyecto_id'])
-        torres = TorreConstruccion.objects.filter(proyecto=proyecto).order_by('numero')
+        torres = ordenar_torres_construccion(TorreConstruccion.objects.filter(proyecto=proyecto))
 
         filas = []
         verdes = 0
@@ -260,7 +274,7 @@ class AmbientalView(LoginRequiredMixin, RoleRequiredMixin, TemplateView):
         ctx = super().get_context_data(**kwargs)
         proyecto = get_object_or_404(ProyectoConstruccion,
                                      id=self.kwargs['proyecto_id'])
-        torres = TorreConstruccion.objects.filter(proyecto=proyecto).order_by('numero')
+        torres = ordenar_torres_construccion(TorreConstruccion.objects.filter(proyecto=proyecto))
 
         filas = []
         verdes = 0
@@ -1088,7 +1102,7 @@ class ObraCivilListView(LoginRequiredMixin, RoleRequiredMixin, TemplateView):
                                      id=self.kwargs['proyecto_id'])
         torres_qs = TorreConstruccion.objects.filter(proyecto=proyecto)
         torres_qs = filtrar_torres_por_cuadrilla(torres_qs, self.request.user)
-        torres_qs = torres_qs.prefetch_related('pata_obra').order_by('numero')
+        torres_qs = ordenar_torres_construccion(torres_qs.prefetch_related('pata_obra'))
 
         filas = []
         total_alarma = 0
@@ -1201,7 +1215,7 @@ class MontajeListView(LoginRequiredMixin, RoleRequiredMixin, TemplateView):
                                      id=self.kwargs['proyecto_id'])
         torres_qs = TorreConstruccion.objects.filter(proyecto=proyecto)
         torres_qs = filtrar_torres_por_cuadrilla(torres_qs, self.request.user)
-        torres_qs = torres_qs.select_related('fase').order_by('numero')
+        torres_qs = ordenar_torres_construccion(torres_qs.select_related('fase'))
 
         filas = []
         listas_para_tendido = 0
@@ -1278,7 +1292,7 @@ class TendidoListView(LoginRequiredMixin, RoleRequiredMixin, TemplateView):
                                      id=self.kwargs['proyecto_id'])
         torres_qs = TorreConstruccion.objects.filter(proyecto=proyecto)
         torres_qs = filtrar_torres_por_cuadrilla(torres_qs, self.request.user)
-        torres_qs = torres_qs.select_related('fase').order_by('numero')
+        torres_qs = ordenar_torres_construccion(torres_qs.select_related('fase'))
 
         filas = []
         habilitadas = 0
@@ -1363,7 +1377,7 @@ class ObraCivilMatrizView(LoginRequiredMixin, RoleRequiredMixin, TemplateView):
                                      id=self.kwargs['proyecto_id'])
         torres_qs = TorreConstruccion.objects.filter(proyecto=proyecto)
         torres_qs = filtrar_torres_por_cuadrilla(torres_qs, self.request.user)
-        torres_qs = torres_qs.select_related().order_by('numero')
+        torres_qs = ordenar_torres_construccion(torres_qs.select_related())
 
         # Asegurar OC para cada torre (crear si no existe — idempotente).
         existentes = {oc.torre_id: oc for oc in ObraCivilTorre.objects.filter(proyecto=proyecto)}
@@ -1481,7 +1495,7 @@ class MontajeMatrizView(LoginRequiredMixin, RoleRequiredMixin, TemplateView):
                                      id=self.kwargs['proyecto_id'])
         torres_qs = TorreConstruccion.objects.filter(proyecto=proyecto)
         torres_qs = filtrar_torres_por_cuadrilla(torres_qs, self.request.user)
-        torres_qs = torres_qs.select_related().order_by('numero')
+        torres_qs = ordenar_torres_construccion(torres_qs.select_related())
 
         existentes = {m.torre_id: m for m in
                       MontajeEstructuraTorre.objects.filter(proyecto=proyecto)}
@@ -1606,9 +1620,9 @@ class SPTPinturaIndexView(LoginRequiredMixin, RoleRequiredMixin, TemplateView):
         proyecto = get_object_or_404(ProyectoConstruccion, id=self.kwargs['proyecto_id'])
         torres_qs = TorreConstruccion.objects.filter(proyecto=proyecto)
         torres_qs = filtrar_torres_por_cuadrilla(torres_qs, self.request.user)
-        torres_qs = torres_qs.select_related().prefetch_related(
+        torres_qs = ordenar_torres_construccion(torres_qs.select_related().prefetch_related(
             'spt', 'pintura_patas', 'pintura_aeronautica__franjas',
-        ).order_by('numero')
+        ))
 
         filas = []
         for torre in torres_qs:
@@ -1668,7 +1682,7 @@ class SPTPinturaTorreView(LoginRequiredMixin, RoleRequiredMixin, TemplateView):
         franjas = list(aero.franjas.order_by('numero_franja'))
 
         # Navegación prev/next (por orden alfabético de numero)
-        torres = list(TorreConstruccion.objects.filter(proyecto=proyecto).order_by('numero'))
+        torres = list(ordenar_torres_construccion(TorreConstruccion.objects.filter(proyecto=proyecto)))
         idx = next((i for i, t in enumerate(torres) if t.id == torre.id), None)
         prev_t = torres[idx - 1] if idx is not None and idx > 0 else None
         next_t = torres[idx + 1] if idx is not None and idx < len(torres) - 1 else None
@@ -1846,7 +1860,7 @@ class TendidoMatrizView(LoginRequiredMixin, RoleRequiredMixin, TemplateView):
         proyecto = get_object_or_404(ProyectoConstruccion, id=self.kwargs['proyecto_id'])
         torres_qs = TorreConstruccion.objects.filter(proyecto=proyecto)
         torres_qs = filtrar_torres_por_cuadrilla(torres_qs, self.request.user)
-        torres_qs = torres_qs.select_related().order_by('numero')
+        torres_qs = ordenar_torres_construccion(torres_qs.select_related())
 
         existentes = {t.torre_id: t for t in TendidoTorre.objects.filter(proyecto=proyecto)}
         filas = []
@@ -2024,7 +2038,7 @@ class TrinchosCunetasListView(LoginRequiredMixin, RoleRequiredMixin, TemplateVie
         ctx.update({
             'proyecto': proyecto,
             'obras': obras,
-            'torres_disponibles': torres_qs.order_by('numero'),
+            'torres_disponibles': ordenar_torres_construccion(torres_qs),
             'total_metros': total_metros,
             'completadas': completadas,
             'por_cuadrilla': por_cuadrilla,

--- a/apps/lineas/models_base.py
+++ b/apps/lineas/models_base.py
@@ -1,6 +1,8 @@
 """
 Models for transmission lines, towers, and easements.
 """
+import re
+
 from django.contrib.gis.db import models as gis_models
 from django.db import models
 
@@ -325,16 +327,61 @@ class Torre(BaseModel):
         unique_together = ['linea', 'numero']
         ordering = ['linea', 'numero']
 
+    # Prefijos del campo `numero` que corresponden a TORRES (se renombran a T-{n}).
+    # 'P*' son postes (se preservan como P-{n}); el resto (pórticos, códigos
+    # especiales tipo PSAC / T-AUTO / texto libre) se dejan intactos.
+    _PREFIJOS_TORRE = ('', 'T', 'E')
+
+    @staticmethod
+    def normalizar_numero(numero):
+        """Normaliza el `numero` crudo a una etiqueta de display consistente.
+
+        Reglas (issue #100, feedback Sofi):
+        - Torres ('1', 'E-1', 'T-1', 'T15') → 'T-{n}' en formato uniforme.
+        - Postes ('P001', 'P-3') → 'P-{n}' (se preserva la semántica de poste).
+        - Otros prefijos de una letra con número ('F3') → '{LETRA}-{n}'.
+        - Formatos no estándar ('Pórtico Santamarta', 'T-AUTO', 'TN Planta…',
+          textos sin número limpio) → se devuelven tal cual.
+        """
+        raw = (numero or '').strip()
+        if not raw:
+            return raw
+        # prefijo de letras opcional + separador opcional + número, fin de cadena.
+        m = re.match(r'^([A-Za-z]+)?\s*-?\s*(\d+)$', raw)
+        if not m:
+            return raw  # no estándar → no tocar
+        prefijo = (m.group(1) or '').upper()
+        num = int(m.group(2))
+        if prefijo in Torre._PREFIJOS_TORRE:
+            return f'T-{num}'
+        if prefijo == 'P':
+            return f'P-{num}'
+        return f'{prefijo}-{num}'
+
+    @property
+    def numero_display(self):
+        """Etiqueta de la estructura para mostrar al usuario (#100)."""
+        return self.normalizar_numero(self.numero)
+
+    @property
+    def orden_numerico(self):
+        """Parte numérica de `numero` para ordenamiento ascendente (#100).
+
+        Devuelve un entero grande si no hay número, para que los formatos
+        no estándar queden al final sin romper el sort.
+        """
+        m = re.search(r'\d+', self.numero or '')
+        return int(m.group()) if m else 10 ** 9
+
     def __str__(self):
-        # B1.1 — formato uniforme T{numero}. Para variantes con línea usar
-        # `codigo_display` (e.g. en exports o detalle cuando se requiere desambiguar).
-        return f"T{self.numero}"
+        # #100 — etiqueta normalizada uniforme (T-{n} para torres).
+        return self.numero_display
 
     @property
     def codigo_display(self):
         """Variante con línea para casos donde se necesita desambiguar
         (e.g. listados cross-línea, exports a Excel, breadcrumbs)."""
-        return f"T{self.numero} ({self.linea.codigo})"
+        return f"{self.numero_display} ({self.linea.codigo})"
 
     def save(self, *args, **kwargs):
         # Auto-generate geometry from lat/lon

--- a/apps/lineas/tests/test_100_numero.py
+++ b/apps/lineas/tests/test_100_numero.py
@@ -1,0 +1,96 @@
+"""
+Tests #100 — Renombre/normalización de torres a T-{n} + orden numérico.
+
+Cubre:
+- Torre.normalizar_numero / numero_display (torres → T-{n}, postes → P-{n},
+  formatos no estándar preservados).
+- Orden numérico ascendente (E-1, E-2, ..., E-10) vía ordenar_torres_num.
+- Dato legacy preservado.
+- TorreConstruccion.numero_display reusa la misma lógica.
+
+Ejecutar:  pytest apps/lineas/tests/test_100_numero.py -v
+"""
+import pytest
+
+from apps.lineas.models import Linea, Torre
+from apps.lineas.views import ordenar_torres_num
+
+
+CASOS_NORM = [
+    ('E-1', 'T-1'),
+    ('E-10', 'T-10'),
+    ('1', 'T-1'),
+    ('T15', 'T-15'),
+    ('T-1', 'T-1'),
+    ('P001', 'P-1'),
+    ('P-3', 'P-3'),
+    ('Pórtico Santamarta', 'Pórtico Santamarta'),
+    ('T-AUTO', 'T-AUTO'),
+    ('F3', 'F-3'),
+    ('', ''),
+]
+
+
+@pytest.mark.parametrize('crudo,esperado', CASOS_NORM)
+def test_normalizar_numero(crudo, esperado):
+    assert Torre.normalizar_numero(crudo) == esperado
+
+
+def _linea():
+    return Linea.objects.create(codigo='LN-T100', nombre='LN T100', cliente='TRANSELCA')
+
+
+def _torre(linea, numero):
+    return Torre.objects.create(linea=linea, numero=numero, latitud=10, longitud=-74)
+
+
+@pytest.mark.django_db
+def test_numero_display_property():
+    linea = _linea()
+    assert _torre(linea, 'E-1').numero_display == 'T-1'
+    assert _torre(linea, 'P010').numero_display == 'P-10'
+    assert str(_torre(linea, '5')) == 'T-5'
+
+
+@pytest.mark.django_db
+def test_orden_numerico_ascendente():
+    linea = _linea()
+    for n in ['E-1', 'E-10', 'E-2', 'E-21', 'E-3']:
+        _torre(linea, n)
+    ordenadas = list(ordenar_torres_num(Torre.objects.filter(linea=linea)))
+    nums = [t.numero for t in ordenadas]
+    # Debe quedar 1, 2, 3, 10, 21 (numérico), NO 1, 10, 2, 21, 3 (alfabético).
+    assert nums == ['E-1', 'E-2', 'E-3', 'E-10', 'E-21']
+    # Y se muestran como T-1..T-21.
+    assert [t.numero_display for t in ordenadas] == ['T-1', 'T-2', 'T-3', 'T-10', 'T-21']
+
+
+@pytest.mark.django_db
+def test_orden_no_estandar_al_final():
+    linea = _linea()
+    _torre(linea, 'Pórtico Santamarta')  # sin número → al final
+    _torre(linea, '7')
+    _torre(linea, '3')
+    nums = [t.numero for t in ordenar_torres_num(Torre.objects.filter(linea=linea))]
+    assert nums == ['3', '7', 'Pórtico Santamarta']
+
+
+@pytest.mark.django_db
+def test_dato_legacy_preservado():
+    """Un poste legacy 'P001' sigue siendo poste (P-1), no se convierte en torre."""
+    linea = _linea()
+    poste = _torre(linea, 'P001')
+    poste.refresh_from_db()
+    assert poste.numero == 'P001'           # dato crudo intacto
+    assert poste.numero_display == 'P-1'     # display de poste, NO 'T-1'
+
+
+@pytest.mark.django_db
+def test_torre_construccion_numero_display():
+    from apps.contratos.models import Contrato
+    from apps.construccion.models import ProyectoConstruccion, TorreConstruccion
+    contrato = Contrato.objects.create(codigo='C-T100', nombre='C T100', unidad_negocio='CONSTRUCCION')
+    proyecto = ProyectoConstruccion.objects.create(contrato=contrato, nombre='Proy T100')
+    t = TorreConstruccion.objects.create(proyecto=proyecto, numero='E-7')
+    assert t.numero_display == 'T-7'
+    assert str(t) == 'T-7'

--- a/apps/lineas/views.py
+++ b/apps/lineas/views.py
@@ -11,6 +11,8 @@ from django.views import View
 from django.views.generic import ListView, DetailView, TemplateView
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import JsonResponse
+from django.db.models import IntegerField, Value, F, Func
+from django.db.models.functions import Cast, NullIf
 from django.views.decorators.http import require_http_methods
 from django.utils.decorators import method_decorator
 import json
@@ -18,6 +20,20 @@ from apps.core.mixins import HTMXMixin, RoleRequiredMixin
 from .models import Linea, Torre, Vano
 
 logger = logging.getLogger(__name__)
+
+
+def ordenar_torres_num(qs):
+    """Ordena torres por la parte numérica de ``numero`` (ascendente), no
+    alfabéticamente (#100: evita E-1, E-10, E-2). Los formatos sin número
+    quedan al final. Postgres-only (usa ``regexp_replace``)."""
+    return qs.annotate(
+        _solo_digitos=Func(
+            F('numero'), Value(r'[^0-9]'), Value(''), Value('g'),
+            function='regexp_replace',
+        ),
+    ).annotate(
+        _num_ord=Cast(NullIf(F('_solo_digitos'), Value('')), IntegerField()),
+    ).order_by(F('_num_ord').asc(nulls_last=True), 'numero')
 
 
 class LineaListView(LoginRequiredMixin, RoleRequiredMixin, HTMXMixin, ListView):
@@ -59,7 +75,7 @@ class LineaDetailView(LoginRequiredMixin, RoleRequiredMixin, HTMXMixin, DetailVi
     def get_context_data(self, **kwargs):
         import json
         context = super().get_context_data(**kwargs)
-        context['torres'] = self.object.torres.all()
+        context['torres'] = ordenar_torres_num(self.object.torres.all())
         context['total_torres'] = self.object.torres.count()
         if self.object.kmz_geojson:
             context['kmz_geojson_json'] = json.dumps(self.object.kmz_geojson)
@@ -178,7 +194,7 @@ class TorresLineaView(LoginRequiredMixin, RoleRequiredMixin, HTMXMixin, ListView
     allowed_roles = ['admin', 'director', 'coordinador', 'ing_residente', 'ing_ambiental', 'supervisor', 'liniero']
 
     def get_queryset(self):
-        return Torre.objects.filter(linea_id=self.kwargs['pk']).order_by('numero')
+        return ordenar_torres_num(Torre.objects.filter(linea_id=self.kwargs['pk']))
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/templates/actividades/detalle.html
+++ b/templates/actividades/detalle.html
@@ -14,7 +14,7 @@
             </a>
             <div>
                 <h1 class="text-2xl font-bold text-gray-900 dark:text-white">{{ actividad.tipo_actividad.nombre }}</h1>
-                <p class="text-gray-600 dark:text-gray-400">Torre {{ actividad.torre.numero }} - {{ actividad.linea.codigo }}</p>
+                <p class="text-gray-600 dark:text-gray-400">{{ actividad.torre.numero_display }} - {{ actividad.linea.codigo }}</p>
             </div>
         </div>
         <div class="flex gap-2">
@@ -134,7 +134,7 @@
                     <dt class="text-sm text-gray-500 dark:text-gray-400">Torre</dt>
                     <dd>
                         <a href="{% url 'lineas:torre_detalle' actividad.torre.id %}" class="text-blue-600 hover:text-blue-800">
-                            {{ actividad.torre.numero }}
+                            {{ actividad.torre.numero_display }}
                         </a>
                     </dd>
                 </div>

--- a/templates/actividades/editar.html
+++ b/templates/actividades/editar.html
@@ -13,7 +13,7 @@
         </a>
         <div>
             <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Editar Actividad</h1>
-            <p class="text-gray-600 dark:text-gray-400">{{ actividad.tipo_actividad.nombre }} - Torre {{ actividad.torre.numero }}</p>
+            <p class="text-gray-600 dark:text-gray-400">{{ actividad.tipo_actividad.nombre }} - {{ actividad.torre.numero_display }}</p>
         </div>
     </div>
 

--- a/templates/actividades/partials/detalle_actividad.html
+++ b/templates/actividades/partials/detalle_actividad.html
@@ -5,7 +5,7 @@
         <h4 id="ubicacion-heading" class="text-sm font-medium text-gray-500 dark:text-gray-400 mb-2">Ubicacion</h4>
         <div class="bg-gray-50 dark:bg-gray-700 rounded-lg p-3">
             <p class="text-sm"><strong>Linea:</strong> {{ actividad.linea.nombre }}</p>
-            <p class="text-sm"><strong>Torre:</strong> {{ actividad.torre.numero }} ({{ actividad.torre.get_tipo_display }})</p>
+            <p class="text-sm"><strong>Torre:</strong> {{ actividad.torre.numero_display }} ({{ actividad.torre.get_tipo_display }})</p>
             <p class="text-sm"><strong>Coordenadas:</strong> {{ actividad.torre.latitud }}, {{ actividad.torre.longitud }}</p>
             {% if actividad.torre.altitud %}
             <p class="text-sm"><strong>Altitud:</strong> {{ actividad.torre.altitud }} m</p>

--- a/templates/actividades/partials/detalle_modal.html
+++ b/templates/actividades/partials/detalle_modal.html
@@ -4,7 +4,7 @@
     <div class="flex justify-between items-start">
         <div>
             <h3 class="text-lg font-bold text-gray-900 dark:text-white">
-                Torre {{ actividad.torre.numero }}
+                {{ actividad.torre.numero_display }}
             </h3>
             <p class="text-sm text-gray-500 dark:text-gray-400">
                 {{ actividad.linea.codigo }} - {{ actividad.linea.nombre }}

--- a/templates/actividades/partials/lista_actividades.html
+++ b/templates/actividades/partials/lista_actividades.html
@@ -62,7 +62,7 @@
                 <div>
                     <div class="flex items-center gap-2">
                         <h3 id="actividad-titulo-{{ actividad.id }}" class="font-medium text-gray-900 dark:text-white">
-                            Torre {{ actividad.torre.numero }}
+                            {{ actividad.torre.numero_display }}
                         </h3>
                         <span class="text-sm text-gray-500">{{ actividad.linea.codigo }}</span>
                         {% if actividad.aviso_sap %}

--- a/templates/actividades/partials/modal_restricciones.html
+++ b/templates/actividades/partials/modal_restricciones.html
@@ -13,7 +13,7 @@
             </div>
 
             <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
-                Torre {{ actividad.torre.numero }} - {{ actividad.linea.codigo }} | {{ actividad.tipo_actividad.nombre }}
+                {{ actividad.torre.numero_display }} - {{ actividad.linea.codigo }} | {{ actividad.tipo_actividad.nombre }}
             </p>
 
             <form hx-post="{% url 'actividades:editar_restricciones' actividad.id %}"

--- a/templates/actividades/programacion.html
+++ b/templates/actividades/programacion.html
@@ -327,7 +327,7 @@
                             {{ actividad.linea.codigo }}
                         </td>
                         <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-900 dark:text-white">
-                            {{ actividad.torre.numero }}
+                            {{ actividad.torre.numero_display }}
                         </td>
                         <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400 font-mono">
                             {{ actividad.orden_sap|default:"-" }}

--- a/templates/ambiental/consolidado.html
+++ b/templates/ambiental/consolidado.html
@@ -181,7 +181,7 @@
                             </a>
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap font-medium text-gray-900 dark:text-white">
-                            {{ registro.actividad.torre.numero }}
+                            {{ registro.actividad.torre.numero_display }}
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400">
                             {% with datos=registro.datos_formulario %}

--- a/templates/ambiental/detalle.html
+++ b/templates/ambiental/detalle.html
@@ -165,7 +165,7 @@
                     {% for actividad in actividades %}
                     <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
                         <td class="px-6 py-4 whitespace-nowrap font-medium text-gray-900 dark:text-white">
-                            {{ actividad.torre.numero }}
+                            {{ actividad.torre.numero_display }}
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap text-gray-600 dark:text-gray-400">
                             {{ actividad.tipo_actividad.nombre }}

--- a/templates/ambiental/permisos.html
+++ b/templates/ambiental/permisos.html
@@ -75,7 +75,7 @@
                     <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
                         <td class="px-6 py-4 whitespace-nowrap">
                             <div>
-                                <span class="font-medium text-gray-900 dark:text-white">{{ permiso.torre.numero }}</span>
+                                <span class="font-medium text-gray-900 dark:text-white">{{ permiso.torre.numero_display }}</span>
                                 <span class="text-sm text-gray-500 block">{{ permiso.torre.linea.codigo }}</span>
                             </div>
                         </td>

--- a/templates/campo/avances_lista.html
+++ b/templates/campo/avances_lista.html
@@ -99,7 +99,7 @@
                         {{ avance.fecha_avance|date:"d/m/Y H:i" }}
                     </td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
-                        {{ avance.linea.codigo }} / Torre {{ avance.torre.numero }}
+                        {{ avance.linea.codigo }} / {{ avance.torre.numero_display }}
                     </td>
                     {% if not request.user.is_campo %}
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">

--- a/templates/campo/detalle.html
+++ b/templates/campo/detalle.html
@@ -14,7 +14,7 @@
         <div class="flex-1">
             <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Registro de Campo</h1>
             <p class="text-gray-600 dark:text-gray-400">
-                {{ registro.actividad.tipo_actividad.nombre }} - Torre {{ registro.actividad.torre.numero }}
+                {{ registro.actividad.tipo_actividad.nombre }} - {{ registro.actividad.torre.numero_display }}
             </p>
         </div>
         <div>
@@ -43,7 +43,7 @@
                     </div>
                     <div>
                         <p class="text-gray-500 dark:text-gray-400">Torre</p>
-                        <p class="font-medium text-gray-900 dark:text-white">{{ registro.actividad.torre.numero }} ({{ registro.actividad.torre.get_tipo_display }})</p>
+                        <p class="font-medium text-gray-900 dark:text-white">{{ registro.actividad.torre.numero_display }} ({{ registro.actividad.torre.get_tipo_display }})</p>
                     </div>
                     <div>
                         <p class="text-gray-500 dark:text-gray-400">Tipo de Actividad</p>

--- a/templates/campo/detalle_dano.html
+++ b/templates/campo/detalle_dano.html
@@ -92,7 +92,7 @@
                     {% if reporte.torre %}
                     <div>
                         <p class="text-gray-500 dark:text-gray-400">Torre</p>
-                        <p class="font-medium text-gray-900 dark:text-white">{{ reporte.torre.numero }}</p>
+                        <p class="font-medium text-gray-900 dark:text-white">{{ reporte.torre.numero_display }}</p>
                     </div>
                     {% endif %}
                 </div>

--- a/templates/campo/evidencias.html
+++ b/templates/campo/evidencias.html
@@ -16,7 +16,7 @@
             <div>
                 <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Evidencias Fotograficas</h1>
                 <p class="text-gray-600 dark:text-gray-400">
-                    {{ registro.actividad.tipo_actividad.nombre }} - Torre {{ registro.actividad.torre.numero }}
+                    {{ registro.actividad.tipo_actividad.nombre }} - {{ registro.actividad.torre.numero_display }}
                 </p>
             </div>
         </div>

--- a/templates/campo/lista.html
+++ b/templates/campo/lista.html
@@ -106,7 +106,7 @@
                         {{ registro.actividad.tipo_actividad.nombre|default:"-" }}
                     </td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
-                        {{ registro.actividad.linea.codigo|default:"-" }} / {{ registro.actividad.torre.numero|default:"-" }}
+                        {{ registro.actividad.linea.codigo|default:"-" }} / {{ registro.actividad.torre.numero_display|default:"-"  }}
                     </td>
                     {% if not request.user.is_campo %}
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">

--- a/templates/campo/lista_danos.html
+++ b/templates/campo/lista_danos.html
@@ -154,7 +154,7 @@
                     </td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                         {% if reporte.linea %}{{ reporte.linea.codigo }}{% endif %}
-                        {% if reporte.torre %} / T{{ reporte.torre.numero }}{% endif %}
+                        {% if reporte.torre %} / {{ reporte.torre.numero_display }}{% endif %}
                         {% if not reporte.linea and not reporte.torre %}-{% endif %}
                     </td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">

--- a/templates/campo/partials/avances_lista.html
+++ b/templates/campo/partials/avances_lista.html
@@ -35,7 +35,7 @@
                     {{ avance.fecha_avance|date:"d/m/Y H:i" }}
                 </td>
                 <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
-                    {{ avance.linea.codigo }} / Torre {{ avance.torre.numero }}
+                    {{ avance.linea.codigo }} / {{ avance.torre.numero_display }}
                 </td>
                 {% if not request.user.is_campo %}
                 <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">

--- a/templates/campo/partials/confirmar_vano.html
+++ b/templates/campo/partials/confirmar_vano.html
@@ -22,7 +22,7 @@
                 </p>
                 <div class="bg-gray-50 dark:bg-gray-700 rounded-lg p-3 text-sm">
                     <p class="text-gray-600 dark:text-gray-400">
-                        <strong>Vano:</strong> Torre {{ vano.torre_inicio.numero }} → Torre {{ vano.torre_fin.numero }}
+                        <strong>Vano:</strong> {{ vano.torre_inicio.numero_display }} → {{ vano.torre_fin.numero_display }}
                     </p>
                 </div>
             </div>

--- a/templates/campo/partials/form_registro.html
+++ b/templates/campo/partials/form_registro.html
@@ -32,7 +32,7 @@
             <option value="{{ actividad.id }}"
                     data-linea="{{ actividad.linea.id }}"
                     {% if actividad_seleccionada == actividad.id|stringformat:"s" %}selected{% endif %}>
-                {{ actividad.tipo_actividad.nombre }} - Torre {{ actividad.torre.numero }} ({{ actividad.linea.codigo }})
+                {{ actividad.tipo_actividad.nombre }} - {{ actividad.torre.numero_display }} ({{ actividad.linea.codigo }})
             </option>
             {% endfor %}
         </select>

--- a/templates/campo/partials/lista_registros.html
+++ b/templates/campo/partials/lista_registros.html
@@ -29,7 +29,7 @@
                             {{ registro.actividad.tipo_actividad.nombre|truncatechars:30 }}
                         </div>
                         <div class="text-xs text-gray-500">
-                            {{ registro.actividad.linea.codigo }} - Torre {{ registro.actividad.torre.numero }}
+                            {{ registro.actividad.linea.codigo }} - {{ registro.actividad.torre.numero_display }}
                         </div>
                     </td>
                     <td class="px-4 py-3 whitespace-nowrap">

--- a/templates/campo/partials/vano_item.html
+++ b/templates/campo/partials/vano_item.html
@@ -9,7 +9,7 @@
             <div class="flex items-center gap-3 mb-2">
                 <span class="text-lg font-bold text-gray-900 dark:text-white">Vano #{{ vano.numero_vano }}</span>
                 <span class="text-sm text-gray-600 dark:text-gray-400">
-                    Torre {{ vano.torre_inicio.numero }} → Torre {{ vano.torre_fin.numero }}
+                    {{ vano.torre_inicio.numero_display }} → {{ vano.torre_fin.numero_display }}
                 </span>
 
                 <!-- Badge de estado -->

--- a/templates/construccion/_actividades_finales_row.html
+++ b/templates/construccion/_actividades_finales_row.html
@@ -8,7 +8,7 @@ Reemplazado por HTMX tras un toggle. Refresca celdas + % avance + badge.
     class="hover:bg-gray-50 dark:hover:bg-gray-700/40 border-t border-gray-200 dark:border-gray-700">
     {# Columna A: Estructura #}
     <th class="px-3 py-2 text-left text-sm font-medium text-gray-900 dark:text-gray-100 sticky left-0 bg-white dark:bg-gray-800 z-10 whitespace-nowrap">
-        <span class="font-semibold">T{{ fila.torre.numero }}</span>
+        <span class="font-semibold">T{{ fila.torre.numero_display }}</span>
         {% if fila.torre.tipo %}<span class="ml-1 text-xs text-gray-500">{{ fila.torre.tipo }}</span>{% endif %}
     </th>
 
@@ -22,7 +22,7 @@ Reemplazado por HTMX tras un toggle. Refresca celdas + % avance + badge.
                 hx-swap="outerHTML"
                 hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
                 hx-on::after-request="if(event.detail.failed){ var det=event.detail.xhr.responseText; var t=document.getElementById('actividades-finales-toast'); if(t){t.innerHTML=det; t.classList.remove('hidden');} }"
-                aria-label="Toggle {{ celda.label }} de T{{ fila.torre.numero }}"
+                aria-label="Toggle {{ celda.label }} de T{{ fila.torre.numero_display }}"
                 class="w-9 h-7 rounded text-xs font-bold transition-colors
                        {% if celda.valor %}
                          bg-green-500 hover:bg-green-600 text-white

--- a/templates/construccion/ambiental.html
+++ b/templates/construccion/ambiental.html
@@ -42,7 +42,7 @@
       <tbody>
         {% for f in filas %}
         <tr class="border-t border-gray-100 dark:border-gray-700">
-          <td class="px-3 py-2 font-medium">{{ f.torre.numero }}</td>
+          <td class="px-3 py-2 font-medium">{{ f.torre.numero_display }}</td>
           <td class="px-3 py-2 text-center">
             {% if not f.ambiental.ahuyentamiento_aplica %}<span class="text-gray-400 text-xs">n/a</span>
             {% elif f.ambiental.ahuyentamiento_fecha %}<span class="text-green-600">✓</span>

--- a/templates/construccion/ambiental_torre.html
+++ b/templates/construccion/ambiental_torre.html
@@ -1,10 +1,10 @@
 {% extends 'base.html' %}
-{% block title %}Ambiental — Torre {{ torre.numero }}{% endblock %}
+{% block title %}Ambiental — {{ torre.numero_display }}{% endblock %}
 {% block content %}
 <div class="space-y-6">
   <div class="flex items-center justify-between">
     <div>
-      <h1 class="text-2xl font-bold">🌳 Ambiental — Torre {{ torre.numero }}</h1>
+      <h1 class="text-2xl font-bold">🌳 Ambiental — {{ torre.numero_display }}</h1>
       <p class="text-sm text-gray-500">
         {{ proyecto.nombre }} ·
         {% if ambiental.semaforo == 'VERDE' %}

--- a/templates/construccion/cilindros_pendientes.html
+++ b/templates/construccion/cilindros_pendientes.html
@@ -24,7 +24,7 @@
       <tbody>
         {% for p in pendientes %}
         <tr class="border-t border-gray-100 dark:border-gray-700">
-          <td class="px-4 py-2 font-medium">{{ p.pata.torre.numero }}</td>
+          <td class="px-4 py-2 font-medium">{{ p.pata.torre.numero_display }}</td>
           <td class="px-4 py-2">Pata {{ p.pata.pata }}</td>
           <td class="px-4 py-2">{{ p.pata.vaciado_fecha|date:"d/m/Y" }}</td>
           <td class="px-4 py-2">
@@ -56,7 +56,7 @@
       <tbody>
         {% for p in proximos %}
         <tr class="border-t border-gray-100 dark:border-gray-700">
-          <td class="px-4 py-2 font-medium">{{ p.pata.torre.numero }}</td>
+          <td class="px-4 py-2 font-medium">{{ p.pata.torre.numero_display }}</td>
           <td class="px-4 py-2">Pata {{ p.pata.pata }}</td>
           <td class="px-4 py-2">
             {% for n, faltan in p.proximos %}

--- a/templates/construccion/montaje_detalle.html
+++ b/templates/construccion/montaje_detalle.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load l10n %}
 
-{% block title %}Montaje · T{{ torre.numero }} — {{ proyecto.nombre }}{% endblock %}
+{% block title %}Montaje · T{{ torre.numero_display }} — {{ proyecto.nombre }}{% endblock %}
 
 {% block content %}
 {% localize off %}
@@ -14,10 +14,10 @@
         <a href="{% url 'construccion:montaje_lista' proyecto_id=proyecto.id %}"
            class="hover:text-blue-600">Montaje (resumen)</a>
         <span aria-hidden="true">/</span>
-        <span class="text-gray-700 font-medium">Torre {{ torre.numero }}</span>
+        <span class="text-gray-700 font-medium">{{ torre.numero_display }}</span>
       </div>
       <h1 class="mt-1 text-2xl font-bold text-gray-900">
-        Montaje · Torre {{ torre.numero }}
+        Montaje · {{ torre.numero_display }}
       </h1>
       <p class="text-sm text-gray-500 mt-0.5">
         Proyecto: <span class="font-medium">{{ proyecto.nombre }}</span>

--- a/templates/construccion/montaje_lista.html
+++ b/templates/construccion/montaje_lista.html
@@ -50,7 +50,7 @@
       <tbody>
         {% for f in filas %}
         <tr class="border-t border-gray-100 dark:border-gray-700 {% if not f.oc_completa %}opacity-60{% endif %}">
-          <td class="px-3 py-2 font-medium">{{ f.torre.numero }}</td>
+          <td class="px-3 py-2 font-medium">{{ f.torre.numero_display }}</td>
           <td class="px-3 py-2 text-xs">{{ f.fase.get_funcion_torre_display|default:"—" }}</td>
           <td class="px-3 py-2 text-xs">{{ f.fase.cuadrilla_montaje|default:"—" }}</td>
           <td class="px-3 py-2 text-center">

--- a/templates/construccion/montaje_matriz.html
+++ b/templates/construccion/montaje_matriz.html
@@ -108,7 +108,7 @@ Los avances de las 4 etapas son READ-ONLY: vienen del cache
             <td class="px-3 py-2 font-medium text-gray-900 sticky left-0 bg-white z-10">
               <a href="{% url 'construccion:montaje_detalle' proyecto_id=proyecto.id torre_id=fila.torre.id %}?seccion=montaje"
                  class="hover:text-blue-600">
-                {{ fila.torre.numero }}
+                {{ fila.torre.numero_display }}
               </a>
             </td>
             {% for slug, _label in columnas %}

--- a/templates/construccion/montaje_torre.html
+++ b/templates/construccion/montaje_torre.html
@@ -1,10 +1,10 @@
 {% extends 'base.html' %}
-{% block title %}Montaje — Torre {{ torre.numero }}{% endblock %}
+{% block title %}Montaje — {{ torre.numero_display }}{% endblock %}
 {% block content %}
 <div class="space-y-6">
   <div class="flex items-center justify-between">
     <div>
-      <h1 class="text-2xl font-bold">🔩 Montaje — Torre {{ torre.numero }}</h1>
+      <h1 class="text-2xl font-bold">🔩 Montaje — {{ torre.numero_display }}</h1>
       <p class="text-sm text-gray-500">{{ proyecto.nombre }} · % Montaje: <span class="font-semibold">{{ fase.porcentaje_montaje }}%</span></p>
     </div>
     <a href="{% url 'construccion:montaje_lista' proyecto.id %}" class="text-sm text-blue-600 hover:underline">← Volver a lista</a>

--- a/templates/construccion/obra_civil_detalle.html
+++ b/templates/construccion/obra_civil_detalle.html
@@ -15,7 +15,7 @@
   Pata + sección activos vienen por query params `?pata=A&seccion=excavacion`.
 {% endcomment %}
 
-{% block title %}Obra Civil — T{{ torre.numero }} — {{ proyecto.nombre }}{% endblock %}
+{% block title %}Obra Civil — T{{ torre.numero_display }} — {{ proyecto.nombre }}{% endblock %}
 
 {% block content %}
 {% localize off %}
@@ -38,7 +38,7 @@
     </a>
     <div class="flex-1">
       <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
-        Obra Civil — Torre Nº {{ torre.numero }}
+        Obra Civil — Torre Nº {{ torre.numero_display }}
       </h1>
       <p class="text-sm text-gray-500 dark:text-gray-400">
         Proyecto: <span class="font-medium">{{ proyecto.nombre }}</span>

--- a/templates/construccion/obra_civil_lista.html
+++ b/templates/construccion/obra_civil_lista.html
@@ -45,7 +45,7 @@
         {% for f in filas %}
         <tr class="border-t border-gray-100 dark:border-gray-700
                    {% if f.alarma_materiales %}bg-red-50 dark:bg-red-900/20{% endif %}">
-          <td class="px-4 py-2 font-medium">{{ f.torre.numero }}</td>
+          <td class="px-4 py-2 font-medium">{{ f.torre.numero_display }}</td>
           <td class="px-4 py-2 text-xs text-gray-600 dark:text-gray-300">{{ f.torre.cuadrilla_civil|default:"—" }}</td>
           <td class="px-4 py-2 text-right">
             <span class="font-semibold">{{ f.avance }}%</span>

--- a/templates/construccion/obra_civil_matriz.html
+++ b/templates/construccion/obra_civil_matriz.html
@@ -131,7 +131,7 @@
                                 <a href="{% url 'construccion:obra_civil_detalle' proyecto_id=proyecto.id torre_id=torre.id %}?pata=A&seccion=cerramiento"
                                    class="hover:text-blue-600 dark:hover:text-blue-400"
                                    title="Abrir detalle por pata × sección">
-                                    {{ torre.numero }}
+                                    {{ torre.numero_display }}
                                 </a>
                             </td>
                             <td class="px-3 py-1 text-center"><a class="block px-2 py-1 rounded hover:bg-blue-50 dark:hover:bg-blue-900/20 text-gray-900 dark:text-white" href="{% url 'construccion:obra_civil_detalle' proyecto_id=proyecto.id torre_id=torre.id %}?pata=A&seccion=cerramiento" data-celda="cerramiento" data-torre="{{ torre.id }}">{{ oc.avance_cerramiento|unlocalize|floatformat:2 }}</a></td>
@@ -150,7 +150,7 @@
                                 <a href="{% url 'construccion:obra_civil_detalle' proyecto_id=proyecto.id torre_id=torre.id %}?pata=A&seccion=cerramiento"
                                    class="hover:text-blue-600 dark:hover:text-blue-400"
                                    title="Abrir detalle por pata × sección">
-                                    {{ torre.numero }}
+                                    {{ torre.numero_display }}
                                 </a>
                             </td>
                             <td class="px-3 py-1 text-center"><a class="block px-2 py-1 rounded hover:bg-blue-50 dark:hover:bg-blue-900/20 text-gray-900 dark:text-white" href="{% url 'construccion:obra_civil_detalle' proyecto_id=proyecto.id torre_id=torre.id %}?pata=A&seccion=cerramiento" data-celda="cerramiento" data-torre="{{ torre.id }}">{{ oc.avance_cerramiento|unlocalize|floatformat:2 }}</a></td>

--- a/templates/construccion/obra_civil_torre.html
+++ b/templates/construccion/obra_civil_torre.html
@@ -1,10 +1,10 @@
 {% extends 'base.html' %}
-{% block title %}Obra civil — Torre {{ torre.numero }}{% endblock %}
+{% block title %}Obra civil — {{ torre.numero_display }}{% endblock %}
 {% block content %}
 <div class="space-y-6">
   <div class="flex items-center justify-between">
     <div>
-      <h1 class="text-2xl font-bold">🏗️ Obra civil — Torre {{ torre.numero }}</h1>
+      <h1 class="text-2xl font-bold">🏗️ Obra civil — {{ torre.numero_display }}</h1>
       <p class="text-sm text-gray-500">
         {{ proyecto.nombre }} ·
         {% if torre.obra_civil_completa %}

--- a/templates/construccion/planillas/_base.html
+++ b/templates/construccion/planillas/_base.html
@@ -27,7 +27,7 @@ section h2 { background: #ddd; padding: 4px 6px; font-size: 11pt; margin-top: 6m
   <div class="codigo">Código: <strong>{{ codigo_ft }}</strong> · Módulo: {{ modulo }}</div>
   <div class="proyecto">
     <strong>Proyecto:</strong> {{ proyecto.nombre }} · <strong>Contrato:</strong> {{ contrato.codigo }}<br>
-    <strong>Torre:</strong> {{ torre.numero }}
+    <strong>Torre:</strong> {{ torre.numero_display }}
   </div>
 </header>
 

--- a/templates/construccion/protecciones_lista.html
+++ b/templates/construccion/protecciones_lista.html
@@ -27,7 +27,7 @@
       <tbody>
         {% for p in protecciones %}
         <tr class="border-t border-gray-100 dark:border-gray-700">
-          <td class="px-4 py-2 font-medium">{{ p.torre.numero }}</td>
+          <td class="px-4 py-2 font-medium">{{ p.torre.numero_display }}</td>
           <td class="px-4 py-2 text-xs">{{ p.tipos_medida }}</td>
           <td class="px-4 py-2 text-right">{{ p.metros_trinchos|default:"—" }}</td>
           <td class="px-4 py-2 text-right">{{ p.metros_cunetas|default:"—" }}</td>

--- a/templates/construccion/social_predial.html
+++ b/templates/construccion/social_predial.html
@@ -42,7 +42,7 @@
       <tbody>
         {% for f in filas %}
         <tr class="border-t border-gray-100 dark:border-gray-700">
-          <td class="px-3 py-2 font-medium">{{ f.torre.numero }}</td>
+          <td class="px-3 py-2 font-medium">{{ f.torre.numero_display }}</td>
           <td class="px-3 py-2">{{ f.social.predio|default:"—" }}</td>
           <td class="px-3 py-2">{{ f.social.propietario|default:"—" }}</td>
           <td class="px-3 py-2">{{ f.social.municipio|default:"—" }}</td>

--- a/templates/construccion/social_predial_torre.html
+++ b/templates/construccion/social_predial_torre.html
@@ -1,10 +1,10 @@
 {% extends 'base.html' %}
-{% block title %}Sociopredial — Torre {{ torre.numero }}{% endblock %}
+{% block title %}Sociopredial — {{ torre.numero_display }}{% endblock %}
 {% block content %}
 <div class="space-y-6">
   <div class="flex items-center justify-between">
     <div>
-      <h1 class="text-2xl font-bold">🏘️ Sociopredial — Torre {{ torre.numero }}</h1>
+      <h1 class="text-2xl font-bold">🏘️ Sociopredial — {{ torre.numero_display }}</h1>
       <p class="text-sm text-gray-500">
         {{ proyecto.nombre }} ·
         {% if social.semaforo == 'VERDE' %}

--- a/templates/construccion/spt_pintura_index.html
+++ b/templates/construccion/spt_pintura_index.html
@@ -30,7 +30,7 @@
                 <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
                     {% for fila in filas %}
                     <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
-                        <td class="px-3 py-2 font-medium text-gray-900 dark:text-white">{{ fila.torre.numero }}</td>
+                        <td class="px-3 py-2 font-medium text-gray-900 dark:text-white">{{ fila.torre.numero_display }}</td>
                         <td class="px-3 py-2 text-center"
                             class="{% if fila.spt_pct >= 75 %}text-green-600{% elif fila.spt_pct >= 50 %}text-amber-600{% else %}text-red-600{% endif %}">
                             {{ fila.spt_pct }}%

--- a/templates/construccion/spt_pintura_torre.html
+++ b/templates/construccion/spt_pintura_torre.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static l10n %}
 
-{% block title %}SPT y Pintura — Torre {{ torre.numero }}{% endblock %}
+{% block title %}SPT y Pintura — {{ torre.numero_display }}{% endblock %}
 
 {% block content %}
 {% localize off %}
@@ -14,7 +14,7 @@
     <!-- Header con navegación -->
     <div class="flex items-center justify-between gap-4">
         <div class="flex-1">
-            <h1 class="text-2xl font-bold text-gray-900 dark:text-white">🔌⚡ SPT y Pintura — Torre {{ torre.numero }}</h1>
+            <h1 class="text-2xl font-bold text-gray-900 dark:text-white">🔌⚡ SPT y Pintura — {{ torre.numero_display }}</h1>
             <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
                 Proyecto: <span class="font-medium">{{ proyecto.nombre }}</span>
                 · Posición: <span class="font-medium">{{ posicion }} / {{ total_torres }}</span>
@@ -23,13 +23,13 @@
         <div class="flex items-center gap-2">
             {% if prev_torre %}
             <a href="{% url 'construccion:spt_pintura_torre' proyecto_id=proyecto.id torre_id=prev_torre.id %}"
-               class="px-3 py-1.5 rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-sm">← {{ prev_torre.numero }}</a>
+               class="px-3 py-1.5 rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-sm">← {{ prev_torre.numero_display }}</a>
             {% endif %}
             <a href="{% url 'construccion:spt_pintura' proyecto_id=proyecto.id %}"
                class="px-3 py-1.5 rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-sm">Lista</a>
             {% if next_torre %}
             <a href="{% url 'construccion:spt_pintura_torre' proyecto_id=proyecto.id torre_id=next_torre.id %}"
-               class="px-3 py-1.5 rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-sm">{{ next_torre.numero }} →</a>
+               class="px-3 py-1.5 rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-sm">{{ next_torre.numero_display }} →</a>
             {% endif %}
         </div>
     </div>

--- a/templates/construccion/tendido_lista.html
+++ b/templates/construccion/tendido_lista.html
@@ -51,7 +51,7 @@
       <tbody>
         {% for f in filas %}
         <tr class="border-t border-gray-100 dark:border-gray-700 {% if not f.puede_iniciar %}opacity-50{% endif %}">
-          <td class="px-2 py-2 font-medium">{{ f.torre.numero }}</td>
+          <td class="px-2 py-2 font-medium">{{ f.torre.numero_display }}</td>
           <td class="px-2 py-2">{{ f.torre.tramo_tendido|default:"—" }}</td>
           <td class="px-2 py-2">{{ f.fase.cuadrilla_tendido|default:"—" }}</td>
           <td class="px-2 py-2 text-center">{% if f.fase.vestida_torres_ok %}<span class="text-green-600">✓</span>{% else %}—{% endif %}</td>

--- a/templates/construccion/tendido_matriz.html
+++ b/templates/construccion/tendido_matriz.html
@@ -148,7 +148,7 @@
                             empalmes_opgw: {% if fila.empalmes_opgw %}true{% else %}false{% endif %}
                         })'
                         class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
-                        <td class="px-2 py-1 font-medium sticky left-0 bg-white dark:bg-gray-800 z-10">{{ fila.torre.numero }}</td>
+                        <td class="px-2 py-1 font-medium sticky left-0 bg-white dark:bg-gray-800 z-10">{{ fila.torre.numero_display }}</td>
                         <td class="px-2 py-1 text-center text-gray-600 dark:text-gray-400">{{ fila.funcion|slice:":3" }}</td>
                         <td class="px-1 py-1 text-center"><input type="checkbox" :checked="campos.vestida_conductor" @change="toggle('vestida_conductor', $event.target.checked)"></td>
                         {% for slug, _ in columnas_conductor %}

--- a/templates/construccion/tendido_torre.html
+++ b/templates/construccion/tendido_torre.html
@@ -1,10 +1,10 @@
 {% extends 'base.html' %}
-{% block title %}Tendido — Torre {{ torre.numero }}{% endblock %}
+{% block title %}Tendido — {{ torre.numero_display }}{% endblock %}
 {% block content %}
 <div class="space-y-6">
   <div class="flex items-center justify-between">
     <div>
-      <h1 class="text-2xl font-bold">⚡ Tendido — Torre {{ torre.numero }}</h1>
+      <h1 class="text-2xl font-bold">⚡ Tendido — {{ torre.numero_display }}</h1>
       <p class="text-sm text-gray-500">{{ proyecto.nombre }} · % Tendido: <span class="font-semibold">{{ fase.porcentaje_tendido }}%</span></p>
     </div>
     <a href="{% url 'construccion:tendido_lista' proyecto.id %}" class="text-sm text-blue-600 hover:underline">← Volver a lista</a>

--- a/templates/construccion/torres_list.html
+++ b/templates/construccion/torres_list.html
@@ -39,7 +39,7 @@
             <tbody class="divide-y divide-gray-200 dark:divide-gray-600">
                 {% for torre in torres %}
                 <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
-                    <td class="px-6 py-4 text-sm text-gray-900 dark:text-white font-medium">{{ torre.numero }}</td>
+                    <td class="px-6 py-4 text-sm text-gray-900 dark:text-white font-medium">{{ torre.numero_display }}</td>
                     <td class="px-6 py-4 text-sm text-gray-600 dark:text-gray-400">{{ torre.tipo|default:"-" }}</td>
                     <td class="px-6 py-4 text-sm text-gray-600 dark:text-gray-400">{{ torre.get_tipo_cimentacion_display|default:"-" }}</td>
                     <td class="px-6 py-4 text-sm text-gray-600 dark:text-gray-400">{{ torre.peso_kg|floatformat:0|default:"-" }}</td>

--- a/templates/construccion/trinchos_cunetas_lista.html
+++ b/templates/construccion/trinchos_cunetas_lista.html
@@ -122,7 +122,7 @@
                 <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
                     {% for o in obras %}
                     <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50">
-                        <td class="px-3 py-2 font-medium">{{ o.torre.numero }}</td>
+                        <td class="px-3 py-2 font-medium">{{ o.torre.numero_display }}</td>
                         <td class="px-3 py-2 text-center">{{ o.get_medida_manejo_display }}</td>
                         <td class="px-3 py-2 text-right">{{ o.metros_trinchos|default:"—" }}</td>
                         <td class="px-3 py-2 text-right">{{ o.metros_cunetas|default:"—" }}</td>

--- a/templates/financiero/cuadro_costos.html
+++ b/templates/financiero/cuadro_costos.html
@@ -96,7 +96,7 @@
                             {{ ejecucion.fecha|date:"d/m/Y" }}
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap font-medium text-gray-900 dark:text-white">
-                            {% if ejecucion.actividad %}{{ ejecucion.actividad.torre.numero }}{% else %}-{% endif %}
+                            {% if ejecucion.actividad %}{{ ejecucion.actividad.torre.numero_display }}{% else %}-{% endif %}
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap text-gray-600 dark:text-gray-400">
                             {% if ejecucion.actividad %}{{ ejecucion.actividad.tipo_actividad.nombre }}{% else %}-{% endif %}

--- a/templates/financiero/presupuesto_detalle.html
+++ b/templates/financiero/presupuesto_detalle.html
@@ -226,7 +226,7 @@
                         <td class="px-6 py-4 whitespace-nowrap text-gray-600 dark:text-gray-400">
                             {% if ejecucion.actividad %}
                             <a href="{% url 'actividades:detalle' ejecucion.actividad.id %}" class="text-blue-600 hover:text-blue-800">
-                                Torre {{ ejecucion.actividad.torre.numero }}
+                                {{ ejecucion.actividad.torre.numero_display }}
                             </a>
                             {% else %}
                             -

--- a/templates/indicadores/dashboard.html
+++ b/templates/indicadores/dashboard.html
@@ -182,7 +182,7 @@
                                 {% elif act.estado == 'EN_CURSO' %}bg-yellow-500
                                 {% else %}bg-gray-400{% endif %}"
                                 aria-hidden="true"></span>
-                            <span class="text-gray-600 dark:text-gray-400">{{ act.torre.numero }}</span>
+                            <span class="text-gray-600 dark:text-gray-400">{{ act.torre.numero_display }}</span>
                             <span class="sr-only">
                                 {% if act.estado == 'COMPLETADA' %}completada
                                 {% elif act.estado == 'EN_CURSO' %}en curso

--- a/templates/lineas/avance.html
+++ b/templates/lineas/avance.html
@@ -69,7 +69,7 @@
                         <td class="px-6 py-3 whitespace-nowrap">
                             <a href="{% url 'lineas:torre_detalle' fila.torre.pk %}"
                                class="font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400">
-                                T{{ fila.torre.numero }}
+                                {{ fila.torre.numero_display }}
                             </a>
                         </td>
                         <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">

--- a/templates/lineas/avance_campo.html
+++ b/templates/lineas/avance_campo.html
@@ -80,7 +80,7 @@
                                 <svg class="w-4 h-4 text-gray-400 transition-transform" id="chevron-{{ fila.torre.id }}" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
                                 </svg>
-                                T{{ fila.torre.numero }}
+                                {{ fila.torre.numero_display }}
                             </div>
                         </td>
                         <td class="px-6 py-3 text-center text-sm text-gray-900 dark:text-white">

--- a/templates/lineas/detalle.html
+++ b/templates/lineas/detalle.html
@@ -292,7 +292,7 @@
                     {% for torre in torres %}
                     <tr class="hover:bg-gray-50 dark:hover:bg-gray-700 edit-row-detail" data-torre-id="{{ torre.id }}">
                         <td class="px-6 py-4 whitespace-nowrap font-medium text-gray-900 dark:text-white">
-                            {{ torre.numero }}
+                            {{ torre.numero_display }}
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap text-gray-600 dark:text-gray-400">
                             {{ torre.get_tipo_display }}

--- a/templates/lineas/hoja_de_vida.html
+++ b/templates/lineas/hoja_de_vida.html
@@ -107,9 +107,9 @@
                     {% if e.usuario %}<span>👤 {{ e.usuario.get_full_name|default:e.usuario }}</span>{% endif %}
                     {% if e.cuadrilla %}<span>🛠 {{ e.cuadrilla }}</span>{% endif %}
                     {% if e.torre_inicio and e.torre_fin %}
-                        <span>📍 {{ e.torre_inicio.numero }} → {{ e.torre_fin.numero }}</span>
+                        <span>📍 {{ e.torre_inicio.numero_display }} → {{ e.torre_fin.numero_display }}</span>
                     {% elif e.torre_inicio %}
-                        <span>📍 Torre {{ e.torre_inicio.numero }}</span>
+                        <span>📍 {{ e.torre_inicio.numero_display }}</span>
                     {% endif %}
                 </div>
             </li>

--- a/templates/lineas/mapa.html
+++ b/templates/lineas/mapa.html
@@ -119,8 +119,8 @@
                             role="button"
                             tabindex="0"
                             onkeypress="if(event.key==='Enter') focusTower({{ torre.latitud }}, {{ torre.longitud }})"
-                            aria-label="Enfocar torre {{ torre.numero }} en el mapa">
-                            <td class="px-4 py-2 font-medium">{{ torre.numero }}</td>
+                            aria-label="Enfocar torre {{ torre.numero_display }} en el mapa">
+                            <td class="px-4 py-2 font-medium">{{ torre.numero_display }}</td>
                             <td class="px-4 py-2 text-sm text-gray-600">{{ torre.get_tipo_display }}</td>
                             <td class="px-4 py-2 text-sm text-gray-600">{{ torre.latitud }}, {{ torre.longitud }}</td>
                             <td class="px-4 py-2 text-sm text-gray-600">{{ torre.altitud|default:"-" }} m</td>

--- a/templates/lineas/partials/detalle_linea.html
+++ b/templates/lineas/partials/detalle_linea.html
@@ -96,7 +96,7 @@
                 <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
                     {% for torre in linea.torres.all %}
                     <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
-                        <td class="px-4 py-3 text-sm text-gray-900 dark:text-white">{{ torre.numero }}</td>
+                        <td class="px-4 py-3 text-sm text-gray-900 dark:text-white">{{ torre.numero_display }}</td>
                         <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{{ torre.get_tipo_display }}</td>
                         <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{{ torre.observaciones|default:"-" }}</td>
                         <td class="px-4 py-3 text-right text-sm flex justify-end gap-2">

--- a/templates/lineas/partials/detalle_torre.html
+++ b/templates/lineas/partials/detalle_torre.html
@@ -6,7 +6,7 @@
             <dl class="space-y-3">
                 <div>
                     <dt class="text-sm text-gray-500 dark:text-gray-400">Numero</dt>
-                    <dd class="font-medium text-gray-900 dark:text-white">{{ torre.numero }}</dd>
+                    <dd class="font-medium text-gray-900 dark:text-white">{{ torre.numero_display }}</dd>
                 </div>
                 <div>
                     <dt class="text-sm text-gray-500 dark:text-gray-400">Linea</dt>

--- a/templates/lineas/partials/lista_torres.html
+++ b/templates/lineas/partials/lista_torres.html
@@ -13,7 +13,7 @@
         {% for torre in torres %}
         <tr class="hover:bg-gray-50 dark:hover:bg-gray-700 edit-row" data-torre-id="{{ torre.id }}">
             <td class="px-6 py-4 whitespace-nowrap">
-                <span class="font-medium text-gray-900 dark:text-white">{{ torre.numero }}</span>
+                <span class="font-medium text-gray-900 dark:text-white">{{ torre.numero_display }}</span>
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-gray-600 dark:text-gray-400">
                 {{ torre.get_tipo_display }}

--- a/templates/lineas/torre_detalle.html
+++ b/templates/lineas/torre_detalle.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {# B1.1 — formato uniforme T{numero} #}
-{% block title %}T{{ torre.numero }} - TransMaint{% endblock %}
+{% block title %}{{ torre.numero_display }} - TransMaint{% endblock %}
 
 {% block content %}
 <div class="space-y-6">
@@ -14,7 +14,7 @@
                 </svg>
             </a>
             <div>
-                <h1 class="text-2xl font-bold text-gray-900 dark:text-white">T{{ torre.numero }}</h1>
+                <h1 class="text-2xl font-bold text-gray-900 dark:text-white">{{ torre.numero_display }}</h1>
                 <p class="text-gray-600 dark:text-gray-400">{{ torre.linea.codigo }} - {{ torre.linea.nombre }}</p>
             </div>
         </div>
@@ -35,7 +35,7 @@
             <dl class="space-y-3">
                 <div>
                     <dt class="text-sm text-gray-500 dark:text-gray-400">Numero</dt>
-                    <dd class="font-medium text-gray-900 dark:text-white">{{ torre.numero }}</dd>
+                    <dd class="font-medium text-gray-900 dark:text-white">{{ torre.numero_display }}</dd>
                 </div>
                 <div>
                     <dt class="text-sm text-gray-500 dark:text-gray-400">Linea</dt>

--- a/templates/lineas/torres.html
+++ b/templates/lineas/torres.html
@@ -100,7 +100,7 @@
                     {% for torre in torres %}
                     <tr class="hover:bg-gray-50 dark:hover:bg-gray-700 edit-row" data-torre-id="{{ torre.id }}">
                         <td class="px-6 py-4 whitespace-nowrap">
-                            <span class="font-medium text-gray-900 dark:text-white">{{ torre.numero }}</span>
+                            <span class="font-medium text-gray-900 dark:text-white">{{ torre.numero_display }}</span>
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap text-gray-600 dark:text-gray-400">
                             {{ torre.get_tipo_display }}


### PR DESCRIPTION
Feedback de Sofi: las torres mostraban 'E-1' y en orden alfabético (E-1, E-10, E-2).

**Causa raíz:** el campo `numero` es texto libre con formatos mezclados (T15, P001, E-1, 1...); los templates renderizaban `{{ torre.numero }}` crudo y el orden era alfabético sobre el CharField.

**Fix:**
- `numero_display` en `Torre` y `TorreConstruccion`: normaliza a **T-{n}** (torres), **P-{n}** (postes), preservando pórticos/no estándar.
- **Orden numérico ascendente** (regexp_replace + Cast) en las vistas de torres de líneas y construcción.
- **57 templates** actualizados a `numero_display` (todos los módulos).
- Sin migraciones (solo métodos). 16 tests verdes en PostGIS.

Refs #100