### PR TITLE
fix(#101): materializar filas Vano desde cantidad_vanos (grid de Registrar Avances vacío)

### DIFF
--- a/SPRINTS/PLAN_2026-06-06_issue101_vanos.md
+++ b/SPRINTS/PLAN_2026-06-06_issue101_vanos.md
@@ -1,0 +1,29 @@
+# Plan #101 — Vanos no cargan en Registrar Avances (re-apertura Sofi 2026-06-06)
+
+## Causa raíz (confirmada)
+- `lineas.cantidad_vanos` es un **contador metadato** (PositiveIntegerField). Editarlo
+  (acción AJAX `actualizar_vanos` en `LineaDetailView.post`) NO crea filas `Vano`.
+- La grilla de Registrar Avances (`RegistroAvanceCreateView`) se construye de filas
+  `Vano` reales (tabla `vanos`). LN5114: `cantidad_vanos=100`, 104 torres, **0 vanos** →
+  "No hay vanos registrados".
+- Los PRs #106/#107/#108 arreglaron el 500 (UUID, `ignore missing`, rol admin_general)
+  pero el gap real era que nunca se materializan los vanos.
+- Bonus: el check de permiso de `actualizar_vanos` excluye `admin_general`/`ing_residente`
+  (RBAC v2) → esos roles reciben 403.
+
+## Decisión (Miguel → "qué recomiendas" → Opción A)
+Materializar vanos desde el contador, idempotente y NO destructivo.
+
+## Pasos
+1. `Linea.sincronizar_vanos(cantidad)` en `models_base.py` — crea Vano `1..N` faltantes,
+   nunca borra, tope 5000. [prioridad 1]
+2. `LineaDetailView.post` (`actualizar_vanos`): llamar sincronizar + JSON con creados/total
+   + ampliar roles a admin_general/ing_residente. [prioridad 1, dep 1]
+3. `RegistroAvanceCreateView._build_context`: ordenar vanos numéricamente (evita 1,10,100,11). [prioridad 2]
+4. Tests: idempotencia, no-destructivo, cap, integración POST. [prioridad 1, dep 1-2]
+5. Deploy → smoke: re-guardar 100 en LN5114 vía endpoint (materializa la línea real +
+   valida) → grid muestra 100 casillas. Cleanup NO (es el dato que el cliente quiere). [dep 4]
+6. Comentario a Sofi + assignee validador.
+
+## Bloqueos
+- Ninguno. BD prod accesible vía proxy 5433.

--- a/apps/campo/views.py
+++ b/apps/campo/views.py
@@ -816,8 +816,14 @@ class RegistroAvanceCreateView(LoginRequiredMixin, RoleRequiredMixin, TemplateVi
         )
 
         # Materializar para reusar y para que ``{% if vanos %}`` del template
-        # no dispare un COUNT(*) adicional.
-        vanos_list = list(vanos)
+        # no dispare un COUNT(*) adicional. Orden numérico real: ``numero`` es
+        # CharField, así que ``order_by('numero')`` daría 1,10,100,11... — se
+        # reordena en Python para que la grilla vaya 1,2,...,100 (#101).
+        vanos_list = sorted(
+            vanos,
+            key=lambda v: (0, int(v.numero)) if (v.numero or '').isdigit()
+            else (1, v.numero or ''),
+        )
 
         context['linea'] = linea
         context['vanos'] = vanos_list

--- a/apps/lineas/models_base.py
+++ b/apps/lineas/models_base.py
@@ -207,6 +207,39 @@ class Linea(BaseModel):
             return (self.cantidad_torres or 0) + (self.cantidad_postes or 0)
         return self.cantidad_torres or 0
 
+    # Tope defensivo: evita que un número tecleado por error (ej. 100000)
+    # genere una avalancha de filas Vano. #101.
+    MAX_VANOS_AUTOGENERADOS = 5000
+
+    def sincronizar_vanos(self, cantidad):
+        """Materializa filas ``Vano`` numeradas ``1..cantidad`` para esta línea.
+
+        Idempotente y NO destructivo: crea solo los vanos faltantes y nunca
+        borra los existentes (que pueden tener estado/pendientes registrados).
+        Devuelve la cantidad de vanos efectivamente creados.
+
+        Resuelve #101: ``cantidad_vanos`` era solo un contador y no
+        materializaba los registros que la grilla de Registrar Avances
+        necesita, por lo que la grilla salía vacía pese a "tener 100 vanos".
+        """
+        try:
+            n = int(cantidad)
+        except (TypeError, ValueError):
+            return 0
+        if n <= 0:
+            return 0
+        n = min(n, self.MAX_VANOS_AUTOGENERADOS)
+
+        existentes = set(self.vanos.values_list('numero', flat=True))
+        nuevos = [
+            Vano(linea=self, numero=str(i))
+            for i in range(1, n + 1)
+            if str(i) not in existentes
+        ]
+        if nuevos:
+            Vano.objects.bulk_create(nuevos, batch_size=500, ignore_conflicts=True)
+        return len(nuevos)
+
 
 class Torre(BaseModel):
     """

--- a/apps/lineas/tests_vanos_sync.py
+++ b/apps/lineas/tests_vanos_sync.py
@@ -1,0 +1,128 @@
+"""#101 — Tests para la materialización de Vanos desde ``cantidad_vanos``.
+
+Causa raíz del re-reporte (Sofi 2026-06-06): ``cantidad_vanos`` era un contador
+metadato; editarlo NO creaba filas ``Vano``, así que la grilla de Registrar
+Avances salía vacía pese a "tener 100 vanos". Fix: ``Linea.sincronizar_vanos``
++ llamada en el handler AJAX ``actualizar_vanos``.
+
+Cubre:
+- crea vanos 1..N
+- idempotencia (no duplica al re-sincronizar)
+- NO destructivo (preserva vanos con estado/datos)
+- tope MAX_VANOS_AUTOGENERADOS
+- entradas inválidas / <=0 → 0
+- integración POST actualizar_vanos (crea vanos + JSON) y rol admin_general permitido
+"""
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+
+from apps.lineas.models import Linea, Vano
+
+User = get_user_model()
+
+
+def _linea(codigo='L-101', cantidad_vanos=None):
+    return Linea.objects.create(
+        codigo=codigo,
+        nombre='Test 101',
+        cliente=Linea.Cliente.TRANSELCA,
+        cantidad_vanos=cantidad_vanos,
+    )
+
+
+class TestSincronizarVanos(TestCase):
+    def test_crea_1_a_n(self):
+        linea = _linea()
+        creados = linea.sincronizar_vanos(100)
+        self.assertEqual(creados, 100)
+        self.assertEqual(linea.vanos.count(), 100)
+        numeros = set(linea.vanos.values_list('numero', flat=True))
+        self.assertIn('1', numeros)
+        self.assertIn('100', numeros)
+        self.assertNotIn('101', numeros)
+
+    def test_idempotente(self):
+        linea = _linea()
+        self.assertEqual(linea.sincronizar_vanos(50), 50)
+        # Segunda corrida: nada nuevo, sin duplicados (unique_together linea,numero)
+        self.assertEqual(linea.sincronizar_vanos(50), 0)
+        self.assertEqual(linea.vanos.count(), 50)
+
+    def test_ampliar_solo_crea_faltantes(self):
+        linea = _linea()
+        linea.sincronizar_vanos(10)
+        creados = linea.sincronizar_vanos(15)
+        self.assertEqual(creados, 5)
+        self.assertEqual(linea.vanos.count(), 15)
+
+    def test_no_destructivo_preserva_estado(self):
+        linea = _linea()
+        linea.sincronizar_vanos(10)
+        v = linea.vanos.get(numero='3')
+        v.estado = Vano.Estado.EJECUTADO
+        v.save(update_fields=['estado'])
+        # Reducir el contador no debe borrar nada (no destructivo)
+        creados = linea.sincronizar_vanos(5)
+        self.assertEqual(creados, 0)
+        self.assertEqual(linea.vanos.count(), 10)
+        self.assertEqual(linea.vanos.get(numero='3').estado, Vano.Estado.EJECUTADO)
+
+    def test_cap_max(self):
+        linea = _linea()
+        creados = linea.sincronizar_vanos(Linea.MAX_VANOS_AUTOGENERADOS + 500)
+        self.assertEqual(creados, Linea.MAX_VANOS_AUTOGENERADOS)
+        self.assertEqual(linea.vanos.count(), Linea.MAX_VANOS_AUTOGENERADOS)
+
+    def test_invalidos_devuelven_cero(self):
+        linea = _linea()
+        for v in (0, -5, None, 'abc'):
+            self.assertEqual(linea.sincronizar_vanos(v), 0)
+        self.assertEqual(linea.vanos.count(), 0)
+
+
+class TestActualizarVanosEndpoint(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin = User.objects.create_user(
+            email='admin@101.test', password='x', rol='admin',
+            is_superuser=True, is_staff=True,
+        )
+        cls.admin_general = User.objects.create_user(
+            email='ag@101.test', password='x', rol='admin_general',
+        )
+        cls.liniero = User.objects.create_user(
+            email='lin@101.test', password='x', rol='liniero',
+        )
+
+    def _post(self, linea, cantidad):
+        return self.client.post(
+            reverse('lineas:detalle', kwargs={'pk': linea.pk}),
+            {'action': 'actualizar_vanos', 'cantidad_vanos': str(cantidad)},
+        )
+
+    def test_admin_materializa_vanos(self):
+        linea = _linea()
+        self.client.force_login(self.admin)
+        r = self._post(linea, 100)
+        self.assertEqual(r.status_code, 200)
+        data = r.json()
+        self.assertTrue(data['success'])
+        self.assertEqual(data['vanos_creados'], 100)
+        self.assertEqual(data['vanos_total'], 100)
+        self.assertEqual(linea.vanos.count(), 100)
+
+    def test_admin_general_permitido(self):
+        """admin_general (RBAC v2) NO debe recibir 403 al actualizar vanos."""
+        linea = _linea()
+        self.client.force_login(self.admin_general)
+        r = self._post(linea, 5)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(linea.vanos.count(), 5)
+
+    def test_liniero_403(self):
+        linea = _linea()
+        self.client.force_login(self.liniero)
+        r = self._post(linea, 5)
+        self.assertEqual(r.status_code, 403)
+        self.assertEqual(linea.vanos.count(), 0)

--- a/apps/lineas/views.py
+++ b/apps/lineas/views.py
@@ -86,17 +86,30 @@ class LineaDetailView(LoginRequiredMixin, RoleRequiredMixin, HTMXMixin, DetailVi
         from django.http import JsonResponse
         self.object = self.get_object()
 
-        # Check if user has permission to edit
-        if not self.request.user.is_authenticated or self.request.user.rol not in ['admin', 'director', 'coordinador']:
+        # Check if user has permission to edit. Incluye admin_general e
+        # ing_residente (RBAC v2 #44) — sin ellos esos roles recibían 403 al
+        # actualizar vanos. #101.
+        admin_roles = ['admin', 'admin_general', 'director', 'coordinador', 'ing_residente']
+        if not self.request.user.is_authenticated or self.request.user.rol not in admin_roles:
             return JsonResponse({'error': 'No autorizado'}, status=403)
 
         # Handle vanos update
         if request.POST.get('action') == 'actualizar_vanos':
             cantidad_vanos = request.POST.get('cantidad_vanos', '').strip()
             if cantidad_vanos.isdigit():
-                self.object.cantidad_vanos = int(cantidad_vanos)
+                n = int(cantidad_vanos)
+                self.object.cantidad_vanos = n
                 self.object.save(update_fields=['cantidad_vanos'])
-                return JsonResponse({'success': True})
+                # #101: materializar los registros Vano que la grilla de
+                # Registrar Avances necesita (antes cantidad_vanos era solo un
+                # contador y los vanos nunca se creaban → grid vacío).
+                creados = self.object.sincronizar_vanos(n)
+                return JsonResponse({
+                    'success': True,
+                    'cantidad_vanos': n,
+                    'vanos_creados': creados,
+                    'vanos_total': self.object.vanos.count(),
+                })
             else:
                 return JsonResponse({'error': 'Cantidad inválida'}, status=400)
 


### PR DESCRIPTION
Re-apertura de #101 (Sofi, 2026-06-06): la grilla de Registrar Avances sigue saliendo vacía pese a que la línea "tiene 100 vanos".

## Causa raíz
`cantidad_vanos` es un **contador metadato**. El handler AJAX `actualizar_vanos` lo guardaba pero **nunca creaba filas `Vano`** — que es lo que la grilla (una casilla por vano) consume. LN5114: `cantidad_vanos=100`, 104 torres, **0 filas en `vanos`**. Los PRs #106/#107/#108 arreglaron el 500 pero no este gap de materialización.

## Fix (Opción A — idempotente, no destructivo)
- `Linea.sincronizar_vanos(cantidad)`: crea los `Vano` `1..N` faltantes, **nunca borra** los existentes (preserva estado/pendientes), tope `MAX_VANOS_AUTOGENERADOS=5000`.
- `LineaDetailView.post` `actualizar_vanos`: invoca la sincronización y devuelve JSON con `vanos_creados`/`vanos_total`. Amplía los roles admin a `admin_general`/`ing_residente` (RBAC v2 #44), que antes recibían **403**.
- `RegistroAvanceCreateView`: ordena los vanos **numéricamente** (`numero` es CharField → `order_by` daría 1,10,100,11...).

## Tests
- `apps/lineas/tests_vanos_sync.py` (9): crea 1..N, idempotencia, no-destructivo, cap, inválidos, integración POST + `admin_general` permitido + liniero 403.
- Regresión suites #101 existentes (`campo/tests_b12` + `lineas/tests_b21`): **33/33 verdes**.

## Post-deploy
Para LN5114 (Sofi ya puso 100): re-guardar el contador desde la UI materializa los 100 vanos. Se valida en smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)