### PR TITLE
fix(#130): fechas del detalle de montaje no se guardaban (render ISO en input type=date)

### DIFF
--- a/apps/construccion/forms_b3_mont_detalle.py
+++ b/apps/construccion/forms_b3_mont_detalle.py
@@ -63,7 +63,7 @@ class MontSeccionRecepcionForm(forms.ModelForm):
             'recepcion_observaciones',
         ]
         widgets = {
-            'fecha_recibida_patio': forms.DateInput(attrs={
+            'fecha_recibida_patio': forms.DateInput(format='%Y-%m-%d', attrs={
                 'type': 'date',
                 'class': 'block w-full rounded-md border-gray-300 shadow-sm '
                          'focus:border-blue-500 focus:ring-blue-500 sm:text-sm',
@@ -104,12 +104,12 @@ class MontSeccionPrearmadoForm(forms.ModelForm):
                 'class': 'h-4 w-4 rounded border-gray-300 text-blue-600 '
                          'focus:ring-blue-500',
             }),
-            'prearmado_fecha_inicio': forms.DateInput(attrs={
+            'prearmado_fecha_inicio': forms.DateInput(format='%Y-%m-%d', attrs={
                 'type': 'date',
                 'class': 'block w-full rounded-md border-gray-300 shadow-sm '
                          'focus:border-blue-500 focus:ring-blue-500 sm:text-sm',
             }),
-            'prearmado_fecha_fin': forms.DateInput(attrs={
+            'prearmado_fecha_fin': forms.DateInput(format='%Y-%m-%d', attrs={
                 'type': 'date',
                 'class': 'block w-full rounded-md border-gray-300 shadow-sm '
                          'focus:border-blue-500 focus:ring-blue-500 sm:text-sm',
@@ -159,12 +159,12 @@ class MontSeccionMontajeForm(forms.ModelForm):
                 'class': 'block w-full rounded-md border-gray-300 shadow-sm '
                          'focus:border-blue-500 focus:ring-blue-500 sm:text-sm',
             }),
-            'montaje_fecha_inicio': forms.DateInput(attrs={
+            'montaje_fecha_inicio': forms.DateInput(format='%Y-%m-%d', attrs={
                 'type': 'date',
                 'class': 'block w-full rounded-md border-gray-300 shadow-sm '
                          'focus:border-blue-500 focus:ring-blue-500 sm:text-sm',
             }),
-            'montaje_fecha_fin': forms.DateInput(attrs={
+            'montaje_fecha_fin': forms.DateInput(format='%Y-%m-%d', attrs={
                 'type': 'date',
                 'class': 'block w-full rounded-md border-gray-300 shadow-sm '
                          'focus:border-blue-500 focus:ring-blue-500 sm:text-sm',

--- a/apps/construccion/tests_b3_mont_detalle_views.py
+++ b/apps/construccion/tests_b3_mont_detalle_views.py
@@ -412,3 +412,75 @@ def test_post_montaje_fechas_faltantes_dias_none(
     assert r.status_code == 200
     data = r.json()
     assert data['dias_montaje'] is None
+
+
+# ===========================================================================
+# REGRESION #130 - "No guarda fechas en bloque de montaje"
+# ===========================================================================
+# Causa raiz: los DateInput de forms_b3_mont_detalle.py no fijaban
+# format='%Y-%m-%d'. Con LANGUAGE_CODE='es-co' el value se renderizaba como
+# "dd/mm/yyyy", formato que <input type="date"> descarta silenciosamente ->
+# el campo queda vacio al recargar -> el cliente percibe "no guarda".
+# El POST si persistia (HTML5 siempre envia ISO); el bug era de RE-RENDER.
+
+@pytest.mark.django_db
+def test_montaje_fechas_render_iso_al_recargar(
+    authenticated_client, proyecto_b3b, torre_b3b
+):
+    """Tras guardar una fecha, el detalle debe re-renderizar el value en
+    formato ISO (YYYY-MM-DD), NO localizado (dd/mm/yyyy). El segundo es
+    rechazado por el navegador y deja el campo vacio (#130)."""
+    save_url = reverse('construccion:montaje_detalle_save', kwargs={
+        'proyecto_id': proyecto_b3b.id,
+        'torre_id': torre_b3b.id,
+        'seccion': 'montaje',
+    })
+    r = authenticated_client.post(save_url, {
+        'montaje_encargado': 'Ana',
+        'montaje_fecha_inicio': '2026-05-10',
+        'montaje_fecha_fin': '2026-05-17',
+        'montaje_observaciones': '',
+    })
+    assert r.status_code == 200, r.content
+
+    # Recargar el detalle (journey real del cliente: guardar -> recargar).
+    detalle_url = reverse('construccion:montaje_detalle', kwargs={
+        'proyecto_id': proyecto_b3b.id,
+        'torre_id': torre_b3b.id,
+    }) + '?seccion=montaje'
+    g = authenticated_client.get(detalle_url)
+    assert g.status_code == 200
+    html = g.content.decode()
+
+    # ISO presente (el navegador lo acepta) ...
+    assert 'value="2026-05-10"' in html
+    assert 'value="2026-05-17"' in html
+    # ... y el formato localizado NO debe aparecer (causaba el campo vacio).
+    assert 'value="10/05/2026"' not in html
+    assert 'value="17/05/2026"' not in html
+
+
+@pytest.mark.django_db
+def test_montaje_widgets_fecha_format_iso(db):
+    """Todos los DateInput del detalle de montaje fijan format='%Y-%m-%d'.
+    Guard estructural: evita la regresion #130 si alguien edita los forms."""
+    from apps.construccion.forms_b3_mont_detalle import (
+        MontSeccionRecepcionForm,
+        MontSeccionPrearmadoForm,
+        MontSeccionMontajeForm,
+    )
+    from django import forms as djforms
+
+    campos_fecha = [
+        (MontSeccionRecepcionForm, 'fecha_recibida_patio'),
+        (MontSeccionPrearmadoForm, 'prearmado_fecha_inicio'),
+        (MontSeccionPrearmadoForm, 'prearmado_fecha_fin'),
+        (MontSeccionMontajeForm, 'montaje_fecha_inicio'),
+        (MontSeccionMontajeForm, 'montaje_fecha_fin'),
+    ]
+    for form_cls, campo in campos_fecha:
+        widget = form_cls().fields[campo].widget
+        assert isinstance(widget, djforms.DateInput)
+        assert '%Y-%m-%d' in widget.format, (
+            f'{form_cls.__name__}.{campo} debe fijar format=%Y-%m-%d (#130)'
+        )


### PR DESCRIPTION
Cierra parcialmente #130.

## Causa raíz
Los `DateInput` de `apps/construccion/forms_b3_mont_detalle.py` no fijaban `format='%Y-%m-%d'`. Con `LANGUAGE_CODE='es-co'` el locale fuerza `DATE_INPUT_FORMATS[0]='%d/%m/%Y'`, por lo que al recargar el detalle el widget renderizaba `value="dd/mm/yyyy"`. Un `<input type="date">` **solo** acepta `YYYY-MM-DD` y descarta silenciosamente ese valor → el campo aparece vacío → el cliente lo percibe como "no guarda las fechas".

El POST sí persistía (HTML5 siempre envía ISO); el bug era de **re-render**. El `{% localize off %}` del template no corrige esto porque el `format_value` del widget ocurre en Python e ignora el flag del template.

El resto del módulo construcción (`forms.py`, `forms_b2_indicadores.py`) ya usaba `format='%Y-%m-%d'`; este archivo B3 era el único que lo omitió.

## Fix
- `format='%Y-%m-%d'` en los 5 `DateInput` del detalle de montaje (recepción, pre-armado inicio/fin, montaje inicio/fin).

## Tests
- `test_montaje_fechas_render_iso_al_recargar` — journey real: guardar → recargar → assert `value="2026-05-10"` presente y `value="10/05/2026"` ausente.
- `test_montaje_widgets_fecha_format_iso` — guard estructural sobre los 5 widgets.
- Verde local (los fallos `regexp_replace` son función Postgres del view resumen, solo bajo SQLite; ajenos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)