### PR TITLE
fix(#100): propagar T-{n} (numero_display) a todo el aplicativo (exports, mensajes, mapa, dropdowns)

### DIFF
--- a/apps/actividades/exporters.py
+++ b/apps/actividades/exporters.py
@@ -123,7 +123,7 @@ class ProgramacionSemanalExporter:
             if actividad.tramo:
                 tramo_info = f"{actividad.tramo.nombre} (T{actividad.tramo.torre_inicio.numero} - T{actividad.tramo.torre_fin.numero})"
             elif actividad.torre:
-                tramo_info = f"Torre {actividad.torre.numero}"
+                tramo_info = f"Torre {actividad.torre.numero_display}"
             else:
                 tramo_info = '-'
 
@@ -368,7 +368,7 @@ class ReporteAvanceExporter:
             observaciones = '; '.join(obs_list) if obs_list else ''
 
             # Llenar fila
-            sheet.cell(row=row_num, column=1, value=torre.numero)
+            sheet.cell(row=row_num, column=1, value=torre.numero_display)
             sheet.cell(row=row_num, column=2, value=torre.get_tipo_display())
             sheet.cell(row=row_num, column=3, value=total_actividades)
             sheet.cell(row=row_num, column=4, value=f'{avance_promedio:.1f}%')
@@ -411,7 +411,7 @@ class ReporteAvanceExporter:
 
         row_num = 4
         for reg in registros:
-            sheet.cell(row=row_num, column=1, value=reg.actividad.torre.numero if reg.actividad.torre else '-')
+            sheet.cell(row=row_num, column=1, value=reg.actividad.torre.numero_display if reg.actividad.torre else '-')
             sheet.cell(row=row_num, column=2, value=reg.actividad.tipo_actividad.nombre)
             sheet.cell(row=row_num, column=3, value=reg.get_tipo_pendiente_display())
             sheet.cell(row=row_num, column=4, value=reg.descripcion_pendiente)
@@ -659,7 +659,7 @@ class InformeDiarioPDFExporter:
             for act in informe_diario.actividades_realizadas.all():
                 act_rows.append([
                     act.tipo_actividad.nombre,
-                    act.torre.numero if act.torre else '-',
+                    act.torre.numero_display if act.torre else '-',
                     act.aviso_sap or '-',
                     f'{act.porcentaje_avance}%'
                 ])

--- a/apps/actividades/models.py
+++ b/apps/actividades/models.py
@@ -372,7 +372,7 @@ class Actividad(BaseModel):
         ]
 
     def __str__(self):
-        return f"{self.tipo_actividad.nombre} - Torre {self.torre.numero} ({self.fecha_programada})"
+        return f"{self.tipo_actividad.nombre} - Torre {self.torre.numero_display} ({self.fecha_programada})"
 
     @property
     def fecha_efectiva(self):

--- a/apps/actividades/reports.py
+++ b/apps/actividades/reports.py
@@ -221,7 +221,7 @@ class ReporteAvanceServidumbre:
 
         row_num = 4
         for idx, reg in enumerate(registros, start=1):
-            torre = reg.actividad.torre.numero if reg.actividad.torre else '-'
+            torre = reg.actividad.torre.numero_display if reg.actividad.torre else '-'
             tipo = reg.get_tipo_pendiente_display() if reg.tipo_pendiente else '-'
             descripcion = reg.descripcion_pendiente or '-'
             actividad = reg.actividad.tipo_actividad.nombre

--- a/apps/actividades/tests_torres_endpoint_100.py
+++ b/apps/actividades/tests_torres_endpoint_100.py
@@ -1,0 +1,68 @@
+"""#100 — Endpoint torres-por-linea: etiqueta T-{n} + orden numérico.
+
+El dropdown web de torres (actividades/crear, form_actividad, campo/reportar_dano)
+consume `/actividades/api/torres-por-linea/<linea_id>/`. Antes devolvía el
+`numero` crudo (E-1, E-10...) ordenado lexicográficamente. Ahora devuelve
+`numero_display` (T-{n}) en orden numérico ascendente. El value del <option>
+sigue siendo el `id`.
+"""
+import json
+
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+
+from apps.lineas.models import Linea, Torre
+
+User = get_user_model()
+
+
+class TestTorresPorLineaEndpoint(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(
+            email='t100@test.com', password='x', rol='admin',
+            is_superuser=True, is_staff=True,
+        )
+        cls.linea = Linea.objects.create(
+            codigo='L-100', nombre='Test 100', cliente=Linea.Cliente.TRANSELCA,
+        )
+        # Numeros crudos desordenados y en formato 'E-' (caso real Sofi)
+        from decimal import Decimal
+        for n in ['E-2', 'E-10', 'E-1', 'E-3']:
+            Torre.objects.create(
+                linea=cls.linea, numero=n, tipo='SUSPENSION', estado='BUENO',
+                latitud=Decimal('5.0'), longitud=Decimal('-75.0'),
+            )
+
+    def _get(self):
+        self.client.force_login(self.user)
+        return self.client.get(reverse(
+            'actividades:torres_por_linea', kwargs={'linea_id': self.linea.id},
+        ))
+
+    def test_devuelve_numero_display_T(self):
+        r = self._get()
+        self.assertEqual(r.status_code, 200)
+        data = json.loads(r.content)
+        numeros = [t['numero'] for t in data]
+        # Todos en formato T-{n}, ninguno con 'E-'
+        self.assertTrue(all(x.startswith('T-') for x in numeros), numeros)
+        self.assertFalse(any('E-' in x for x in numeros), numeros)
+
+    def test_orden_numerico_ascendente(self):
+        r = self._get()
+        data = json.loads(r.content)
+        numeros = [t['numero'] for t in data]
+        # Numérico (1,2,3,10), NO lexicográfico (1,10,2,3)
+        self.assertEqual(numeros, ['T-1', 'T-2', 'T-3', 'T-10'])
+
+    def test_value_sigue_siendo_id(self):
+        r = self._get()
+        data = json.loads(r.content)
+        for t in data:
+            # cada item trae id (identificador) + numero (display)
+            self.assertIn('id', t)
+            self.assertIn('numero', t)
+            # el id es un UUID parseable, no la etiqueta
+            self.assertNotEqual(t['id'], t['numero'])

--- a/apps/actividades/views.py
+++ b/apps/actividades/views.py
@@ -578,8 +578,15 @@ class TorresParaLineaView(LoginRequiredMixin, View):
         except ValueError:
             return JsonResponse([], safe=False)
 
-        torres = Torre.objects.filter(linea_id=linea_id).order_by('numero').values('id', 'numero')
-        return JsonResponse(list(torres), safe=False)
+        # #100: etiqueta normalizada (T-{n}) y orden numérico ascendente
+        # (no lexicográfico). `numero_display` es @property → iterar objetos,
+        # no usar .values(). El value del <option> sigue siendo el id.
+        torres = sorted(
+            Torre.objects.filter(linea_id=linea_id),
+            key=lambda t: t.orden_numerico,
+        )
+        data = [{'id': str(t.id), 'numero': t.numero_display} for t in torres]
+        return JsonResponse(data, safe=False)
 
 
 class ActividadCreateView(LoginRequiredMixin, RoleRequiredMixin, HTMXMixin, TemplateView):
@@ -1061,7 +1068,7 @@ class EventosAPIView(LoginRequiredMixin, View):
 
             events.append({
                 'id': str(actividad.id),
-                'title': f"T{actividad.torre.numero} - {actividad.linea.codigo}",
+                'title': f"{actividad.torre.numero_display} - {actividad.linea.codigo}",
                 'start': actividad.fecha_programada.isoformat(),
                 'backgroundColor': color,
                 'borderColor': color,

--- a/apps/ambiental/models.py
+++ b/apps/ambiental/models.py
@@ -202,7 +202,7 @@ class PermisoServidumbre(BaseModel):
         ordering = ['-fecha_autorizacion']
 
     def __str__(self):
-        return f"Permiso {self.propietario_nombre} - Torre {self.torre.numero}"
+        return f"Permiso {self.propietario_nombre} - Torre {self.torre.numero_display}"
 
     @property
     def vigente(self):

--- a/apps/ambiental/tasks.py
+++ b/apps/ambiental/tasks.py
@@ -115,7 +115,7 @@ def generar_excel_informe(informe, actividades, registros):
         cell.font = Font(bold=True)
 
     for row, act in enumerate(actividades, 2):
-        ws_act.cell(row=row, column=1, value=act.torre.numero)
+        ws_act.cell(row=row, column=1, value=act.torre.numero_display)
         ws_act.cell(row=row, column=2, value=act.tipo_actividad.nombre)
         ws_act.cell(row=row, column=3, value=act.fecha_programada.isoformat())
         ws_act.cell(row=row, column=4, value=act.estado)

--- a/apps/campo/models.py
+++ b/apps/campo/models.py
@@ -312,7 +312,7 @@ class Evidencia(BaseModel):
         ]
 
     def __str__(self):
-        return f"{self.get_tipo_display()} - {self.registro_campo.actividad.torre.numero}"
+        return f"{self.get_tipo_display()} - {self.registro_campo.actividad.torre.numero_display}"
 
     @property
     def es_valida(self):
@@ -758,7 +758,7 @@ class RegistroAvance(BaseModel):
     def __str__(self):
         return (
             f"Avance {self.get_tipo_avance_display()} - "
-            f"Torre {self.torre.numero} - {self.usuario.get_full_name()}"
+            f"Torre {self.torre.numero_display} - {self.usuario.get_full_name()}"
         )
 
     def clean(self):

--- a/apps/campo/tasks.py
+++ b/apps/campo/tasks.py
@@ -137,7 +137,7 @@ def estampar_metadata_imagen(evidencia_id: str):
     torre = evidencia.registro_campo.actividad.torre
     linea = evidencia.registro_campo.actividad.linea
 
-    texto = f"""Torre: {torre.numero} | Línea: {linea.codigo}
+    texto = f"""Torre: {torre.numero_display} | Línea: {linea.codigo}
 Fecha: {evidencia.fecha_captura.strftime('%Y-%m-%d %H:%M')}
 GPS: {evidencia.latitud}, {evidencia.longitud}
 Tipo: {evidencia.get_tipo_display()}"""

--- a/apps/campo/views.py
+++ b/apps/campo/views.py
@@ -951,7 +951,7 @@ class RegistroAvanceCreateView(LoginRequiredMixin, RoleRequiredMixin, TemplateVi
             )
             messages.success(
                 request,
-                f'Avance registrado en Torre {torre.numero} exitosamente.'
+                f'Avance registrado en Torre {torre.numero_display} exitosamente.'
             )
         except Exception as e:
             messages.error(request, f'Error al registrar avance: {str(e)}')

--- a/apps/construccion/models.py
+++ b/apps/construccion/models.py
@@ -550,7 +550,7 @@ class PataObra(BaseModel):
 
     def __str__(self):
         # B1.1 — formato T{numero}
-        return f"T{self.torre.numero} - Pata {self.pata}"
+        return f"{self.torre.numero_display} - Pata {self.pata}"
 
     @property
     def porcentaje_completado(self):
@@ -736,7 +736,7 @@ class ObraCivilTorre(BaseModel):
         ordering = ['torre__numero']
 
     def __str__(self):
-        return f"OC {self.torre.numero}"
+        return f"OC {self.torre.numero_display}"
 
     COLUMNAS = [
         ('cerramiento', 'Cerramiento'),
@@ -857,7 +857,7 @@ class MontajeEstructuraTorre(BaseModel):
         ordering = ['torre__numero']
 
     def __str__(self):
-        return f"Montaje {self.torre.numero}"
+        return f"Montaje {self.torre.numero_display}"
 
     COLUMNAS = [
         ('estructura_sitio', 'Estructura en sitio'),
@@ -949,7 +949,7 @@ class SPTTorre(BaseModel):
         ordering = ['torre__numero']
 
     def __str__(self):
-        return f"SPT {self.torre.numero}"
+        return f"SPT {self.torre.numero_display}"
 
     @property
     def diferencia_cable(self):
@@ -987,7 +987,7 @@ class PinturaPatasTorre(BaseModel):
         ordering = ['torre__numero']
 
     def __str__(self):
-        return f"Pintura patas {self.torre.numero}"
+        return f"Pintura patas {self.torre.numero_display}"
 
 
 class PinturaAeronauticaTorre(BaseModel):
@@ -1009,7 +1009,7 @@ class PinturaAeronauticaTorre(BaseModel):
         ordering = ['torre__numero']
 
     def __str__(self):
-        return f"Pintura aero {self.torre.numero}"
+        return f"Pintura aero {self.torre.numero_display}"
 
 
 class PinturaFranja(BaseModel):
@@ -1127,7 +1127,7 @@ class TendidoTorre(BaseModel):
         ordering = ['torre__numero']
 
     def __str__(self):
-        return f"Tendido {self.torre.numero}"
+        return f"Tendido {self.torre.numero_display}"
 
     COLUMNAS_CONDUCTOR = [
         ('riega_manila_conductor', 'Riega manila'),
@@ -1279,7 +1279,7 @@ class TrinchoCuneta(BaseModel):
         ordering = ['torre__numero']
 
     def __str__(self):
-        return f"{self.torre.numero} - {self.get_medida_manejo_display()}"
+        return f"{self.torre.numero_display} - {self.get_medida_manejo_display()}"
 
     @property
     def total_metros_obra(self):
@@ -1563,7 +1563,7 @@ class FaseTorre(BaseModel):
 
     def __str__(self):
         # B1.1 — formato T{numero}
-        return f"Fases - T{self.torre.numero}"
+        return f"Fases - {self.torre.numero_display}"
 
     @property
     def porcentaje_montaje(self):
@@ -1690,7 +1690,7 @@ class SocialPredial(BaseModel):
 
     def __str__(self):
         # B1.1 — formato T{numero}
-        return f"Social - T{self.torre.numero}"
+        return f"Social - {self.torre.numero_display}"
 
     @property
     def semaforo(self):
@@ -1787,7 +1787,7 @@ class AmbientalTorre(BaseModel):
 
     def __str__(self):
         # B1.1 — formato T{numero}
-        return f"Ambiental - T{self.torre.numero}"
+        return f"Ambiental - {self.torre.numero_display}"
 
     @property
     def semaforo(self):
@@ -1842,7 +1842,7 @@ class ControlLluvia(BaseModel):
 
     def __str__(self):
         # B1.1 — formato T{numero}
-        return f"Lluvia - T{self.torre.numero} ({self.fecha})"
+        return f"Lluvia - {self.torre.numero_display} ({self.fecha})"
 
 
 class ReporteReplanteo(BaseModel):
@@ -1970,7 +1970,7 @@ class EntregaElectromecanica(BaseModel):
 
     def __str__(self):
         # B1.1 — formato T{numero}
-        return f"Entrega - T{self.torre.numero}"
+        return f"Entrega - {self.torre.numero_display}"
 
 
 class CorreccionEntrega(BaseModel):
@@ -2004,7 +2004,7 @@ class CorreccionEntrega(BaseModel):
 
     def __str__(self):
         # B1.1 — formato T{numero}
-        return f"Corrección - T{self.torre.numero}"
+        return f"Corrección - {self.torre.numero_display}"
 
 
 class ObraProteccion(BaseModel):
@@ -2063,7 +2063,7 @@ class ObraProteccion(BaseModel):
 
     def __str__(self):
         # B1.1 — formato T{numero}
-        return f"Protección - T{self.torre.numero}"
+        return f"Protección - {self.torre.numero_display}"
 
 
 class PruebaTecnica(BaseModel):

--- a/apps/construccion/models_b1_actividades_finales.py
+++ b/apps/construccion/models_b1_actividades_finales.py
@@ -158,7 +158,7 @@ class ActividadFinalTorre(BaseModel):
         ordering = ['torre__numero']
 
     def __str__(self):
-        return f'ActividadesFinales T{self.torre.numero} ({self.pct_avance:.0f}%)'
+        return f'ActividadesFinales {self.torre.numero_display} ({self.pct_avance:.0f}%)'
 
     # ==================================================================
     # Validaciones de progresión lógica (server-side)

--- a/apps/construccion/models_b3_mont_detalle.py
+++ b/apps/construccion/models_b3_mont_detalle.py
@@ -189,7 +189,7 @@ class MontajeEstructuraTorreDetalle(BaseModel):
         ordering = ['torre__numero']
 
     def __str__(self):
-        return f'MontDetalle T{self.torre.numero}'
+        return f'MontDetalle {self.torre.numero_display}'
 
     # ======================================================================
     # Properties calculadas (paridad Excel)

--- a/apps/construccion/models_b3_oc_detalle.py
+++ b/apps/construccion/models_b3_oc_detalle.py
@@ -381,7 +381,7 @@ class ObraCivilTorreDetalle(BaseModel):
         ordering = ['torre__numero', 'pata']
 
     def __str__(self):
-        return f"T{self.torre.numero} - Pata {self.pata} (CANT OOCC)"
+        return f"{self.torre.numero_display} - Pata {self.pata} (CANT OOCC)"
 
     # =====================================================================
     # Computed properties — avance ponderado y desviaciones sub-bloques

--- a/apps/construccion/planillas.py
+++ b/apps/construccion/planillas.py
@@ -90,5 +90,5 @@ def descargar_planilla_torre(request, codigo_ft, torre_id):
             f'Error generando planilla {codigo_ft}: {e}', status=500)
     response = HttpResponse(pdf_bytes, content_type='application/pdf')
     response['Content-Disposition'] = (
-        f'attachment; filename="{codigo_ft}_{torre.numero}.pdf"')
+        f'attachment; filename="{codigo_ft}_{torre.numero_display}.pdf"')
     return response

--- a/apps/lineas/api.py
+++ b/apps/lineas/api.py
@@ -329,7 +329,9 @@ def torres_geojson(
             'geometry': {'type': 'Point', 'coordinates': [float(t.longitud), float(t.latitud)]},
             'properties': {
                 'id': str(t.id),
-                'numero': t.numero,
+                # #100: etiqueta normalizada T-{n} para el popup del mapa (web).
+                # El identificador sigue siendo `id`.
+                'numero': t.numero_display,
                 'tipo': t.tipo,
                 'estado': t.estado,
                 'inspection_status': t.inspection_status,

--- a/apps/lineas/models_base.py
+++ b/apps/lineas/models_base.py
@@ -486,7 +486,7 @@ class PoligonoServidumbre(BaseModel):
     def __str__(self):
         if self.torre:
             # B1.1 — usar formato T{numero} en lugar de "Torre N"
-            return f"Servidumbre - T{self.torre.numero}"
+            return f"Servidumbre - {self.torre.numero_display}"
         return f"Servidumbre - {self.nombre or self.id}"
 
     def punto_dentro(self, latitud: float, longitud: float) -> bool:

--- a/apps/lineas/tests/test_b11.py
+++ b/apps/lineas/tests/test_b11.py
@@ -1,4 +1,4 @@
-"""Tests B1.1 — Renombre torres a formato T{numero}.
+"""Tests B1.1 — Renombre torres a formato T-{numero} (canónico Sofi #100).
 
 Cubre:
 - Happy path: Torre.__str__ retorna "T{numero}" sin variantes
@@ -48,22 +48,22 @@ class TestB11RenderTorresFormatTNumero:
 
     def test_b11_render_torres_format_T_numero(self, torre):
         """Happy path: __str__ retorna 'T{numero}' sin "Torre " ni linea."""
-        assert str(torre) == "T15"
+        assert str(torre) == "T-15"
         # No debe contener variantes legacy
         assert "Torre " not in str(torre)
         assert " - " not in str(torre)
 
     def test_b11_codigo_display_preserva_linea(self, torre):
         """codigo_display retiene la línea para casos cross-línea."""
-        assert torre.codigo_display == "T15 (LN-X)"
+        assert torre.codigo_display == "T-15 (LN-X)"
 
     def test_b11_numeros_multi_digito_sin_padding(self, db, linea):
         """T1, T15, T100, T999 — todos sin padding ni zeros."""
         casos = [
-            ("1", "T1"),
-            ("15", "T15"),
-            ("100", "T100"),
-            ("999", "T999"),
+            ("1", "T-1"),
+            ("15", "T-15"),
+            ("100", "T-100"),
+            ("999", "T-999"),
         ]
         for n, esperado in casos:
             t = Torre.objects.create(
@@ -84,7 +84,7 @@ class TestB11RenderTorresFormatTNumero:
             latitud=Decimal("6.0"), longitud=Decimal("-74.0"),
         )
         t.refresh_from_db()
-        assert str(t) == "T042"
+        assert str(t) == "T-42"
         # numero original (legacy) preservado intacto
         assert t.numero == "042"
 
@@ -95,7 +95,7 @@ class TestB11RenderTorresFormatTNumero:
             linea=linea, numero="TX-3", tipo="SUSPENSION", estado="BUENO",
             latitud=Decimal("5.0"), longitud=Decimal("-75.0"),
         )
-        assert str(t) == "TTX-3"  # T + numero literal — consistencia formato
+        assert str(t) == "TX-3"  # prefijo no-torre se preserva como {PREFIJO}-{n}
 
     def test_b11_poligono_servidumbre_usa_T_numero(self, db, linea, torre):
         """PoligonoServidumbre.__str__ también usa formato T{n}."""
@@ -109,7 +109,7 @@ class TestB11RenderTorresFormatTNumero:
             linea=linea, torre=torre, nombre="Servidumbre Test",
             geometria=poly,
         )
-        assert str(p) == "Servidumbre - T15"
+        assert str(p) == "Servidumbre - T-15"
         assert "Torre " not in str(p)
 
     def test_b11_poligono_sin_torre_no_rompe(self, db, linea):
@@ -158,7 +158,7 @@ class TestB11TorreConstruccionFormatTNumero:
         torre = TorreConstruccion.objects.create(
             proyecto=proyecto_construccion_b11, numero="42",
         )
-        assert str(torre) == "T42"
+        assert str(torre) == "T-42"
         assert "Torre " not in str(torre)
         assert "(" not in str(torre)  # proyecto NO en __str__ default
 
@@ -169,7 +169,7 @@ class TestB11TorreConstruccionFormatTNumero:
             proyecto=proyecto_construccion_b11, numero="7",
         )
         # Formato: "T{numero} ({proyecto.nombre})"
-        assert torre.codigo_display.startswith("T7 (")
+        assert torre.codigo_display.startswith("T-7 (")
         assert proyecto_construccion_b11.nombre in torre.codigo_display
 
     def test_b11_pataobra_str_format_T(self, proyecto_construccion_b11):
@@ -179,7 +179,7 @@ class TestB11TorreConstruccionFormatTNumero:
             proyecto=proyecto_construccion_b11, numero="10",
         )
         pata = PataObra.objects.create(torre=torre, pata="A")
-        assert str(pata) == "T10 - Pata A"
+        assert str(pata) == "T-10 - Pata A"
         assert "Torre " not in str(pata)
 
     def test_b11_dato_legacy_torreconstruccion(self, proyecto_construccion_b11):
@@ -190,7 +190,7 @@ class TestB11TorreConstruccionFormatTNumero:
             proyecto=proyecto_construccion_b11, numero="LEGACY-99",
         )
         torre.refresh_from_db()
-        assert str(torre) == "TLEGACY-99"
+        assert str(torre) == "LEGACY-99"
         assert torre.numero == "LEGACY-99"  # campo intacto
 
     def test_b11_no_residuos_torre_n_en_construccion_models(self):

--- a/apps/lineas/views.py
+++ b/apps/lineas/views.py
@@ -271,7 +271,7 @@ class MapaLineasView(LoginRequiredMixin, RoleRequiredMixin, TemplateView):
             if torre.latitud and torre.longitud:
                 torres_data.append({
                     'id': str(torre.id),
-                    'numero': torre.numero,
+                    'numero': torre.numero_display,
                     'linea': linea.codigo if linea else '',
                     'tipo': torre.tipo,
                     'estado': torre.estado,
@@ -761,10 +761,10 @@ class TorreCreateView(LoginRequiredMixin, RoleRequiredMixin, View):
             tower.longitud = -74.2973
             try:
                 tower.save()
-                messages.success(request, f'Torre {tower.numero} creada exitosamente.')
+                messages.success(request, f'Torre {tower.numero_display} creada exitosamente.')
                 return redirect('lineas:detalle', pk=linea_pk)
             except IntegrityError:
-                messages.error(request, f'Ya existe una torre con número "{tower.numero}" en esta línea. Use un número diferente.')
+                messages.error(request, f'Ya existe una torre con número "{tower.numero_display}" en esta línea. Use un número diferente.')
                 return self.render_form(request, linea, form)
         else:
             messages.error(request, 'Error al crear la torre. Revise los datos.')
@@ -813,7 +813,7 @@ class TorreEditView(LoginRequiredMixin, RoleRequiredMixin, View):
 
         if form.is_valid():
             form.save()
-            messages.success(request, f'Torre {torre.numero} actualizada exitosamente.')
+            messages.success(request, f'Torre {torre.numero_display} actualizada exitosamente.')
             return redirect('lineas:detalle', pk=torre.linea.pk)
         else:
             messages.error(request, 'Error al actualizar la torre. Revise los datos.')

--- a/templates/construccion/trinchos_cunetas_lista.html
+++ b/templates/construccion/trinchos_cunetas_lista.html
@@ -39,7 +39,7 @@
                             class="px-3 py-1.5 rounded border border-gray-300 dark:border-gray-600 dark:bg-gray-700">
                         <option value="">--</option>
                         {% for t in torres_disponibles %}
-                        <option value="{{ t.id }}">{{ t.numero }}</option>
+                        <option value="{{ t.id }}">{{ t.numero_display }}</option>
                         {% endfor %}
                     </select>
                 </label>


### PR DESCRIPTION
Re-apertura de #100: PR #129 normalizó el display de torres a **T-{n}** y el orden en la ficha de línea, pero quedaban ~46 referencias a `.numero` crudo (E-1, E-10…) en el resto del aplicativo, incumpliendo el criterio "todo el aplicativo".

## Barrido user-facing (`numero` → `numero_display`)
- **`__str__`** de modelos derivados (construcción ×15, campo, actividades, ambiental, líneas/Servidumbre). Quita el `T` literal pegado para evitar "TE-1".
- **Mensajes flash** (crear/editar/duplicado de torre, avance de campo).
- **Exports/reportes Excel + PDF/notificaciones** (actividades, ambiental, construcción/planillas).
- **Mapa**: context `torres_json` + geojson `properties.numero` + popup.
- **Endpoint dropdown** `/actividades/api/torres-por-linea/`: devuelve `numero_display` + **orden numérico** (no lexicográfico). El value del `<option>` sigue siendo el `id`. Esto cubre los dropdowns de actividades/crear, form_actividad y campo/reportar_dano.
- Título del calendario de actividades + template trinchos.

## Intencionalmente sin tocar (back-compat)
- Campos **Ninja API consumidos por mobile** (sync `torre_numero`, `validar-ubicacion`, `TorreOut.numero`, `ActividadOut.torre_numero`). Cambiarlos rompería el sync móvil — el label en la app móvil es **followup** de ese codebase/deploy.
- Logs de import y management commands (citan el input crudo del usuario).

## Decisión de formato: T-{n} (con guion)
El issue body decía "T1/T15", pero Sofi pidió explícitamente **"T-1"** y el PR #129 (deployado y aceptado) usa T-{n}. Mantengo ese canónico y **alineo los asserts stale de `test_b11`** (estaban en "T15" sin guion, rojos desde #129). Si se prefiere "T1" sin guion, es un cambio de 1 línea en `Torre.normalizar_numero`.

## Tests
- `apps/actividades/tests_torres_endpoint_100.py`: endpoint devuelve T-{n} + orden numérico + value=id.
- `test_b11` alineado a T-{n} (150 tests verdes en dev_lite; los rojos restantes son GIS/`regexp_replace` sólo de SQLite local, pasan en CI con PostGIS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)