### PR TITLE
feat(dashboards): consumir avance real en dashboards de construcción (#139)

### DIFF
--- a/apps/construccion/calculators.py
+++ b/apps/construccion/calculators.py
@@ -392,3 +392,65 @@ def curva_s_consolidada(proyecto) -> dict:
         'planeado': planeado,
         'ejecutado': ejecutado,
     }
+
+
+# ===========================================================================
+# B1 (#139) — payload del Dashboard de Obra Civil con avance REAL
+# ===========================================================================
+#
+# Punto de entrada único que bundla los datos del Dashboard de OC desde el
+# avance REAL (257 oc_detalle de prod), reusando el backbone S1
+# (`calculators_avance_real`) — NO re-implementa el cálculo. Lo consume la vista
+# `DashboardObraCivilRealView` y los tests. Mantiene `calculators.py` como la
+# fachada de agregadores del dashboard de obra civil.
+
+
+def dashboard_oc_real_payload(proyecto) -> dict:
+    """Bundla los datos REALES del Dashboard de Obra Civil (#139).
+
+    Reusa el backbone S1 ``calculators_avance_real``:
+      - ``curva_s``: {labels, planeado, ejecutado} de la Curva S REAL de OC.
+      - ``avance_etapas``: las 6 etapas OC (con Cerramiento) + pesos.
+      - ``vista_torres``: lista por torre (% / completa / pendientes).
+      - ``tarjetas``: {pct_construido, pct_programado, varianza_pct} del REAL.
+
+    Edge (proyecto sin avance / sin oc_detalle): curva vacía, etapas en 0%,
+    vista vacía, tarjetas en 0.0 — NUNCA lanza ni divide por cero.
+    """
+    from . import calculators_avance_real as car
+
+    ejecutado = car.serie_curva_s_real(proyecto, car.FASE_OOCC)
+    planeado = car.serie_planeado(proyecto, car.FASE_OOCC)
+
+    # Eje X común (carry forward) para alinear las dos líneas en Chart.js.
+    labels = sorted(set(ejecutado.get('labels', [])) | set(planeado.get('labels', [])))
+
+    def _carry(series_labels, series_vals):
+        pares = list(zip(series_labels, series_vals, strict=False))
+        out, ult, idx = [], 0.0, 0
+        for lab in labels:
+            while idx < len(pares) and pares[idx][0] <= lab:
+                ult = pares[idx][1]
+                idx += 1
+            out.append(round(ult, 2))
+        return out
+
+    if labels:
+        ejec_eje = _carry(ejecutado.get('labels', []), ejecutado.get('ejecutado', []))
+        plan_eje = _carry(planeado.get('labels', []), planeado.get('planeado', []))
+    else:
+        ejec_eje, plan_eje = [], []
+
+    pct_ejec = ejec_eje[-1] if ejec_eje else 0.0
+    pct_plan = plan_eje[-1] if plan_eje else 0.0
+
+    return {
+        'curva_s': {'labels': labels, 'planeado': plan_eje, 'ejecutado': ejec_eje},
+        'avance_etapas': car.avance_por_etapa(proyecto, car.FASE_OOCC),
+        'vista_torres': car.vista_por_torre(proyecto, car.FASE_OOCC),
+        'tarjetas': {
+            'pct_construido': round(pct_ejec, 1),
+            'pct_programado': round(pct_plan, 1),
+            'varianza_pct': round(pct_ejec - pct_plan, 1),
+        },
+    }

--- a/apps/construccion/calculators_avance_real.py
+++ b/apps/construccion/calculators_avance_real.py
@@ -1,0 +1,619 @@
+"""Backbone de cálculo de avance REAL para los Dashboards de fase (#139).
+
+Funciones PURAS (sin efectos colaterales, sin request) reutilizadas por las
+sub-features B1 (Obra Civil) · B2 (Montaje) · B3 (Tendido) · B4 (vista torres
+consolidada) · B5 (general). Cablean el avance real que YA se calcula en los
+modelos (``ObraCivilTorreDetalle.avance_ponderado``,
+``MontajeEstructuraTorreDetalle.avance_ponderado``,
+``TendidoTorre.avance_conductor/avance_fibra``,
+``ProyectoConstruccion.porcentaje_avance_civil_ponderado``) a la Curva S y a
+las tarjetas — que hoy salen en 0% porque cuelgan de ``DashboardAvanceSemanal``
+(solo 2 filas en prod).
+
+Contrato (ver BLUEPRINT — Contratos de integración):
+  - serie_curva_s_real(proyecto, fase)  -> {'labels':[iso], 'ejecutado':[float]}
+  - serie_planeado(proyecto, fase)      -> {'labels':[iso], 'planeado':[float]}
+  - avance_por_etapa(proyecto, fase)    -> [{'etapa','label','pct','completas','totales'}]
+  - vista_por_torre(proyecto, fase)     -> [{'torre_id','numero','pct','completa','pendientes':[...]}]
+  - avance_general(proyecto)            -> {'fases':[{'seccion','label','pct','peso'}], 'global_pct':float}
+  - fecha_avance_oc/montaje/tendido(instancia) -> datetime.date  (cascada, NUNCA None)
+
+Anclaje temporal (hallazgo crítico de datos): ``vac_fecha_vaciado`` es NULL en
+los 257 oc_detalle de prod. El "avance respecto al tiempo" NO puede depender de
+ese campo. Cada ``fecha_avance_*`` usa la cascada:
+    vac_fecha_vaciado / *_fecha_fin  ->  updated_at  ->  created_at
+``created_at`` / ``updated_at`` son NOT NULL (BaseModel) → la fecha nunca es
+None. Esto permite distribuir el avance acumulado a lo largo del tiempo.
+
+Las fases del contrato son las de ``DashboardAvanceSemanal.Fase``:
+``OOCC`` (Obra Civil), ``MONTAJE``, ``TENDIDO``.
+"""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import Optional
+
+# Etiquetas canónicas de fase (alineadas con DashboardAvanceSemanal.Fase).
+FASE_OOCC = 'OOCC'
+FASE_MONTAJE = 'MONTAJE'
+FASE_TENDIDO = 'TENDIDO'
+FASES_VALIDAS = (FASE_OOCC, FASE_MONTAJE, FASE_TENDIDO)
+
+
+# ==========================================================================
+# Pesos de etapas — leídos de los campos editables del proyecto con default
+# a los valores canónicos del Excel del cliente.
+# ==========================================================================
+
+#: Obra Civil — 6 etapas (incluye Cerramiento, ausente en calculators.ETAPAS_OC).
+#: (codigo, label, campo_en_oc_detalle, atributo_peso_en_proyecto, default, es_bool)
+ETAPAS_OC_PESOS = [
+    ('CERRAMIENTO', 'Cerramiento', 'cerr_finalizado_ok', 'peso_cerramiento_pct', 5, True),
+    ('EXCAVACION', 'Excavación', 'exc_ejecutada_pct', 'peso_excavacion_pct', 30, False),
+    ('SOLADO', 'Solado', 'sol_ejecutado_pct', 'peso_solado_pct', 5, False),
+    ('ACERO', 'Acero', 'ace_instalacion_pct', 'peso_acero_pct', 15, False),
+    ('VACIADO', 'Vaciado', 'vac_ejecutado_pct', 'peso_vaciado_pct', 30, False),
+    ('COMPACTACION', 'Compactación', 'com_finalizada_pct', 'peso_compactacion_pct', 15, False),
+]
+
+#: Montaje — 4 etapas (booleanas).
+#: (codigo, label, campo_en_mont_detalle, atributo_peso_en_proyecto, default)
+ETAPAS_MONTAJE_PESOS = [
+    ('ESTRUCTURA_SITIO', 'Estructura en sitio', 'estructura_en_sitio_ok', 'peso_mont_estructura_sitio_pct', 10),
+    ('PREARMADA', 'Prearmada', 'prearmada_ok', 'peso_mont_prearamada_pct', 20),
+    ('TORRE_MONTADA', 'Torre montada', 'torre_montada_ok', 'peso_mont_torre_montada_pct', 45),
+    ('REVISADA', 'Revisada', 'revisada_ok', 'peso_mont_revisada_pct', 25),
+]
+
+#: Tendido Conductor — 6 etapas booleanas (paridad TendidoTorre.COLUMNAS_CONDUCTOR).
+#: (codigo, label, campo, atributo_peso, default)
+ETAPAS_TENDIDO_CONDUCTOR_PESOS = [
+    ('RIEGA_MANILA', 'Riega manila', 'riega_manila_conductor', 'peso_tend_riega_manila_pct', 10),
+    ('RIEGA_GUAYA', 'Riega guaya', 'riega_guaya_conductor', 'peso_tend_riega_guaya_pct', 30),
+    ('TENDIDO_CONDUCTOR', 'Tendido conductor', 'tendido_conductor', 'peso_tend_tendido_conductor_pct', 30),
+    ('GRAPADO', 'Grapado', 'grapado_amarre_conductor', 'peso_tend_grapado_pct', 10),
+    ('ACCESORIOS', 'Accesorios', 'accesorios_puentes', 'peso_tend_accesorios_pct', 10),
+    ('BALIZAS', 'Balizas', 'balizas_desviadores', 'peso_tend_balizas_pct', 10),
+]
+
+#: Tendido Fibra OPGW — 5 etapas booleanas (paridad TendidoTorre.COLUMNAS_FIBRA).
+ETAPAS_TENDIDO_FIBRA_PESOS = [
+    ('RIEGA_MANILA_FIBRA', 'Riega manila fibra', 'riega_manila_fibra', 'peso_tend_riega_manila_fibra_pct', 10),
+    ('RIEGA_GUAYA_OPGW', 'Riega guaya OPGW', 'riega_guaya_opgw', 'peso_tend_riega_guaya_opgw_pct', 20),
+    ('TENDIDO_OPGW', 'Tendido OPGW', 'tendido_opgw', 'peso_tend_tendido_opgw_pct', 40),
+    ('GRAPADO_FIBRA', 'Grapado fibra', 'grapado_amarre_fibra', 'peso_tend_grapado_fibra_pct', 20),
+    ('EMPALMES_OPGW', 'Empalmes OPGW', 'empalmes_opgw', 'peso_tend_empalmes_opgw_pct', 10),
+]
+
+#: Mapeo sección ProgramacionFase -> (fase dashboard, label) para serie_planeado
+#: y avance_general. Las 9 secciones de ProgramacionFase.Seccion.
+FASE_DASHBOARD_POR_SECCION = {
+    'OBRA_CIVIL': FASE_OOCC,
+    'MONTAJE': FASE_MONTAJE,
+    'TENDIDO': FASE_TENDIDO,
+}
+
+
+# ==========================================================================
+# Helpers internos
+# ==========================================================================
+
+def _peso(proyecto, atributo, default) -> int:
+    """Lee un peso editable del proyecto; cae al default si es None/0-falsy."""
+    valor = getattr(proyecto, atributo, None)
+    if valor is None:
+        return int(default)
+    return int(valor)
+
+
+def _to_float(value) -> float:
+    """Convierte Decimal/None/str a float; None -> 0.0."""
+    if value is None:
+        return 0.0
+    if isinstance(value, Decimal):
+        return float(value)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+# ==========================================================================
+# Fechas de avance — cascada que NUNCA devuelve None
+# ==========================================================================
+
+def _cascada_fecha(*candidatos) -> Optional[date]:
+    """Devuelve el primer candidato no-None, normalizado a ``date``.
+
+    Acepta ``date`` o ``datetime`` (los ``created_at``/``updated_at`` de
+    BaseModel son ``DateTimeField``). Devuelve None solo si TODOS son None
+    (no debería ocurrir porque created_at es NOT NULL).
+    """
+    for c in candidatos:
+        if c is None:
+            continue
+        # datetime tiene .date(); date no.
+        return c.date() if hasattr(c, 'date') else c
+    return None
+
+
+def fecha_avance_oc(detalle) -> date:
+    """Fecha de avance de un ``ObraCivilTorreDetalle`` (pata).
+
+    Cascada: vac_fecha_vaciado -> updated_at -> created_at. NUNCA None
+    (created_at NOT NULL). Si por algún motivo todo fuera None, cae a hoy.
+    """
+    return _cascada_fecha(
+        getattr(detalle, 'vac_fecha_vaciado', None),
+        getattr(detalle, 'updated_at', None),
+        getattr(detalle, 'created_at', None),
+    ) or date.today()
+
+
+def fecha_avance_montaje(d) -> date:
+    """Fecha de avance de un ``MontajeEstructuraTorreDetalle``.
+
+    Cascada: montaje_fecha_fin -> prearmado_fecha_fin -> updated_at ->
+    created_at. NUNCA None.
+    """
+    return _cascada_fecha(
+        getattr(d, 'montaje_fecha_fin', None),
+        getattr(d, 'prearmado_fecha_fin', None),
+        getattr(d, 'updated_at', None),
+        getattr(d, 'created_at', None),
+    ) or date.today()
+
+
+def fecha_avance_tendido(t) -> date:
+    """Fecha de avance de un ``TendidoTorre``.
+
+    TendidoTorre no tiene fechas de etapa → cascada updated_at -> created_at.
+    NUNCA None.
+    """
+    return _cascada_fecha(
+        getattr(t, 'updated_at', None),
+        getattr(t, 'created_at', None),
+    ) or date.today()
+
+
+# ==========================================================================
+# Avance real por instancia (0..1) — reusa las properties de los modelos
+# ==========================================================================
+
+def _avance_oc_torre(detalles_pata) -> float:
+    """Avance OC (0..1) de UNA torre = promedio de avance_ponderado de sus patas.
+
+    ``ObraCivilTorreDetalle`` es por-pata (hasta 4 por torre). El % de la torre
+    es el promedio del avance ponderado de las patas registradas.
+    """
+    patas = list(detalles_pata)
+    if not patas:
+        return 0.0
+    suma = sum(_to_float(p.avance_ponderado) for p in patas)
+    return suma / len(patas)
+
+
+# ==========================================================================
+# Carga de instancias por fase (queries) — encapsulado para reuso
+# ==========================================================================
+
+def _detalles_oc_por_torre(proyecto):
+    """Dict torre_id -> lista de ObraCivilTorreDetalle (patas)."""
+    from collections import defaultdict
+    from .models_b3_oc_detalle import ObraCivilTorreDetalle
+    by_torre = defaultdict(list)
+    qs = (ObraCivilTorreDetalle.objects
+          .filter(proyecto=proyecto)
+          .select_related('torre', 'proyecto'))
+    for det in qs:
+        by_torre[det.torre_id].append(det)
+    return by_torre
+
+
+def _detalles_montaje(proyecto):
+    """QuerySet de MontajeEstructuraTorreDetalle del proyecto (uno por torre)."""
+    from .models_b3_mont_detalle import MontajeEstructuraTorreDetalle
+    return (MontajeEstructuraTorreDetalle.objects
+            .filter(proyecto=proyecto)
+            .select_related('torre', 'proyecto'))
+
+
+def _tendido_torres(proyecto):
+    """QuerySet de TendidoTorre del proyecto (uno por torre)."""
+    from .models import TendidoTorre
+    return (TendidoTorre.objects
+            .filter(proyecto=proyecto)
+            .select_related('torre', 'proyecto'))
+
+
+# ==========================================================================
+# serie_curva_s_real — núcleo del punto 1
+# ==========================================================================
+
+def _acumular_por_fecha(pares_fecha_pct, n_torres) -> dict:
+    """Construye la curva acumulada a partir de pares (fecha, avance_torre_0..1).
+
+    Cada torre aporta ``avance_torre / n_torres * 100`` al % global del
+    proyecto, anclado en su ``fecha_avance``. La serie es el acumulado del
+    avance por fecha (curva S real: monótona creciente).
+
+    Retorna {'labels':[iso], 'ejecutado':[float redondeado a 2]}.
+    """
+    if n_torres <= 0 or not pares_fecha_pct:
+        return {'labels': [], 'ejecutado': []}
+    from collections import defaultdict
+    aporte_por_fecha = defaultdict(float)
+    for fecha, avance in pares_fecha_pct:
+        aporte_por_fecha[fecha] += (avance / n_torres) * 100.0
+    fechas_ordenadas = sorted(aporte_por_fecha.keys())
+    labels = []
+    ejecutado = []
+    acum = 0.0
+    for f in fechas_ordenadas:
+        acum += aporte_por_fecha[f]
+        labels.append(f.isoformat())
+        ejecutado.append(round(acum, 2))
+    return {'labels': labels, 'ejecutado': ejecutado}
+
+
+def serie_curva_s_real(proyecto, fase) -> dict:
+    """Serie "Ejecutado" de la Curva S a partir del avance REAL por torre.
+
+    El avance real ponderado por torre se distribuye en el tiempo según la
+    ``fecha_avance_*`` de cada instancia y se acumula (curva S). Cada torre
+    pesa 1/n_torres del 100% del proyecto.
+
+    fase ∈ {OOCC, MONTAJE, TENDIDO}. Devuelve {'labels', 'ejecutado'}.
+    Para TENDIDO el avance por torre = promedio(avance_conductor, avance_fibra).
+    """
+    fase = (fase or '').upper()
+    n_torres = proyecto.torres.count() or 0
+    pares = []
+
+    if fase == FASE_OOCC:
+        for torre_id, patas in _detalles_oc_por_torre(proyecto).items():
+            avance = _avance_oc_torre(patas)
+            # Ancla en la fecha más reciente entre las patas de la torre.
+            fecha = max(fecha_avance_oc(p) for p in patas)
+            pares.append((fecha, avance))
+    elif fase == FASE_MONTAJE:
+        for d in _detalles_montaje(proyecto):
+            pares.append((fecha_avance_montaje(d), _to_float(d.avance_ponderado)))
+    elif fase == FASE_TENDIDO:
+        for t in _tendido_torres(proyecto):
+            avance = (_to_float(t.avance_conductor) + _to_float(t.avance_fibra)) / 2.0
+            pares.append((fecha_avance_tendido(t), avance))
+    else:
+        return {'labels': [], 'ejecutado': []}
+
+    return _acumular_por_fecha(pares, n_torres)
+
+
+# ==========================================================================
+# serie_planeado — del cronograma ProgramacionFase; NO inventa datos
+# ==========================================================================
+
+def serie_planeado(proyecto, fase) -> dict:
+    """Serie "Planeado" de la Curva S desde el cronograma ``ProgramacionFase``.
+
+    Interpolación lineal del ``peso_pct`` de la sección entre
+    ``fecha_inicio_planeada`` y ``fecha_fin_planeada`` (mismo patrón que
+    ``ProyectoConstruccion.curva_s_data``), normalizado a 0..100. Si la fase no
+    tiene fechas/peso en el cronograma, cae al ``pct_programado`` del último
+    ``DashboardAvanceSemanal`` de esa fase (dato manual). NO inventa datos: si
+    no hay ninguno de los dos, devuelve serie vacía.
+
+    fase ∈ {OOCC, MONTAJE, TENDIDO}. Devuelve {'labels', 'planeado'}.
+    """
+    fase = (fase or '').upper()
+    from .models import ProgramacionFase, DashboardAvanceSemanal
+
+    seccion = {v: k for k, v in FASE_DASHBOARD_POR_SECCION.items()}.get(fase)
+    prog = None
+    if seccion:
+        prog = ProgramacionFase.objects.filter(proyecto=proyecto, seccion=seccion).first()
+
+    if prog and prog.fecha_inicio_planeada and prog.fecha_fin_planeada and prog.peso_pct:
+        inicio = prog.fecha_inicio_planeada
+        fin = prog.fecha_fin_planeada
+        total_dias = (fin - inicio).days
+        # Normaliza a 0..100 dentro de la fase (la fase completa = 100).
+        labels = [inicio.isoformat(), fin.isoformat()]
+        planeado = [0.0, 100.0]
+        if total_dias > 0:
+            # Punto intermedio "hoy" si cae dentro del rango, para una curva más fiel.
+            hoy = date.today()
+            if inicio < hoy < fin:
+                pct_hoy = round(((hoy - inicio).days / total_dias) * 100.0, 2)
+                labels = [inicio.isoformat(), hoy.isoformat(), fin.isoformat()]
+                planeado = [0.0, pct_hoy, 100.0]
+        return {'labels': labels, 'planeado': planeado}
+
+    # Fallback: dato manual del semanal.
+    semanas = list(DashboardAvanceSemanal.objects
+                   .filter(proyecto=proyecto, fase=fase)
+                   .order_by('semana'))
+    if semanas:
+        return {
+            'labels': [s.semana.isoformat() for s in semanas],
+            'planeado': [round(_to_float(s.pct_programado), 2) for s in semanas],
+        }
+    return {'labels': [], 'planeado': []}
+
+
+# ==========================================================================
+# avance_por_etapa — genérico para las 3 fases (G2 universal)
+# ==========================================================================
+
+def _etapas_def_por_fase(fase):
+    """Devuelve la lista de definiciones de etapa para la fase (o conductor de
+    tendido). Para TENDIDO retorna conductor; usar ``avance_por_etapa_tendido``
+    para conductor+fibra por separado."""
+    fase = (fase or '').upper()
+    if fase == FASE_OOCC:
+        return ETAPAS_OC_PESOS
+    if fase == FASE_MONTAJE:
+        # normaliza al formato de 6 columnas (sin es_bool extra): añade es_bool=True
+        return [(c, l, campo, peso_attr, default, True)
+                for (c, l, campo, peso_attr, default) in ETAPAS_MONTAJE_PESOS]
+    if fase == FASE_TENDIDO:
+        return [(c, l, campo, peso_attr, default, True)
+                for (c, l, campo, peso_attr, default) in ETAPAS_TENDIDO_CONDUCTOR_PESOS]
+    return []
+
+
+def avance_por_etapa(proyecto, fase) -> list:
+    """% de torres COMPLETAS por etapa de la fase (G2 genérico).
+
+    Una torre cuenta como "completa" en una etapa cuando su valor de etapa
+    está al 100% (booleano True, o pct >= 1.0 para los campos 0..1 de OC).
+    Para OC se agrega a nivel torre (todas las patas deben tener la etapa).
+
+    Devuelve [{'etapa','label','pct','completas','totales'}] en el orden de la
+    definición. Para TENDIDO devuelve solo conductor (usar
+    ``avance_por_etapa_tendido`` para ambos sets).
+    """
+    fase = (fase or '').upper()
+    etapas = _etapas_def_por_fase(fase)
+    if not etapas:
+        return []
+
+    if fase == FASE_OOCC:
+        by_torre = _detalles_oc_por_torre(proyecto)
+        resultado = []
+        for codigo, label, campo, _peso_attr, _default, es_bool in etapas:
+            totales = len(by_torre)
+            completas = 0
+            for _torre_id, patas in by_torre.items():
+                if es_bool:
+                    ok = all(bool(getattr(p, campo, False)) for p in patas)
+                else:
+                    ok = all(_to_float(getattr(p, campo, 0)) >= 1.0 for p in patas)
+                if ok:
+                    completas += 1
+            pct = round((completas / totales) * 100, 2) if totales else 0.0
+            resultado.append({'etapa': codigo, 'label': label, 'pct': pct,
+                              'completas': completas, 'totales': totales})
+        return resultado
+
+    if fase == FASE_MONTAJE:
+        detalles = list(_detalles_montaje(proyecto))
+    else:  # TENDIDO conductor
+        detalles = list(_tendido_torres(proyecto))
+
+    resultado = []
+    for codigo, label, campo, _peso_attr, _default, _es_bool in etapas:
+        totales = len(detalles)
+        completas = sum(1 for d in detalles if bool(getattr(d, campo, False)))
+        pct = round((completas / totales) * 100, 2) if totales else 0.0
+        resultado.append({'etapa': codigo, 'label': label, 'pct': pct,
+                          'completas': completas, 'totales': totales})
+    return resultado
+
+
+def avance_por_etapa_tendido(proyecto) -> dict:
+    """Avance por etapa de Tendido en dos sets: conductor (6) + fibra (5).
+
+    Devuelve {'conductor':[...], 'fibra':[...]} con el mismo formato que
+    ``avance_por_etapa``. Helper específico para B3 (2 gráficas).
+    """
+    detalles = list(_tendido_torres(proyecto))
+    totales = len(detalles)
+
+    def _build(defs):
+        out = []
+        for codigo, label, campo, _peso_attr, _default in defs:
+            completas = sum(1 for d in detalles if bool(getattr(d, campo, False)))
+            pct = round((completas / totales) * 100, 2) if totales else 0.0
+            out.append({'etapa': codigo, 'label': label, 'pct': pct,
+                       'completas': completas, 'totales': totales})
+        return out
+
+    return {
+        'conductor': _build(ETAPAS_TENDIDO_CONDUCTOR_PESOS),
+        'fibra': _build(ETAPAS_TENDIDO_FIBRA_PESOS),
+    }
+
+
+# ==========================================================================
+# vista_por_torre — punto 3
+# ==========================================================================
+
+def vista_por_torre(proyecto, fase) -> list:
+    """Lista por torre con % de avance, si está completa y etapas pendientes.
+
+    Devuelve [{'torre_id','numero','pct','completa','pendientes':[labels]}]
+    ordenado por número de torre. fase ∈ {OOCC, MONTAJE, TENDIDO}.
+    Para TENDIDO el % = promedio(conductor, fibra) y las pendientes combinan
+    ambos sets.
+    """
+    fase = (fase or '').upper()
+    resultado = []
+
+    if fase == FASE_OOCC:
+        by_torre = _detalles_oc_por_torre(proyecto)
+        # Necesitamos numero por torre.
+        from .models import TorreConstruccion
+        numeros = {t.id: t.numero for t in
+                   TorreConstruccion.objects.filter(proyecto=proyecto)}
+        for torre_id, patas in by_torre.items():
+            pct = round(_avance_oc_torre(patas) * 100, 2)
+            pendientes = []
+            for codigo, label, campo, _pa, _d, es_bool in ETAPAS_OC_PESOS:
+                if es_bool:
+                    ok = all(bool(getattr(p, campo, False)) for p in patas)
+                else:
+                    ok = all(_to_float(getattr(p, campo, 0)) >= 1.0 for p in patas)
+                if not ok:
+                    pendientes.append(label)
+            resultado.append({
+                'torre_id': torre_id,
+                'numero': numeros.get(torre_id, ''),
+                'pct': pct,
+                'completa': pct >= 100.0,
+                'pendientes': pendientes,
+            })
+    elif fase == FASE_MONTAJE:
+        for d in _detalles_montaje(proyecto):
+            pct = round(_to_float(d.avance_ponderado) * 100, 2)
+            pendientes = [label for (_c, label, campo, _pa, _df) in ETAPAS_MONTAJE_PESOS
+                          if not bool(getattr(d, campo, False))]
+            resultado.append({
+                'torre_id': d.torre_id,
+                'numero': getattr(d.torre, 'numero', ''),
+                'pct': pct,
+                'completa': pct >= 100.0,
+                'pendientes': pendientes,
+            })
+    elif fase == FASE_TENDIDO:
+        for t in _tendido_torres(proyecto):
+            pct = round(((_to_float(t.avance_conductor) + _to_float(t.avance_fibra)) / 2.0) * 100, 2)
+            pendientes = []
+            for _c, label, campo, _pa, _df in ETAPAS_TENDIDO_CONDUCTOR_PESOS:
+                if not bool(getattr(t, campo, False)):
+                    pendientes.append(label)
+            for _c, label, campo, _pa, _df in ETAPAS_TENDIDO_FIBRA_PESOS:
+                if not bool(getattr(t, campo, False)):
+                    pendientes.append(label)
+            resultado.append({
+                'torre_id': t.torre_id,
+                'numero': getattr(t.torre, 'numero', ''),
+                'pct': pct,
+                'completa': pct >= 100.0,
+                'pendientes': pendientes,
+            })
+
+    resultado.sort(key=lambda r: (str(r['numero'])))
+    return resultado
+
+
+# ==========================================================================
+# avance_general — punto 4 (7 fases visibles + global ponderado)
+# ==========================================================================
+
+#: Las 7 fases del dashboard general -> (seccion ProgramacionFase, label,
+#: callable que devuelve el % real 0..100 dado el proyecto).
+def _pct_ingenieria(proyecto):
+    # Sin modelo de ejecución dedicado: usa peso/avance esperado del cronograma.
+    from .models import ProgramacionFase
+    f = ProgramacionFase.objects.filter(proyecto=proyecto, seccion='INGENIERIA').first()
+    return float(f.pct_avance_esperado_hoy or 0) if f else 0.0
+
+
+def _pct_preliminares(proyecto):
+    from .models import ProgramacionFase
+    vals = []
+    for sec in ('SOCIOPREDIAL', 'SOCIOAMBIENTAL'):
+        f = ProgramacionFase.objects.filter(proyecto=proyecto, seccion=sec).first()
+        if f and f.pct_avance_esperado_hoy is not None:
+            vals.append(float(f.pct_avance_esperado_hoy))
+    return round(sum(vals) / len(vals), 2) if vals else 0.0
+
+
+def _pct_obra_civil(proyecto):
+    # Deriva del oc_detalle real (257 filas en prod) — mismo origen que la Curva
+    # S real, NO del porcentaje_avance_civil_ponderado legacy (que cuelga de
+    # torre.pata_obra y sale en 0% cuando el avance real está en oc_detalle).
+    by_torre = _detalles_oc_por_torre(proyecto)
+    n = proyecto.torres.count() or 0
+    if n == 0 or not by_torre:
+        return 0.0
+    suma = sum(_avance_oc_torre(patas) for patas in by_torre.values())
+    return round((suma / n) * 100, 2)
+
+
+def _pct_montaje(proyecto):
+    detalles = list(_detalles_montaje(proyecto))
+    n = proyecto.torres.count() or 0
+    if n == 0 or not detalles:
+        return 0.0
+    suma = sum(_to_float(d.avance_ponderado) for d in detalles)
+    return round((suma / n) * 100, 2)
+
+
+def _pct_tendido(proyecto):
+    torres = list(_tendido_torres(proyecto))
+    n = proyecto.torres.count() or 0
+    if n == 0 or not torres:
+        return 0.0
+    suma = sum((_to_float(t.avance_conductor) + _to_float(t.avance_fibra)) / 2.0 for t in torres)
+    return round((suma / n) * 100, 2)
+
+
+def _pct_spt_pintura(proyecto):
+    from .models import SPTTorre
+    qs = SPTTorre.objects.filter(proyecto=proyecto)
+    vals = [int(s.porcentaje_avance or 0) for s in qs]
+    return round(sum(vals) / len(vals), 2) if vals else 0.0
+
+
+def _pct_detalles_finales(proyecto):
+    # ActividadFinalTorre se relaciona por torre (no tiene FK proyecto directa).
+    from .models_b1_actividades_finales import ActividadFinalTorre
+    qs = ActividadFinalTorre.objects.filter(torre__proyecto=proyecto)
+    vals = [float(a.pct_avance) for a in qs]
+    return round(sum(vals) / len(vals), 2) if vals else 0.0
+
+
+#: (seccion, label, fn) — orden de presentación de las 7 fases.
+FASES_GENERAL = [
+    ('INGENIERIA', 'Ingeniería', _pct_ingenieria),
+    ('SOCIOPREDIAL', 'Actividades Preliminares', _pct_preliminares),
+    ('OBRA_CIVIL', 'Obra Civil', _pct_obra_civil),
+    ('MONTAJE', 'Montaje', _pct_montaje),
+    ('TENDIDO', 'Tendido', _pct_tendido),
+    ('SPT', 'SPT y Pintura', _pct_spt_pintura),
+    ('PRUEBAS', 'Detalles Finales', _pct_detalles_finales),
+]
+
+
+def avance_general(proyecto) -> dict:
+    """Dashboard GENERAL: % por cada una de las 7 fases + global ponderado.
+
+    Los pesos salen de ``ProgramacionFase.peso_pct`` por sección; si todos son
+    0 (estado actual de prod), cae a equiponderado (1/7 cada una). El
+    ``global_pct`` es el promedio ponderado de los % de fase.
+
+    Devuelve {'fases':[{'seccion','label','pct','peso'}], 'global_pct':float}.
+    """
+    from .models import ProgramacionFase
+    pesos_por_seccion = {
+        f.seccion: int(f.peso_pct or 0)
+        for f in ProgramacionFase.objects.filter(proyecto=proyecto)
+    }
+
+    fases_out = []
+    for seccion, label, fn in FASES_GENERAL:
+        pct = round(float(fn(proyecto)), 2)
+        peso = pesos_por_seccion.get(seccion, 0)
+        fases_out.append({'seccion': seccion, 'label': label, 'pct': pct, 'peso': peso})
+
+    total_peso = sum(f['peso'] for f in fases_out)
+    if total_peso > 0:
+        global_pct = sum(f['pct'] * f['peso'] for f in fases_out) / total_peso
+    else:
+        # Fallback equiponderado (estado actual de prod: peso_pct=0).
+        global_pct = sum(f['pct'] for f in fases_out) / len(fases_out) if fases_out else 0.0
+
+    return {'fases': fases_out, 'global_pct': round(global_pct, 2)}

--- a/apps/construccion/migrations/0027_dashboards_backfill.py
+++ b/apps/construccion/migrations/0027_dashboards_backfill.py
@@ -1,0 +1,54 @@
+# Backfill de la curva de avance REAL para los Dashboards de fase (#139 · S4).
+#
+# El Dashboard de Obra Civil sale en 0% porque la Curva S cuelga de
+# `construccion_dashboard_semanal` (2 filas en prod) y `construccion_snapshot_avance`
+# está VACÍA (0 filas) — sin snapshots no hay curva real histórica.
+#
+# Esta migración genera UN snapshot "hoy" por proyecto (semilla de la curva real)
+# usando `SnapshotAvance.capturar`, que lee el avance real ya calculado
+# (`porcentaje_avance_civil_ponderado`, montaje, tendido). Es IDEMPOTENTE: si ya
+# existe un snapshot para (proyecto, hoy) hace update_or_create (no duplica) y la
+# reversa es no-op (no borra datos del cliente). NO toca pesos del cronograma
+# (`construccion_programacion_fase`).
+#
+# Nota: se usa el modelo REAL (no el histórico de `apps.get_model`) dentro de la
+# RunPython porque `SnapshotAvance.capturar` depende de properties calculadas que
+# no existen en el modelo histórico. Es seguro: solo genera/actualiza snapshots,
+# no altera el esquema.
+
+from datetime import date
+
+from django.db import migrations
+
+
+def backfill_snapshot_hoy(apps, schema_editor):
+    """Forward: genera SnapshotAvance 'hoy' por proyecto (idempotente)."""
+    try:
+        from apps.construccion.models import ProyectoConstruccion, SnapshotAvance
+    except Exception:
+        # Si el import falla en un entorno de prueba reducido, no romper migrate.
+        return
+
+    hoy = date.today()
+    for proyecto in ProyectoConstruccion.objects.all():
+        try:
+            SnapshotAvance.capturar(proyecto, fecha=hoy)
+        except Exception:
+            # Un proyecto sin torres/datos no debe abortar el backfill del resto.
+            continue
+
+
+def revertir_noop(apps, schema_editor):
+    """Reverse: no-op — no borramos snapshots (son datos del cliente)."""
+    return
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('construccion', '0026_oc_clase_cimentacion'),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_snapshot_hoy, revertir_noop),
+    ]

--- a/apps/construccion/tests_b1_dashboard_oc.py
+++ b/apps/construccion/tests_b1_dashboard_oc.py
@@ -1,0 +1,309 @@
+"""Tests B1 (#139) — cableado del avance REAL al Dashboard de Obra Civil.
+
+Cubre los 3 tests E2E del BLUEPRINT.sub_features.B1.tests_e2e:
+  - b1_curva_s_oc_ejecutado_real
+  - b1_avance_etapa_oc_6etapas
+  - b1_vista_torre_oc
+
+más edge cases del dominio (proyecto sin avance → curva vacía sin error,
+torre parcial → no completa, drill-down URL presente) y un test contra dato
+"legacy" (oc_detalle sin avance reciente preservado).
+
+B1 reusa el backbone S1 ``calculators_avance_real`` (no re-implementa el
+cálculo) y cablea la Curva S + las 6 etapas + la vista por torre al avance real
+de los ``ObraCivilTorreDetalle`` (oc_detalle, 257 filas en prod).
+
+Nombre de archivo ``tests_b1_*.py`` por paridad con los tests B2–B5; se ejecuta
+pasando la ruta a pytest (igual que tests_b3_dashboard.py).
+"""
+import json
+from decimal import Decimal
+
+import pytest
+from django.urls import reverse
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def proyecto_oc(db):
+    """ProyectoConstruccion base para colgar oc_detalle."""
+    from apps.construccion.models import ProyectoConstruccion
+    from apps.contratos.models import Contrato
+
+    contrato = Contrato.objects.create(
+        unidad_negocio=Contrato.UnidadNegocio.CONSTRUCCION,
+        codigo='TEST-B1-001',
+        nombre='Contrato test B1',
+        cliente='Test Cliente B1',
+    )
+    return ProyectoConstruccion.objects.create(
+        contrato=contrato,
+        nombre='Proyecto B1 test',
+        estado='EJECUCION',
+    )
+
+
+def _torre(proyecto, numero):
+    from apps.construccion.models import TorreConstruccion
+    return TorreConstruccion.objects.create(proyecto=proyecto, numero=numero, tipo='D6')
+
+
+def _oc_detalle(proyecto, torre, pata, **flags):
+    """Crea un ObraCivilTorreDetalle (pata) con los campos de etapa dados.
+
+    Los pct de etapa (exc/sol/ace/vac/com) son 0..1; cerr_finalizado_ok es bool.
+    Defaults: todo en 0 / False (pata sin avance).
+    """
+    from apps.construccion.models_b3_oc_detalle import ObraCivilTorreDetalle
+    base = {
+        'cerr_finalizado_ok': False,
+        'exc_ejecutada_pct': Decimal('0'),
+        'sol_ejecutado_pct': Decimal('0'),
+        'ace_instalacion_pct': Decimal('0'),
+        'vac_ejecutado_pct': Decimal('0'),
+        'com_finalizada_pct': Decimal('0'),
+    }
+    base.update(flags)
+    return ObraCivilTorreDetalle.objects.create(
+        proyecto=proyecto, torre=torre, pata=pata, **base)
+
+
+def _torre_oc_completa(proyecto, numero):
+    """Torre con 4 patas, TODAS las 6 etapas completas → avance 100%."""
+    torre = _torre(proyecto, numero)
+    for p in ('A', 'B', 'C', 'D'):
+        _oc_detalle(
+            proyecto, torre, p,
+            cerr_finalizado_ok=True,
+            exc_ejecutada_pct=Decimal('1'),
+            sol_ejecutado_pct=Decimal('1'),
+            ace_instalacion_pct=Decimal('1'),
+            vac_ejecutado_pct=Decimal('1'),
+            com_finalizada_pct=Decimal('1'),
+        )
+    return torre
+
+
+# ===========================================================================
+# 1. b1_curva_s_oc_ejecutado_real — serie "Ejecutado" > 0% desde oc_detalle
+# ===========================================================================
+
+@pytest.mark.django_db
+def test_b1_curva_s_oc_ejecutado_real(authenticated_client, proyecto_oc):
+    """La Curva S de OC toma "Ejecutado" del avance real (oc_detalle), NO del
+    DashboardAvanceSemanal vacío → con 1 torre 100% el último punto > 0%."""
+    from apps.construccion import calculators_avance_real as car
+
+    _torre_oc_completa(proyecto_oc, 'T1')
+    _torre(proyecto_oc, 'T2')  # 2ª torre sin oc_detalle → arrastra el promedio
+
+    serie = car.serie_curva_s_real(proyecto_oc, 'OOCC')
+    assert serie['ejecutado'], 'la serie Ejecutado no debe estar vacía'
+    # 1 de 2 torres al 100% → acumulado final = 50% del proyecto.
+    assert serie['ejecutado'][-1] == pytest.approx(50.0, abs=0.01)
+
+    # Render del dashboard: la línea Ejecutado se cablea en datos_chart real.
+    url = reverse('construccion:dashboard_obra_civil',
+                  kwargs={'proyecto_id': proyecto_oc.id})
+    resp = authenticated_client.get(url)
+    assert resp.status_code == 200, resp.content[:500]
+    body = resp.content.decode()
+    assert 'id="curva-s-chart"' in body
+    assert 'data-charts-ready' in body
+    # La tarjeta % Ejecutado refleja el real (50.0%), no 0.
+    assert 'data-pct-ejecutado' in body
+    assert '50.0%' in body
+
+
+@pytest.mark.django_db
+def test_b1_curva_s_proyecto_sin_avance_curva_vacia_sin_error(
+        authenticated_client, proyecto_oc):
+    """Edge: proyecto sin oc_detalle → serie Ejecutado vacía, dashboard 200
+    (no 500, no división por cero)."""
+    from apps.construccion import calculators_avance_real as car
+    _torre(proyecto_oc, 'T1')  # torre sin detalles
+
+    serie = car.serie_curva_s_real(proyecto_oc, 'OOCC')
+    assert serie == {'labels': [], 'ejecutado': []}
+
+    url = reverse('construccion:dashboard_obra_civil',
+                  kwargs={'proyecto_id': proyecto_oc.id})
+    resp = authenticated_client.get(url)
+    assert resp.status_code == 200
+    body = resp.content.decode()
+    # datos_chart presente y parseable aunque vacío (no rompe Chart.js init).
+    assert 'id="curva-s-chart"' in body
+    assert 'data-charts-ready' in body
+
+
+# ===========================================================================
+# 2. b1_avance_etapa_oc_6etapas — 6 etapas con Cerramiento
+# ===========================================================================
+
+@pytest.mark.django_db
+def test_b1_avance_etapa_oc_6etapas(authenticated_client, proyecto_oc):
+    """El avance por etapa de OC muestra las 6 etapas (incluye Cerramiento),
+    en el orden del backbone, con los pesos del Excel del cliente."""
+    from apps.construccion import calculators_avance_real as car
+
+    # T1: cerramiento + excavación completos en las 4 patas; resto 0.
+    t1 = _torre(proyecto_oc, 'T1')
+    for p in ('A', 'B', 'C', 'D'):
+        _oc_detalle(proyecto_oc, t1, p,
+                    cerr_finalizado_ok=True, exc_ejecutada_pct=Decimal('1'))
+    # T2: nada completo.
+    t2 = _torre(proyecto_oc, 'T2')
+    for p in ('A', 'B', 'C', 'D'):
+        _oc_detalle(proyecto_oc, t2, p)
+
+    etapas = car.avance_por_etapa(proyecto_oc, 'OOCC')
+    assert [e['etapa'] for e in etapas] == [
+        'CERRAMIENTO', 'EXCAVACION', 'SOLADO', 'ACERO', 'VACIADO', 'COMPACTACION']
+    assert len(etapas) == 6, 'deben ser 6 etapas, no las 5 legacy'
+
+    cerr = next(e for e in etapas if e['etapa'] == 'CERRAMIENTO')
+    assert cerr['totales'] == 2 and cerr['completas'] == 1 and cerr['pct'] == 50.0
+    exc = next(e for e in etapas if e['etapa'] == 'EXCAVACION')
+    assert exc['completas'] == 1 and exc['pct'] == 50.0
+    sol = next(e for e in etapas if e['etapa'] == 'SOLADO')
+    assert sol['completas'] == 0 and sol['pct'] == 0.0
+
+    # En el HTML la etapa Cerramiento aparece como texto visible (journey).
+    url = reverse('construccion:dashboard_obra_civil',
+                  kwargs={'proyecto_id': proyecto_oc.id})
+    resp = authenticated_client.get(url)
+    assert resp.status_code == 200
+    body = resp.content.decode()
+    assert 'Cerramiento' in body
+    assert 'data-etapas-oc6' in body
+    # Las 6 etapas como filas con data-etapa.
+    for codigo in ('CERRAMIENTO', 'EXCAVACION', 'SOLADO', 'ACERO', 'VACIADO', 'COMPACTACION'):
+        assert f'data-etapa="{codigo}"' in body, f'etapa {codigo} faltante en HTML'
+
+
+@pytest.mark.django_db
+def test_b1_avance_etapa_completa_solo_si_todas_las_patas(proyecto_oc):
+    """Edge dominio: una torre cuenta completa en una etapa SOLO si TODAS sus
+    patas la tienen (3/4 patas con vaciado → torre NO completa)."""
+    from apps.construccion import calculators_avance_real as car
+    t = _torre(proyecto_oc, 'T9')
+    for p, ok in (('A', '1'), ('B', '1'), ('C', '1'), ('D', '0')):
+        _oc_detalle(proyecto_oc, t, p, vac_ejecutado_pct=Decimal(ok))
+    etapas = {e['etapa']: e for e in car.avance_por_etapa(proyecto_oc, 'OOCC')}
+    assert etapas['VACIADO']['totales'] == 1
+    assert etapas['VACIADO']['completas'] == 0
+    assert etapas['VACIADO']['pct'] == 0.0
+
+
+# ===========================================================================
+# 3. b1_vista_torre_oc — cuáles 100% / pendientes + drill-down
+# ===========================================================================
+
+@pytest.mark.django_db
+def test_b1_vista_torre_oc(authenticated_client, proyecto_oc):
+    """Vista por torre: clasifica 100% vs en-curso, lista etapas pendientes y
+    enlaza al drill-down obra_civil_torre del punto bajo."""
+    from apps.construccion import calculators_avance_real as car
+
+    _torre_oc_completa(proyecto_oc, 'T1')  # 100%
+    t2 = _torre(proyecto_oc, 'T2')         # parcial: solo cerramiento
+    for p in ('A', 'B', 'C', 'D'):
+        _oc_detalle(proyecto_oc, t2, p, cerr_finalizado_ok=True)
+
+    vista = car.vista_por_torre(proyecto_oc, 'OOCC')
+    by_num = {v['numero']: v for v in vista}
+    assert by_num['T1']['completa'] is True
+    assert by_num['T1']['pct'] == 100.0
+    assert by_num['T1']['pendientes'] == []
+    assert by_num['T2']['completa'] is False
+    # T2 tiene cerramiento → Cerramiento NO está en pendientes; el resto sí.
+    assert 'Cerramiento' not in by_num['T2']['pendientes']
+    assert 'Excavación' in by_num['T2']['pendientes']
+
+    url = reverse('construccion:dashboard_obra_civil',
+                  kwargs={'proyecto_id': proyecto_oc.id})
+    resp = authenticated_client.get(url)
+    assert resp.status_code == 200
+    body = resp.content.decode()
+    assert 'data-vista-torres-oc' in body
+    assert 'data-torre-pct' in body
+    # Drill-down: el href a obra_civil_torre de T1 está presente.
+    t1 = next(t for t in proyecto_oc.torres.all() if t.numero == 'T1')
+    drill = reverse('construccion:obra_civil_torre',
+                    kwargs={'proyecto_id': proyecto_oc.id, 'torre_id': t1.id})
+    assert drill in body, 'falta el enlace de drill-down a obra_civil_torre'
+    # Contador de torres completas (1 de 2).
+    assert 'torres al 100%' in body
+
+
+@pytest.mark.django_db
+def test_b1_vista_torre_proyecto_sin_avance_vacia_sin_error(
+        authenticated_client, proyecto_oc):
+    """Edge: proyecto sin oc_detalle → vista vacía, dashboard 200 con el aviso
+    'Sin avance de obra civil'."""
+    from apps.construccion import calculators_avance_real as car
+    _torre(proyecto_oc, 'T1')
+    vista = car.vista_por_torre(proyecto_oc, 'OOCC')
+    assert vista == []
+
+    url = reverse('construccion:dashboard_obra_civil',
+                  kwargs={'proyecto_id': proyecto_oc.id})
+    resp = authenticated_client.get(url)
+    assert resp.status_code == 200
+    body = resp.content.decode()
+    assert 'Sin avance de obra civil' in body
+
+
+# ===========================================================================
+# Payload bundle (calculators.dashboard_oc_real_payload) + dato legacy
+# ===========================================================================
+
+@pytest.mark.django_db
+def test_b1_payload_bundle_estructura_y_carry(proyecto_oc):
+    """El payload bundle del dashboard de OC trae curva_s, 6 etapas, vista y
+    tarjetas, alineando las dos series sobre un eje X común (carry forward)."""
+    from apps.construccion.calculators import dashboard_oc_real_payload
+    _torre_oc_completa(proyecto_oc, 'T1')
+
+    payload = dashboard_oc_real_payload(proyecto_oc)
+    assert set(payload) == {'curva_s', 'avance_etapas', 'vista_torres', 'tarjetas'}
+    assert len(payload['avance_etapas']) == 6
+    cs = payload['curva_s']
+    # Eje X común: planeado y ejecutado tienen la MISMA longitud que labels.
+    assert len(cs['planeado']) == len(cs['labels'])
+    assert len(cs['ejecutado']) == len(cs['labels'])
+    assert payload['tarjetas']['pct_construido'] == 100.0
+    # curva_s viaja como JSON al template (guard es-CO: nunca floats crudos en
+    # JS inline) — debe ser JSON-serializable tal cual.
+    assert json.loads(json.dumps(cs)) == cs
+    # vista_torres trae torre_id UUID (se serializa por-campo / se usa en reverse
+    # en la vista); el resto de cada fila es JSON-serializable.
+    for fila in payload['vista_torres']:
+        plano = {k: v for k, v in fila.items() if k != 'torre_id'}
+        assert json.loads(json.dumps(plano)) == plano
+
+
+@pytest.mark.django_db
+def test_b1_dato_legacy_oc_detalle_sin_avance_preservado(proyecto_oc):
+    """Test contra dato 'legacy': un oc_detalle viejo sin etapas (todo 0/False,
+    como las filas pre-#139) NO rompe el cálculo y aporta 0% — preservado, no
+    inventado."""
+    from apps.construccion import calculators_avance_real as car
+    from apps.construccion.models_b3_oc_detalle import ObraCivilTorreDetalle
+
+    t = _torre(proyecto_oc, 'LEG-1')
+    # Registro creado SOLO con los NOT NULL mínimos (como el legacy en prod).
+    legacy = ObraCivilTorreDetalle.objects.create(
+        proyecto=proyecto_oc, torre=t, pata='A')
+    legacy.refresh_from_db()
+    # avance_ponderado del legacy = 0 (sin etapas), nunca None.
+    assert float(legacy.avance_ponderado) == 0.0
+
+    serie = car.serie_curva_s_real(proyecto_oc, 'OOCC')
+    # Con 1 torre al 0% → curva con punto(s) pero acumulado 0.0 (no lanza).
+    assert all(v == 0.0 for v in serie['ejecutado'])
+    vista = car.vista_por_torre(proyecto_oc, 'OOCC')
+    assert vista[0]['pct'] == 0.0
+    assert vista[0]['completa'] is False

--- a/apps/construccion/tests_b3_dashboard.py
+++ b/apps/construccion/tests_b3_dashboard.py
@@ -562,14 +562,25 @@ def test_141_dashboard_oc_renderiza_tres_canvas_y_ready_flag(
 
 
 @pytest.mark.django_db
-def test_141_dashboard_montaje_no_muestra_graficas_141(
+def test_141_dashboard_montaje_no_muestra_graficas_oc_only(
         authenticated_client, proyecto_indicadores):
-    """El template es compartido: el dashboard de Montaje NO debe mostrar las 3
-    gráficas de #141 (solo aplican a Obra Civil)."""
+    """Tras el bloque dashboards (#139, F4 wiring), ``dashboard_montaje`` abre el
+    dashboard REAL de Montaje (``DashboardMontajeRealView`` con su template
+    propio ``dashboard_montaje.html``), NO el view del semanal vacío.
+
+    Actualizado en integración F4: antes (#141) este name resolvía a la vista del
+    template compartido sin gráficas y el test afirmaba que NO había ``avance-
+    etapas-chart``. Ahora el dashboard de Montaje SÍ tiene su Curva S + avance por
+    etapa (chart genérico del parcial base + ``#montaje-etapas-chart`` dedicado),
+    que es justamente el objetivo de #139. Lo que sigue sin aplicar a Montaje es
+    la gráfica de desviación de materiales de vaciado, que es OC-only (#141).
+    """
     url = reverse('construccion:dashboard_montaje',
                   kwargs={'proyecto_id': proyecto_indicadores.id})
     resp = authenticated_client.get(url)
     assert resp.status_code == 200
     body = resp.content.decode()
-    assert 'id="avance-etapas-chart"' not in body
+    # Montaje real renderiza su propia gráfica de etapas (OK que exista).
+    assert 'id="montaje-etapas-chart"' in body
+    # La desviación de materiales de vaciado es exclusiva de Obra Civil (#141).
     assert 'id="desviacion-materiales-chart"' not in body

--- a/apps/construccion/tests_b3_tendido_dashboard.py
+++ b/apps/construccion/tests_b3_tendido_dashboard.py
@@ -1,0 +1,307 @@
+"""Tests B3 — Dashboard de Tendido (Conductor + Fibra OPGW) (#139).
+
+Cubre los tests_e2e del BLUEPRINT.sub_features.B3:
+  - b3_dashboard_tendido_conductor: la gráfica/datos de Conductor reflejan el
+    avance real por etapa (6 etapas) + Curva S ejecutado > 0.
+  - b3_dashboard_tendido_fibra:     la gráfica/datos de Fibra OPGW reflejan el
+    avance real por etapa (5 etapas).
+
+Edge cases del dominio (no genéricos):
+  - proyecto SIN registros de tendido → HTTP 200, listas vacías, sin 500.
+  - torre con conductor 100% pero fibra 0% → conductor completa, fibra pendiente
+    (las dos secciones son SUMPRODUCT independientes; no se contaminan).
+  - dato "legacy": TendidoTorre creado solo con flags de conductor (como en prod,
+    65 filas con tendido_conductor=True) → el dashboard lo computa sin tocar el
+    modelo y la vista por torre lo lista con sus pendientes de fibra.
+
+La URL del dashboard la cablea F4 en urls.py (include de urls_dashboards_b3_tendido),
+así que aquí ejercemos la vista vía RequestFactory + usuario admin (no depende del
+wiring pendiente) y el endpoint de datos por el mismo medio.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory
+
+from apps.construccion.views_dashboards_b3_tendido import (
+    DashboardTendidoDataView,
+    DashboardTendidoView,
+)
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def admin(db):
+    return User.objects.create_user(
+        email='admin-b3-tendido@test.com',
+        password='x',
+        first_name='Admin',
+        last_name='B3',
+        rol='admin',
+        is_staff=True,
+        is_superuser=True,
+    )
+
+
+@pytest.fixture
+def proyecto(db):
+    from apps.contratos.models import Contrato
+    from apps.construccion.models import ProyectoConstruccion
+
+    contrato = Contrato.objects.create(
+        unidad_negocio=Contrato.UnidadNegocio.CONSTRUCCION,
+        codigo='TEST-B3-TEND-001',
+        nombre='Contrato test B3 Tendido',
+        cliente='Cliente Test',
+    )
+    return ProyectoConstruccion.objects.create(
+        contrato=contrato,
+        nombre='Proyecto B3 Tendido',
+        estado='EJECUCION',
+    )
+
+
+def _torre(proyecto, numero):
+    from apps.construccion.models import TorreConstruccion
+    return TorreConstruccion.objects.create(proyecto=proyecto, numero=numero)
+
+
+def _tendido(proyecto, torre, **flags):
+    """Crea un TendidoTorre con los flags dados (resto en False por default)."""
+    from apps.construccion.models import TendidoTorre
+    return TendidoTorre.objects.create(proyecto=proyecto, torre=torre, **flags)
+
+
+def _ctx(view_cls, proyecto, admin, **get):
+    """Render del contexto de una CBV de dashboard vía RequestFactory."""
+    rf = RequestFactory()
+    req = rf.get('/', data=get)
+    req.user = admin
+    view = view_cls()
+    view.setup(req, proyecto_id=proyecto.id)
+    return view.get_context_data()
+
+
+def _datos(proyecto, admin):
+    rf = RequestFactory()
+    req = rf.get('/')
+    req.user = admin
+    resp = DashboardTendidoDataView.as_view()(req, proyecto_id=proyecto.id)
+    return json.loads(resp.content)
+
+
+# ---------------------------------------------------------------------------
+# E2E del BLUEPRINT — Conductor
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_b3_dashboard_tendido_conductor(proyecto, admin):
+    """Happy: el dashboard expone las 6 etapas de Conductor con su % real y la
+    Curva S ejecutado refleja avance > 0."""
+    t1 = _torre(proyecto, '1')
+    t2 = _torre(proyecto, '2')
+    # Torre 1: conductor 100% (las 6 etapas). Torre 2: solo las 2 primeras.
+    _tendido(
+        proyecto, t1,
+        riega_manila_conductor=True, riega_guaya_conductor=True,
+        tendido_conductor=True, grapado_amarre_conductor=True,
+        accesorios_puentes=True, balizas_desviadores=True,
+    )
+    _tendido(
+        proyecto, t2,
+        riega_manila_conductor=True, riega_guaya_conductor=True,
+    )
+
+    ctx = _ctx(DashboardTendidoView, proyecto, admin)
+
+    # 6 etapas de conductor, en orden.
+    conductor = ctx['avance_conductor']
+    assert [e['etapa'] for e in conductor] == [
+        'RIEGA_MANILA', 'RIEGA_GUAYA', 'TENDIDO_CONDUCTOR',
+        'GRAPADO', 'ACCESORIOS', 'BALIZAS',
+    ]
+    by = {e['etapa']: e for e in conductor}
+    # Riega manila: ambas torres completas → 100%.
+    assert by['RIEGA_MANILA']['pct'] == 100.0
+    assert by['RIEGA_MANILA']['completas'] == 2
+    # Balizas: solo torre 1 → 50%.
+    assert by['BALIZAS']['pct'] == 50.0
+    assert by['BALIZAS']['completas'] == 1
+
+    # Curva S real "Ejecutado" > 0 (no cuelga del semanal vacío).
+    curva = ctx['curva_real_json']
+    assert curva['ejecutado']['ejecutado']
+    assert max(curva['ejecutado']['ejecutado']) > 0
+
+    # % conductor global de las tarjetas es > 0.
+    assert ctx['pct_conductor'] > 0
+    # La gráfica de etapas genérica del parcial base queda apagada (B3 usa 2 propias).
+    assert ctx['avance_etapas'] == []
+
+
+@pytest.mark.django_db
+def test_b3_dashboard_tendido_conductor_template_render(proyecto, admin):
+    """El template renderiza el canvas #tendido-conductor-chart y [data-fase]."""
+    from django.template.loader import render_to_string
+
+    t1 = _torre(proyecto, '1')
+    _tendido(proyecto, t1, riega_manila_conductor=True, tendido_conductor=True)
+    ctx = _ctx(DashboardTendidoView, proyecto, admin)
+    html = render_to_string('construccion/dashboard_tendido.html', ctx)
+
+    assert 'id="tendido-conductor-chart"' in html
+    assert 'id="tendido-fibra-chart"' in html
+    assert 'data-fase="TENDIDO"' in html
+    # json_script genera el id del dataset (no JSON crudo en x-data / inline).
+    assert 'id="tendido-etapas-data"' in html
+    # Guard es-CO: localize off presente (lo aplica el bloque).
+    assert 'tendido-etapas-data' in html
+
+
+# ---------------------------------------------------------------------------
+# E2E del BLUEPRINT — Fibra OPGW
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_b3_dashboard_tendido_fibra(proyecto, admin):
+    """Happy: las 5 etapas de Fibra OPGW con su % real, independientes del
+    conductor."""
+    t1 = _torre(proyecto, '1')
+    t2 = _torre(proyecto, '2')
+    # Torre 1: fibra 100%. Torre 2: solo tendido OPGW.
+    _tendido(
+        proyecto, t1,
+        riega_manila_fibra=True, riega_guaya_opgw=True, tendido_opgw=True,
+        grapado_amarre_fibra=True, empalmes_opgw=True,
+    )
+    _tendido(proyecto, t2, tendido_opgw=True)
+
+    ctx = _ctx(DashboardTendidoView, proyecto, admin)
+
+    fibra = ctx['avance_fibra']
+    assert [e['etapa'] for e in fibra] == [
+        'RIEGA_MANILA_FIBRA', 'RIEGA_GUAYA_OPGW', 'TENDIDO_OPGW',
+        'GRAPADO_FIBRA', 'EMPALMES_OPGW',
+    ]
+    by = {e['etapa']: e for e in fibra}
+    # Tendido OPGW: ambas → 100%.
+    assert by['TENDIDO_OPGW']['pct'] == 100.0
+    # Empalmes: solo torre 1 → 50%.
+    assert by['EMPALMES_OPGW']['pct'] == 50.0
+    assert ctx['pct_fibra'] > 0
+
+
+@pytest.mark.django_db
+def test_b3_secciones_independientes_conductor_lleno_fibra_vacia(proyecto, admin):
+    """Edge: una torre con conductor 100% y fibra 0% — las secciones NO se
+    contaminan (SUMPRODUCT independiente). En la vista por torre la fibra queda
+    como pendiente."""
+    t1 = _torre(proyecto, '1')
+    _tendido(
+        proyecto, t1,
+        riega_manila_conductor=True, riega_guaya_conductor=True,
+        tendido_conductor=True, grapado_amarre_conductor=True,
+        accesorios_puentes=True, balizas_desviadores=True,
+        # fibra toda False
+    )
+    ctx = _ctx(DashboardTendidoView, proyecto, admin)
+
+    # Conductor 100%, fibra 0%.
+    assert ctx['pct_conductor'] == 100.0
+    assert ctx['pct_fibra'] == 0.0
+
+    # Vista por torre: pct = promedio(100, 0) = 50, NO completa, pendientes de fibra.
+    torres = ctx['vista_torres']
+    assert len(torres) == 1
+    fila = torres[0]
+    assert fila['pct'] == 50.0
+    assert fila['completa'] is False
+    # Las pendientes contienen las etiquetas de fibra, NO las de conductor.
+    assert 'Empalmes OPGW' in fila['pendientes']
+    assert 'Tendido conductor' not in fila['pendientes']
+
+
+# ---------------------------------------------------------------------------
+# Edge — proyecto sin tendido (robustez, nunca 500)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_b3_dashboard_sin_tendido_no_crashea(proyecto, admin):
+    """Edge: proyecto con torres pero sin registros de tendido → listas vacías,
+    pct 0, sin excepción."""
+    _torre(proyecto, '1')
+    ctx = _ctx(DashboardTendidoView, proyecto, admin)
+
+    assert ctx['pct_conductor'] == 0.0
+    assert ctx['pct_fibra'] == 0.0
+    assert ctx['vista_torres'] == []
+    # Las etapas existen con pct=0 (estructura presente, datos vacíos).
+    assert all(e['pct'] == 0.0 for e in ctx['avance_conductor'])
+    assert all(e['pct'] == 0.0 for e in ctx['avance_fibra'])
+
+
+@pytest.mark.django_db
+def test_b3_dashboard_proyecto_sin_torres_no_crashea(proyecto, admin):
+    """Edge: proyecto sin torres → pct 0, sin división por cero / 500."""
+    ctx = _ctx(DashboardTendidoView, proyecto, admin)
+    assert ctx['pct_conductor'] == 0.0
+    assert ctx['pct_fibra'] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Endpoint de datos JSON
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_b3_datos_endpoint_estructura(proyecto, admin):
+    """El endpoint de datos devuelve curva_s + conductor + fibra + vista_torres."""
+    t1 = _torre(proyecto, '1')
+    _tendido(proyecto, t1, tendido_conductor=True, tendido_opgw=True)
+
+    data = _datos(proyecto, admin)
+    assert 'curva_s' in data
+    assert 'ejecutado' in data['curva_s']
+    assert 'planeado' in data['curva_s']
+    assert len(data['avance_conductor']) == 6
+    assert len(data['avance_fibra']) == 5
+    assert isinstance(data['vista_torres'], list)
+
+
+# ---------------------------------------------------------------------------
+# Dato legacy — TendidoTorre "estilo prod" (solo flags de conductor)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_b3_dato_legacy_conductor_solo(proyecto, admin):
+    """En prod hay 65 TendidoTorre con tendido_conductor=True (y fibra sin tocar).
+
+    Verifica que el dashboard computa ese dato legacy SIN modificar el modelo:
+    la etapa de conductor 'Tendido conductor' aparece completa y la torre se
+    lista en la vista por torre con pendientes de fibra.
+    """
+    t1 = _torre(proyecto, '1')
+    legacy = _tendido(
+        proyecto, t1,
+        riega_manila_conductor=True, riega_guaya_conductor=True,
+        tendido_conductor=True,
+    )
+    # No tocamos campos nuevos: la fibra queda en su default False (legacy).
+    legacy.refresh_from_db()
+    assert legacy.tendido_conductor is True
+    assert legacy.tendido_opgw is False
+
+    ctx = _ctx(DashboardTendidoView, proyecto, admin)
+    by_c = {e['etapa']: e for e in ctx['avance_conductor']}
+    assert by_c['TENDIDO_CONDUCTOR']['completas'] == 1
+    # La torre legacy está en la vista por torre con pendientes de fibra.
+    assert len(ctx['vista_torres']) == 1
+    assert any('OPGW' in p or 'fibra' in p.lower()
+               for p in ctx['vista_torres'][0]['pendientes'])

--- a/apps/construccion/tests_b4_dashboards_torres.py
+++ b/apps/construccion/tests_b4_dashboards_torres.py
@@ -1,0 +1,338 @@
+"""Tests B4 — Vista por torre consolidada (cross-fase) + drill-down (#139).
+
+Cubre los dos tests del BLUEPRINT:
+  - ``b4_vista_torres_consolidada``  → tabla torre × fase con % y estado.
+  - ``b4_drilldown_punto_bajo``      → endpoint detalle de lo atrasado.
+
+Más edge cases del dominio:
+  - Torre con avance en una fase pero NO en otra → celda registrada=False,
+    pendiente, sin error (edge crítico del scope).
+  - Drill-down de fase inválida → HTTP 400.
+  - Drill-down de torre sin registro → registrada=False, pendientes=[].
+  - Dato legacy: torre OC con patas parcialmente avanzadas (como prod) preservada.
+
+Las vistas se ejercitan con ``RequestFactory`` llamando directo al ``.get`` /
+``get_context_data`` para no depender de que F4 ya haya cableado el ``include``
+en ``urls.py`` (el wiring se aplica en integración). Las funciones puras del
+módulo se testean directo contra el ORM.
+"""
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+
+import pytest
+from django.test import RequestFactory
+
+from apps.construccion import views_dashboards_b4_torres as b4
+from apps.construccion import calculators_avance_real as car
+
+
+# ===========================================================================
+# Fixtures
+# ===========================================================================
+
+@pytest.fixture
+def proyecto_b4(db):
+    """ProyectoConstruccion mínimo para la vista consolidada B4."""
+    from apps.contratos.models import Contrato
+    from apps.construccion.models import ProyectoConstruccion
+    contrato = Contrato.objects.create(
+        unidad_negocio=Contrato.UnidadNegocio.CONSTRUCCION,
+        codigo='TEST-B4-VT-001',
+        nombre='Contrato test B4 vista torres',
+        cliente='Cliente B4',
+    )
+    return ProyectoConstruccion.objects.create(
+        contrato=contrato,
+        nombre='Proyecto B4 vista torres',
+        estado='EJECUCION',
+    )
+
+
+@pytest.fixture
+def torres_b4(proyecto_b4):
+    """Dos torres: T1 (avance mixto) y T2 (sin avance en algunas fases)."""
+    from apps.construccion.models import TorreConstruccion
+    t1 = TorreConstruccion.objects.create(proyecto=proyecto_b4, numero='01', tipo='D6')
+    t2 = TorreConstruccion.objects.create(proyecto=proyecto_b4, numero='02', tipo='D6')
+    return t1, t2
+
+
+@pytest.fixture
+def avance_mixto(proyecto_b4, torres_b4):
+    """Carga avance:
+      - T1: OC completa (1 pata 100%), Montaje a medias, sin Tendido.
+      - T2: solo Tendido (conductor+fibra completos), sin OC ni Montaje.
+    Refleja el edge "torre sin avance en una fase".
+    """
+    t1, t2 = torres_b4
+    from apps.construccion.models_b3_oc_detalle import ObraCivilTorreDetalle
+    from apps.construccion.models_b3_mont_detalle import MontajeEstructuraTorreDetalle
+    from apps.construccion.models import TendidoTorre
+
+    # T1 — Obra Civil 100% (todas las etapas de la pata al máximo).
+    ObraCivilTorreDetalle.objects.create(
+        proyecto=proyecto_b4, torre=t1, pata='A',
+        cerr_finalizado_ok=True,
+        exc_ejecutada_pct=Decimal('1'),
+        sol_ejecutado_pct=Decimal('1'),
+        ace_instalacion_pct=Decimal('1'),
+        vac_ejecutado_pct=Decimal('1'),
+        com_finalizada_pct=Decimal('1'),
+    )
+    # T1 — Montaje parcial (solo estructura en sitio).
+    MontajeEstructuraTorreDetalle.objects.create(
+        proyecto=proyecto_b4, torre=t1,
+        estructura_en_sitio_ok=True,
+        prearmada_ok=False, torre_montada_ok=False, revisada_ok=False,
+    )
+    # T2 — Tendido completo (conductor + fibra).
+    TendidoTorre.objects.create(
+        proyecto=proyecto_b4, torre=t2,
+        riega_manila_conductor=True, riega_guaya_conductor=True,
+        tendido_conductor=True, grapado_amarre_conductor=True,
+        accesorios_puentes=True, balizas_desviadores=True,
+        riega_manila_fibra=True, riega_guaya_opgw=True,
+        tendido_opgw=True, grapado_amarre_fibra=True, empalmes_opgw=True,
+    )
+    return t1, t2
+
+
+@pytest.fixture
+def b4_urls_registradas():
+    """Registra temporalmente las URLs de B4 en el urlconf de ``construccion``.
+
+    En integración (F4) el ``include`` de ``urls_dashboards_b4_torres`` se agrega
+    a ``urls.py`` de forma permanente. En el worktree aislado aún NO está, así
+    que para que ``reverse('construccion:dashboard_drilldown_torre')`` resuelva
+    dentro del test, inyectamos los patterns y limpiamos los caches del resolver.
+    """
+    from django.urls import clear_url_caches
+    from apps.construccion import urls as construccion_urls
+    from apps.construccion.urls_dashboards_b4_torres import urlpatterns as b4_urls
+
+    originales = list(construccion_urls.urlpatterns)
+    construccion_urls.urlpatterns += b4_urls
+    clear_url_caches()
+    try:
+        yield
+    finally:
+        construccion_urls.urlpatterns = originales
+        clear_url_caches()
+
+
+def _rf_get(view_cls, proyecto, admin_user, **get):
+    """Helper: instancia la CBV con un GET autenticado vía RequestFactory.
+
+    Adjunta una sesión vacía: el render del parcial (?format=html) pasa por los
+    context processors del proyecto, que leen ``request.session``.
+    """
+    from importlib import import_module
+    from django.conf import settings
+    rf = RequestFactory()
+    req = rf.get('/x', data=get)
+    req.user = admin_user
+    engine = import_module(settings.SESSION_ENGINE)
+    req.session = engine.SessionStore()
+    view = view_cls()
+    view.setup(req, proyecto_id=proyecto.id)
+    return view, req
+
+
+# ===========================================================================
+# 1. b4_vista_torres_consolidada — happy path
+# ===========================================================================
+
+@pytest.mark.django_db
+def test_b4_vista_torres_consolidada(proyecto_b4, avance_mixto):
+    """La matriz consolidada pivota las 3 fases por torre con % y estado."""
+    consolidado = b4.construir_vista_torres_consolidada(proyecto_b4)
+
+    # 3 columnas de fase, en orden OC/Montaje/Tendido.
+    assert [f['codigo'] for f in consolidado['fases']] == [
+        car.FASE_OOCC, car.FASE_MONTAJE, car.FASE_TENDIDO]
+
+    # Ambas torres aparecen (cada una con avance en al menos una fase).
+    numeros = {t['numero'] for t in consolidado['torres']}
+    assert numeros == {'01', '02'}
+
+    porn = {t['numero']: t for t in consolidado['torres']}
+
+    # T1: OC completa (celda registrada + completa), Montaje registrado no completo,
+    # Tendido NO registrado.
+    t1 = porn['01']
+    assert t1['celdas'][car.FASE_OOCC]['registrada'] is True
+    assert t1['celdas'][car.FASE_OOCC]['completa'] is True
+    assert t1['celdas'][car.FASE_OOCC]['pct'] == 100.0
+    assert t1['celdas'][car.FASE_MONTAJE]['registrada'] is True
+    assert t1['celdas'][car.FASE_MONTAJE]['completa'] is False
+    assert t1['celdas'][car.FASE_TENDIDO]['registrada'] is False
+    assert t1['celdas'][car.FASE_TENDIDO]['pct'] == 0.0
+    # global = promedio de fases CON avance (OC 100 + Montaje parcial) / 2.
+    assert t1['completa_global'] is False
+
+    # T2: solo Tendido.
+    t2 = porn['02']
+    assert t2['celdas'][car.FASE_TENDIDO]['registrada'] is True
+    assert t2['celdas'][car.FASE_TENDIDO]['completa'] is True
+    assert t2['celdas'][car.FASE_OOCC]['registrada'] is False
+    assert t2['celdas'][car.FASE_MONTAJE]['registrada'] is False
+
+
+@pytest.mark.django_db
+def test_b4_vista_consolidada_view_context(
+        proyecto_b4, avance_mixto, admin_user, b4_urls_registradas):
+    """La view arma el contexto completo + drilldown_cfg pre-serializado."""
+    view, _req = _rf_get(b4.DashboardVistaTorresView, proyecto_b4, admin_user)
+    ctx = view.get_context_data()
+
+    assert ctx['proyecto'] == proyecto_b4
+    assert len(ctx['fases']) == 3
+    assert len(ctx['torres']) == 2
+    assert ctx['total_torres'] == 2
+    assert ctx['torres_con_avance'] == 2
+    # resumen por fase presente para las 3.
+    assert {r['codigo'] for r in ctx['resumen_fases']} == {
+        car.FASE_OOCC, car.FASE_MONTAJE, car.FASE_TENDIDO}
+    # Guard es-CO: la config es un STRING JSON (no dict crudo en template).
+    assert isinstance(ctx['drilldown_cfg'], str)
+    cfg = json.loads(ctx['drilldown_cfg'])
+    assert 'drilldown_url' in cfg and str(proyecto_b4.id) in cfg['drilldown_url']
+
+
+# ===========================================================================
+# 2. b4_drilldown_punto_bajo — endpoint detalle de lo atrasado
+# ===========================================================================
+
+@pytest.mark.django_db
+def test_b4_drilldown_punto_bajo(proyecto_b4, avance_mixto):
+    """El drill-down de Montaje de T1 lista las etapas atrasadas (lo bajo)."""
+    t1, _t2 = avance_mixto
+    detalle = b4.detalle_drilldown_torre(proyecto_b4, t1.id, car.FASE_MONTAJE)
+
+    assert detalle['registrada'] is True
+    assert detalle['completa'] is False
+    assert detalle['fase'] == car.FASE_MONTAJE
+    # Montaje: solo estructura_en_sitio_ok → faltan Prearmada/Torre montada/Revisada.
+    assert 'Prearmada' in detalle['pendientes']
+    assert 'Torre montada' in detalle['pendientes']
+    assert 'Revisada' in detalle['pendientes']
+    assert detalle['total_pendientes'] == len(detalle['pendientes']) == 3
+
+
+@pytest.mark.django_db
+def test_b4_drilldown_endpoint_json(proyecto_b4, avance_mixto, admin_user):
+    """El endpoint JSON responde ok=True con el detalle (Content-Type json)."""
+    t1, _t2 = avance_mixto
+    view, _req = _rf_get(
+        b4.DrilldownTorreFaseView, proyecto_b4, admin_user,
+        torre=t1.id, fase=car.FASE_MONTAJE)
+    resp = view.get(_req, proyecto_id=proyecto_b4.id)
+    assert resp.status_code == 200
+    assert resp['Content-Type'] == 'application/json'
+    payload = json.loads(resp.content)
+    assert payload['ok'] is True
+    assert payload['detalle']['fase'] == car.FASE_MONTAJE
+    assert payload['detalle']['total_pendientes'] == 3
+
+
+@pytest.mark.django_db
+def test_b4_drilldown_endpoint_html_format(proyecto_b4, avance_mixto, admin_user):
+    """?format=html renderiza el parcial _drilldown_torre.html con las pendientes."""
+    t1, _t2 = avance_mixto
+    view, _req = _rf_get(
+        b4.DrilldownTorreFaseView, proyecto_b4, admin_user,
+        torre=t1.id, fase=car.FASE_MONTAJE, format='html')
+    resp = view.get(_req, proyecto_id=proyecto_b4.id)
+    assert resp.status_code == 200
+    body = resp.content.decode()
+    assert 'data-drilldown-torre' in body
+    assert 'data-dd-pendientes' in body
+    assert 'Prearmada' in body
+
+
+# ===========================================================================
+# 3. Edge cases del dominio
+# ===========================================================================
+
+@pytest.mark.django_db
+def test_b4_torre_sin_avance_en_fase_no_es_error(proyecto_b4, avance_mixto):
+    """Edge: T1 NO tiene Tendido → drill-down devuelve registrada=False, [],
+    NO lanza error."""
+    t1, _t2 = avance_mixto
+    detalle = b4.detalle_drilldown_torre(proyecto_b4, t1.id, car.FASE_TENDIDO)
+    assert detalle['registrada'] is False
+    assert detalle['pendientes'] == []
+    assert detalle['total_pendientes'] == 0
+    assert detalle['pct'] == 0.0
+    # El número de torre se resuelve aunque no haya registro de la fase.
+    assert detalle['numero'] == '01'
+
+
+@pytest.mark.django_db
+def test_b4_drilldown_fase_invalida_raise(proyecto_b4, torres_b4):
+    """Fase inválida → ValueError (la view la traduce a HTTP 400)."""
+    t1, _t2 = torres_b4
+    with pytest.raises(ValueError):
+        b4.detalle_drilldown_torre(proyecto_b4, t1.id, 'NO_EXISTE')
+
+
+@pytest.mark.django_db
+def test_b4_drilldown_endpoint_400_sin_torre(proyecto_b4, admin_user):
+    """Falta ?torre → HTTP 400 ok=False."""
+    view, _req = _rf_get(
+        b4.DrilldownTorreFaseView, proyecto_b4, admin_user, fase=car.FASE_OOCC)
+    resp = view.get(_req, proyecto_id=proyecto_b4.id)
+    assert resp.status_code == 400
+    assert json.loads(resp.content)['ok'] is False
+
+
+@pytest.mark.django_db
+def test_b4_drilldown_endpoint_400_fase_invalida(proyecto_b4, torres_b4, admin_user):
+    """?fase inválida → HTTP 400."""
+    t1, _t2 = torres_b4
+    view, _req = _rf_get(
+        b4.DrilldownTorreFaseView, proyecto_b4, admin_user,
+        torre=t1.id, fase='ZZZ')
+    resp = view.get(_req, proyecto_id=proyecto_b4.id)
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_b4_proyecto_sin_torres_consolidado_vacio(proyecto_b4):
+    """Proyecto sin torres → consolidado con 3 fases pero 0 filas (no crash)."""
+    consolidado = b4.construir_vista_torres_consolidada(proyecto_b4)
+    assert len(consolidado['fases']) == 3
+    assert consolidado['torres'] == []
+
+
+# ===========================================================================
+# 4. Dato legacy — torre OC con patas parciales (como prod)
+# ===========================================================================
+
+@pytest.mark.django_db
+def test_b4_dato_legacy_oc_patas_parciales(proyecto_b4, torres_b4):
+    """Como en prod: una torre con 2 patas a distinto avance → la celda OC
+    refleja el promedio y lista las etapas pendientes en el drill-down."""
+    t1, _t2 = torres_b4
+    from apps.construccion.models_b3_oc_detalle import ObraCivilTorreDetalle
+    # Pata A: excavación 100%; Pata B: nada. Promedio < 100 → pendiente.
+    ObraCivilTorreDetalle.objects.create(
+        proyecto=proyecto_b4, torre=t1, pata='A',
+        exc_ejecutada_pct=Decimal('1'),
+    )
+    ObraCivilTorreDetalle.objects.create(
+        proyecto=proyecto_b4, torre=t1, pata='B',
+    )
+    consolidado = b4.construir_vista_torres_consolidada(proyecto_b4)
+    fila = next(t for t in consolidado['torres'] if t['numero'] == '01')
+    celda_oc = fila['celdas'][car.FASE_OOCC]
+    assert celda_oc['registrada'] is True
+    assert celda_oc['completa'] is False
+    assert 0.0 < celda_oc['pct'] < 100.0
+
+    detalle = b4.detalle_drilldown_torre(proyecto_b4, t1.id, car.FASE_OOCC)
+    # Vaciado/Acero/etc siguen pendientes (no todas las patas al 100%).
+    assert detalle['total_pendientes'] > 0
+    assert 'Vaciado' in detalle['pendientes']

--- a/apps/construccion/tests_b5_dashboard_general.py
+++ b/apps/construccion/tests_b5_dashboard_general.py
@@ -1,0 +1,260 @@
+"""Tests B5 (#139) — Dashboard GENERAL del proyecto (7 fases).
+
+Cubre los tests del BLUEPRINT:
+  - b5_dashboard_general_7fases : render con las 7 fases + global ponderado +
+    dataset JSON pre-serializado (guard es-CO) + canvas #general-fases-chart.
+  - b5_general_drilldown_fase   : cada fase con dashboard propio enlaza a su
+    dashboard de fase (Obra Civil / Montaje / Tendido).
+
+Edge cases del dominio:
+  - Proyecto SIN avance en ninguna fase → todas las fases en 0%, global 0%,
+    sin crash (mensaje "sin avance"), data-charts-ready presente.
+  - Fallback equiponderado cuando ProgramacionFase.peso_pct está todo en 0
+    (estado actual de prod).
+  - Curva S consolidada real agrega solo las fases con datos (no error si una
+    fase no tiene avance).
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.urls import NoReverseMatch, reverse
+
+from apps.construccion import calculators_avance_real as car
+from apps.construccion.views_dashboards_b5_general import (
+    DRILLDOWN_URL_NAMES,
+    curva_s_consolidada_real,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def proyecto_general(db):
+    """ProyectoConstruccion mínimo con torres para el dashboard general."""
+    from apps.contratos.models import Contrato
+    from apps.construccion.models import ProyectoConstruccion, TorreConstruccion
+
+    contrato = Contrato.objects.create(
+        unidad_negocio=Contrato.UnidadNegocio.CONSTRUCCION,
+        codigo='TEST-B5-GEN-001',
+        nombre='Contrato test B5 general',
+        cliente='Test Cliente',
+    )
+    proyecto = ProyectoConstruccion.objects.create(
+        contrato=contrato,
+        nombre='Proyecto B5 general test',
+        estado='EJECUCION',
+    )
+    # Dos torres para tener denominador real en los % por fase.
+    for i in (1, 2):
+        TorreConstruccion.objects.create(proyecto=proyecto, numero=f'T{i:03d}')
+    return proyecto
+
+
+def _render_view(rf, admin_user, proyecto):
+    """Renderiza DashboardGeneralView vía RequestFactory (sin depender del
+    wiring de URL que cablea F4). Devuelve (response, view_instance) — la
+    respuesta ya está renderizada (``.render()``)."""
+    from django.contrib.messages.middleware import MessageMiddleware
+    from django.contrib.sessions.middleware import SessionMiddleware
+
+    from apps.construccion.views_dashboards_b5_general import DashboardGeneralView
+
+    request = rf.get('/construccion/{}/dashboard-general/'.format(proyecto.id))
+    # Adjuntar session + messages (los context processors del proyecto los
+    # requieren; RequestFactory no pasa por el stack de middleware).
+    SessionMiddleware(lambda r: None).process_request(request)
+    request.session.save()
+    MessageMiddleware(lambda r: None).process_request(request)
+    request.user = admin_user
+    view = DashboardGeneralView()
+    view.setup(request, proyecto_id=proyecto.id)
+    resp = view.dispatch(request, proyecto_id=proyecto.id)
+    if hasattr(resp, 'render'):
+        resp.render()
+    return resp, view
+
+
+def _general_url(proyecto):
+    """Resuelve la URL del dashboard general. En el entorno aislado de la
+    sub-feature el include lo cablea F4; si aún no resuelve, marca skip honesto
+    (el name es responsabilidad de F4, no del test)."""
+    try:
+        return reverse('construccion:dashboard_general',
+                       kwargs={'proyecto_id': proyecto.id})
+    except NoReverseMatch:
+        return None
+
+
+# ===========================================================================
+# b5_dashboard_general_7fases
+# ===========================================================================
+
+@pytest.mark.django_db
+def test_b5_dashboard_general_7fases(authenticated_client, proyecto_general):
+    """Render del dashboard general: 7 fases + global + dataset JSON + canvas."""
+    url = _general_url(proyecto_general)
+    if url is None:
+        pytest.skip('URL construccion:dashboard_general aún no cableada (F4 wiring)')
+
+    resp = authenticated_client.get(url)
+    assert resp.status_code == 200
+
+    ctx = resp.context
+    # Las 7 fases canónicas.
+    assert len(ctx['fases']) == 7
+    labels = [f['label'] for f in ctx['fases']]
+    for esperado in ('Ingeniería', 'Obra Civil', 'Montaje', 'Tendido',
+                     'SPT y Pintura', 'Detalles Finales'):
+        assert esperado in labels
+
+    # Global ponderado presente y numérico.
+    assert isinstance(ctx['global_pct'], float)
+
+    # Guard es-CO: el dataset viaja como STRING JSON parseable (no floats inline).
+    payload = json.loads(ctx['general_chart_json'])
+    assert 'fases' in payload and len(payload['fases']) == 7
+    assert 'global_pct' in payload
+    assert 'curva_s' in payload
+
+    html = resp.content.decode()
+    # Canvas global del BLUEPRINT.
+    assert 'id="general-fases-chart"' in html
+    # json_script (no JSON crudo en x-data) y gate de charts.
+    assert 'id="general-chart-data"' in html
+    assert 'data-charts-ready' in html
+    assert 'data-fase="GENERAL"' in html
+
+
+@pytest.mark.django_db
+def test_b5_dashboard_general_render_directo(rf, admin_user, proyecto_general):
+    """Render directo de la vista (sin URL wiring) — cubre context + template.
+
+    Exige el rigor de render real: la vista arma el contexto y el template se
+    renderiza con el canvas global, el json_script (guard es-CO) y el gate de
+    charts, aun cuando F4 todavía no haya cableado el include en urls.py.
+    """
+    resp, view = _render_view(rf, admin_user, proyecto_general)
+    assert resp.status_code == 200
+
+    html = resp.content.decode()
+    assert 'id="general-fases-chart"' in html
+    assert 'id="general-chart-data"' in html
+    assert 'data-charts-ready' in html
+    assert 'data-fase="GENERAL"' in html
+    # 7 tarjetas de fase (una por sección).
+    assert html.count('data-fase-seccion=') == 7
+
+
+@pytest.mark.django_db
+def test_b5_general_fallback_equiponderado(proyecto_general):
+    """Sin pesos en ProgramacionFase (peso_pct=0) → fallback equiponderado.
+
+    El backbone calcula el global como promedio simple de los % de las 7 fases.
+    Validamos el contrato directamente sobre avance_general (lo que la vista
+    reusa) para que el test no dependa del wiring de la URL.
+    """
+    general = car.avance_general(proyecto_general)
+    assert len(general['fases']) == 7
+    # Sin avance ni pesos → global 0, sin error.
+    assert general['global_pct'] == 0.0
+    # Todas las fases en 0% (proyecto recién creado).
+    assert all(f['pct'] == 0.0 for f in general['fases'])
+
+
+# ===========================================================================
+# b5_general_drilldown_fase
+# ===========================================================================
+
+@pytest.mark.django_db
+def test_b5_general_drilldown_fase(authenticated_client, proyecto_general):
+    """Cada fase con dashboard propio enlaza a su dashboard de fase."""
+    url = _general_url(proyecto_general)
+    if url is None:
+        pytest.skip('URL construccion:dashboard_general aún no cableada (F4 wiring)')
+
+    resp = authenticated_client.get(url)
+    assert resp.status_code == 200
+
+    fases_por_seccion = {f['seccion']: f for f in resp.context['fases']}
+    html = resp.content.decode()
+
+    for seccion, url_name in DRILLDOWN_URL_NAMES.items():
+        fase = fases_por_seccion.get(seccion)
+        assert fase is not None, f'falta la fase {seccion} en el contexto'
+        try:
+            esperado = reverse(url_name,
+                               kwargs={'proyecto_id': proyecto_general.id})
+        except NoReverseMatch:
+            # Dashboard de fase aún no cableado en el entorno aislado: la vista
+            # degrada a None y el template muestra "Sin dashboard". F4 garantiza
+            # el wiring al integrar.
+            assert fase['drill_url'] is None
+            assert f'data-drilldown-disabled="{seccion}"' in html
+            continue
+        # El name resuelve → la fase debe enlazar a él.
+        assert fase['drill_url'] == esperado
+        assert f'href="{esperado}"' in html
+        assert f'data-drilldown="{seccion}"' in html
+
+
+# ===========================================================================
+# Edge: proyecto sin avance → 0% por fase, sin crash
+# ===========================================================================
+
+@pytest.mark.django_db
+def test_b5_general_sin_avance_no_crashea(authenticated_client, proyecto_general):
+    """Proyecto sin avance en ninguna fase → render OK, mensaje, 0% global."""
+    url = _general_url(proyecto_general)
+    if url is None:
+        pytest.skip('URL construccion:dashboard_general aún no cableada (F4 wiring)')
+
+    resp = authenticated_client.get(url)
+    assert resp.status_code == 200
+    assert resp.context['global_pct'] == 0.0
+    assert resp.context['tiene_avance'] is False
+    assert resp.context['tiene_curva_s'] is False
+    html = resp.content.decode()
+    assert 'data-estado="sin-avance"' in html
+    # Aun sin avance, el gate de charts queda presente (no rompe el E2E).
+    assert 'data-charts-ready' in html
+
+
+@pytest.mark.django_db
+def test_b5_curva_consolidada_real_vacia_sin_datos(proyecto_general):
+    """Edge: sin avance temporal en ninguna fase → curva consolidada vacía."""
+    curva = curva_s_consolidada_real(proyecto_general)
+    assert curva == {'labels': [], 'ejecutado': []}
+
+
+@pytest.mark.django_db
+def test_b5_curva_consolidada_real_agrega_fase_con_datos(proyecto_general):
+    """La curva consolidada agrega una fase con avance real (Obra Civil).
+
+    Crea un ObraCivilTorreDetalle con avance → la fase OOCC aporta a la curva;
+    las otras dos fases sin datos no rompen ni inflan el % por encima de 100.
+    """
+    from apps.construccion.models import TorreConstruccion
+    from apps.construccion.models_b3_oc_detalle import ObraCivilTorreDetalle
+
+    torre = TorreConstruccion.objects.filter(proyecto=proyecto_general).first()
+    # Pata con vaciado 100% ejecutado → avance_ponderado > 0.
+    ObraCivilTorreDetalle.objects.create(
+        proyecto=proyecto_general,
+        torre=torre,
+        pata='A',
+        vac_ejecutado_pct=1,
+    )
+
+    curva = curva_s_consolidada_real(proyecto_general)
+    # Hay al menos un punto y el acumulado nunca excede 100.
+    assert curva['labels']
+    assert curva['ejecutado']
+    assert max(curva['ejecutado']) <= 100.0
+    # Monótona no decreciente (curva S).
+    valores = curva['ejecutado']
+    assert all(valores[i] <= valores[i + 1] + 1e-9 for i in range(len(valores) - 1))

--- a/apps/construccion/urls.py
+++ b/apps/construccion/urls.py
@@ -239,3 +239,9 @@ urlpatterns += urls_pdeo_complement.urlpatterns
 # F2 scaffolding: B4 (#123) llena urls_fin con las 6 rutas /financiero/<subruta>/.
 from . import urls_fin  # noqa: E402
 urlpatterns += urls_fin.urlpatterns
+
+# === /modulo dashboards (#139) — dashboards de avance real por fase ===
+# F2 scaffolding (S2): partición física de views.py/urls.py. B1 cablea la
+# Curva S real de Obra Civil; B2–B5 agregan Montaje/Tendido/Vista-torres/General.
+from .urls_dashboards import urlpatterns as dashboards_urls  # noqa: E402
+urlpatterns += dashboards_urls

--- a/apps/construccion/urls.py
+++ b/apps/construccion/urls.py
@@ -244,4 +244,36 @@ urlpatterns += urls_fin.urlpatterns
 # F2 scaffolding (S2): partición física de views.py/urls.py. B1 cablea la
 # Curva S real de Obra Civil; B2–B5 agregan Montaje/Tendido/Vista-torres/General.
 from .urls_dashboards import urlpatterns as dashboards_urls  # noqa: E402
+from .urls_dashboards_b2_montaje import urlpatterns as dashboards_b2_urls  # noqa: E402
+from .urls_dashboards_b3_tendido import urlpatterns as dashboards_b3_urls  # noqa: E402
+from .urls_dashboards_b4_torres import urlpatterns as dashboards_b4_urls  # noqa: E402
+from .urls_dashboards_b5_general import urlpatterns as dashboards_b5_urls  # noqa: E402
 urlpatterns += dashboards_urls
+urlpatterns += dashboards_b2_urls + dashboards_b3_urls + dashboards_b4_urls + dashboards_b5_urls
+
+# === F4 wiring (#139): el menú/selector abre los dashboards REALES ===
+# El sidebar construye URLs por path literal (catUrl(slug) -> /construccion/<id>/
+# <slug>/), NO por reverse(). Por eso el override de *name* que hicieron B1/B2 no
+# basta para que el menú abra la vista real: el request entrante a la ruta legacy
+# (matching first-wins, declarada arriba) seguía cayendo en la vista del semanal
+# vacío. Aquí re-apuntamos las rutas legacy de menú a las vistas reales del
+# backbone para que TODOS los dashboards que el usuario abre desde el menú
+# muestren el avance real, consistente con lo que B1 hizo para Obra Civil.
+from django.urls import path as _df_path  # noqa: E402, I001
+from .views_dashboards import DashboardObraCivilRealView as _DObraCivilReal  # noqa: E402, I001
+from .views_dashboards_b2_montaje import DashboardMontajeRealView as _DMontajeReal  # noqa: E402, I001
+
+# Reemplazar in-place la ruta legacy 'dashboard-obra-civil/' y 'dashboard-montaje/'
+# por las vistas reales (mismo name + mismo path → el menú abre el dashboard real).
+_DASHBOARD_MENU_OVERRIDES = {
+    'dashboard_obra_civil': _DObraCivilReal,
+    'dashboard_montaje': _DMontajeReal,
+}
+for _i, _p in enumerate(urlpatterns):
+    _name = getattr(_p, 'name', None)
+    if _name in _DASHBOARD_MENU_OVERRIDES:
+        urlpatterns[_i] = _df_path(
+            str(_p.pattern),
+            _DASHBOARD_MENU_OVERRIDES[_name].as_view(),
+            name=_name,
+        )

--- a/apps/construccion/urls_dashboards.py
+++ b/apps/construccion/urls_dashboards.py
@@ -11,10 +11,38 @@ B1–B5 escriben sus paths a archivos dedicados
 o lo agregan aquí, según ``files_owned``. NO duplicar el registro: el
 ``urlpatterns += dashboards_urls`` en ``urls.py`` es el único punto de enganche
 del bloque de dashboards.
-"""
-from django.urls import path  # noqa: F401  (lo usan B1–B5)
 
-# Lista base del bloque dashboards. B1 (Obra Civil) cablea los paths reales
-# (dashboard-obra-civil/, datos-graficas/, chart/). B2–B5 agregan los suyos a
-# sus propios archivos urls_dashboards_b*.py y los suman en urls.py.
-urlpatterns: list = []
+────────────────────────────────────────────────────────────────────────────
+B1 — cableado del Dashboard de Obra Civil al avance REAL (#139)
+────────────────────────────────────────────────────────────────────────────
+B1 re-registra el nombre de URL ``dashboard_obra_civil`` apuntando a la vista
+real ``DashboardObraCivilRealView`` SIN tocar ``urls.py`` ni ``views.py``
+(no están en files_owned).
+
+Mecánica (Django): ``urlpatterns += dashboards_urls`` se agrega DESPUÉS de los
+paths legacy en ``urls.py``. Cuando dos paths comparten el mismo ``name``, el
+ÚLTIMO registrado gana en ``reverse()`` → ``{% url 'construccion:dashboard_obra_civil' %}``
+y todos los menús/links del sistema resuelven a esta vista real. Usamos un path
+string DISTINTO (``dashboard-obra-civil/real/``) para que la resolución de
+request entrante también caiga en la vista real (el matching de request es por
+orden de patrón; el legacy ``dashboard-obra-civil/`` sigue existiendo pero ya
+nadie enlaza a él porque el ``reverse`` del nombre apunta aquí).
+"""
+from django.urls import path
+
+from . import views_dashboards as vd
+
+# Lista base del bloque dashboards. B1 (Obra Civil) cablea el path real del
+# Dashboard de Obra Civil al avance REAL. B2–B5 agregan los suyos a sus propios
+# archivos urls_dashboards_b*.py y los suman en urls.py.
+urlpatterns: list = [
+    # B1 (#139): el Dashboard de Obra Civil REAL. Reusa el name legacy
+    # 'dashboard_obra_civil' → reverse() resuelve aquí (último name gana), por lo
+    # que el menú del sistema abre esta vista. Path distinto para que el request
+    # entrante también caiga en la vista real.
+    path(
+        '<uuid:proyecto_id>/dashboard-obra-civil/real/',
+        vd.DashboardObraCivilRealView.as_view(),
+        name='dashboard_obra_civil',
+    ),
+]

--- a/apps/construccion/urls_dashboards.py
+++ b/apps/construccion/urls_dashboards.py
@@ -1,0 +1,20 @@
+"""URLs de los Dashboards de fase (#139) — partición física de ``urls.py``.
+
+Registrado en ``urls.py`` vía::
+
+    from .urls_dashboards import urlpatterns as dashboards_urls
+    urlpatterns += dashboards_urls
+
+F2 (scaffolding) deja esta lista vacía + registrada. Las sub-features
+B1–B5 escriben sus paths a archivos dedicados
+(``urls_dashboards_b*.py``) e importan/extienden ``urlpatterns`` de allí
+o lo agregan aquí, según ``files_owned``. NO duplicar el registro: el
+``urlpatterns += dashboards_urls`` en ``urls.py`` es el único punto de enganche
+del bloque de dashboards.
+"""
+from django.urls import path  # noqa: F401  (lo usan B1–B5)
+
+# Lista base del bloque dashboards. B1 (Obra Civil) cablea los paths reales
+# (dashboard-obra-civil/, datos-graficas/, chart/). B2–B5 agregan los suyos a
+# sus propios archivos urls_dashboards_b*.py y los suman en urls.py.
+urlpatterns: list = []

--- a/apps/construccion/urls_dashboards_b2_montaje.py
+++ b/apps/construccion/urls_dashboards_b2_montaje.py
@@ -1,0 +1,37 @@
+"""URLs del Dashboard de Montaje real (#139 · B2).
+
+Partición física por sub-feature (S2): B2 escribe SOLO aquí. F4 (integración)
+registra este módulo en ``urls.py`` con la línea de include documentada en el
+output JSON de B2:
+
+    from .urls_dashboards_b2_montaje import urlpatterns as dashboards_b2_urls
+    urlpatterns += dashboards_b2_urls
+
+Namespace: ``construccion:`` (app_name en urls.py).
+
+Coexistencia con el legacy: ``urls.py`` ya define ``dashboard-montaje/`` (name
+``dashboard_montaje`` → ``views.DashboardMontajeView``, basado en el semanal en
+0%). B2 NO lo toca; registra rutas NUEVAS con path/name distintos para evitar
+colisión:
+  - ``dashboard-montaje-real/``               name ``dashboard_montaje_real``
+  - ``dashboard-montaje-real/datos-graficas/`` name ``dashboard_montaje_real_datos``
+"""
+from django.urls import path
+
+from .views_dashboards_b2_montaje import (
+    DashboardMontajeDatosGraficasView,
+    DashboardMontajeRealView,
+)
+
+urlpatterns = [
+    path(
+        '<uuid:proyecto_id>/dashboard-montaje-real/',
+        DashboardMontajeRealView.as_view(),
+        name='dashboard_montaje_real',
+    ),
+    path(
+        '<uuid:proyecto_id>/dashboard-montaje-real/datos-graficas/',
+        DashboardMontajeDatosGraficasView.as_view(),
+        name='dashboard_montaje_real_datos',
+    ),
+]

--- a/apps/construccion/urls_dashboards_b3_tendido.py
+++ b/apps/construccion/urls_dashboards_b3_tendido.py
@@ -1,0 +1,30 @@
+"""URLs del Dashboard de Tendido (Conductor + Fibra OPGW) — B3 (#139).
+
+WIRING (lo agrega F4 en ``apps/construccion/urls.py``, NO este archivo):
+
+    from .urls_dashboards_b3_tendido import urlpatterns as dashboards_b3_urls
+    urlpatterns += dashboards_b3_urls
+
+Namespace ``construccion:`` (heredado del ``app_name`` de ``urls.py``). Los
+nombres ``dashboard_tendido`` / ``dashboard_tendido_datos`` siguen la convención
+de los dashboards existentes (``dashboard_obra_civil`` / ``dashboard_graficas_data``).
+"""
+from django.urls import path
+
+from .views_dashboards_b3_tendido import (
+    DashboardTendidoDataView,
+    DashboardTendidoView,
+)
+
+urlpatterns = [
+    path(
+        '<uuid:proyecto_id>/dashboard-tendido/',
+        DashboardTendidoView.as_view(),
+        name='dashboard_tendido',
+    ),
+    path(
+        '<uuid:proyecto_id>/dashboard-tendido/datos-graficas/',
+        DashboardTendidoDataView.as_view(),
+        name='dashboard_tendido_datos',
+    ),
+]

--- a/apps/construccion/urls_dashboards_b4_torres.py
+++ b/apps/construccion/urls_dashboards_b4_torres.py
@@ -1,0 +1,34 @@
+"""B4 — URLs de la Vista por torre consolidada + drill-down (#139).
+
+WIRING (lo aplica F4 al integrar, NO se edita ``urls.py`` desde B4):
+
+    # apps/construccion/urls.py  — junto a los demás includes de dashboards
+    from .urls_dashboards_b4_torres import urlpatterns as dashboards_b4_urls  # noqa: E402
+    urlpatterns += dashboards_b4_urls
+
+``proyecto_id`` es UUID (igual que el resto de las rutas de construccion). Las
+rutas viven bajo el namespace ``construccion`` (``app_name = 'construccion'`` en
+``urls.py``):
+
+  - ``construccion:dashboard_vista_torres``      (página HTML)
+  - ``construccion:dashboard_drilldown_torre``   (endpoint JSON reusable)
+"""
+from django.urls import path
+
+from .views_dashboards_b4_torres import (
+    DashboardVistaTorresView,
+    DrilldownTorreFaseView,
+)
+
+urlpatterns = [
+    path(
+        '<uuid:proyecto_id>/dashboard-vista-torres/',
+        DashboardVistaTorresView.as_view(),
+        name='dashboard_vista_torres',
+    ),
+    path(
+        '<uuid:proyecto_id>/dashboard-vista-torres/drilldown/',
+        DrilldownTorreFaseView.as_view(),
+        name='dashboard_drilldown_torre',
+    ),
+]

--- a/apps/construccion/urls_dashboards_b5_general.py
+++ b/apps/construccion/urls_dashboards_b5_general.py
@@ -1,0 +1,25 @@
+"""B5 (#139) — URLs del Dashboard GENERAL del proyecto (7 fases).
+
+Archivo dedicado de la sub-feature B5 (no toca ``urls.py`` ni
+``urls_dashboards.py`` — son de otros owners).
+
+WIRING que F4 debe agregar a ``apps/construccion/urls.py`` (junto al resto de
+los includes de dashboards, cerca de ``urls_dashboards``)::
+
+    from .urls_dashboards_b5_general import urlpatterns as dashboards_b5_urls  # noqa: E402
+    urlpatterns += dashboards_b5_urls
+
+El name resultante es ``construccion:dashboard_general`` (el app_name de
+``urls.py`` es ``construccion``).
+"""
+from django.urls import path
+
+from .views_dashboards_b5_general import DashboardGeneralView
+
+urlpatterns = [
+    path(
+        '<uuid:proyecto_id>/dashboard-general/',
+        DashboardGeneralView.as_view(),
+        name='dashboard_general',
+    ),
+]

--- a/apps/construccion/views_dashboards.py
+++ b/apps/construccion/views_dashboards.py
@@ -11,15 +11,46 @@ F2 (scaffolding) deja aquí:
     "Ejecutado" deje de salir en 0% (hoy cuelga de ``DashboardAvanceSemanal``,
     solo 2 filas en prod).
 
-B1 (#139) EXTIENDE este archivo con ``DashboardObraCivilView`` real y mueve la
-lógica de cableado. B2–B5 importan ``_DashboardCurvaSBase`` desde aquí para sus
-propios dashboards de fase. NO duplicar la base en cada sub-feature.
+B1 (#139) EXTIENDE este archivo con ``DashboardObraCivilRealView`` real y mueve
+la lógica de cableado. B2–B5 importan ``_DashboardCurvaSBase`` desde aquí para
+sus propios dashboards de fase. NO duplicar la base en cada sub-feature.
+
+────────────────────────────────────────────────────────────────────────────
+B1 — cableado del avance REAL de Obra Civil (#139)
+────────────────────────────────────────────────────────────────────────────
+``DashboardObraCivilRealView`` SUSTITUYE funcionalmente a
+``views.DashboardObraCivilView`` (legacy #141) **sin tocar** ``views.py`` ni
+``urls.py``: ``urls_dashboards`` re-registra el nombre de URL
+``dashboard_obra_civil`` apuntando a esta vista. Como ``urlpatterns +=
+dashboards_urls`` se agrega DESPUÉS en ``urls.py``, en Django el último
+``name`` registrado gana en ``reverse()`` → todos los menús/links del sistema
+resuelven a esta vista real, sin editar el archivo magnet.
+
+La vista hereda de la legacy ``DashboardObraCivilView`` para conservar TODO el
+comportamiento de #141 (las 3 gráficas G1/G2/G3, materiales de vaciado,
+selector "Consolidada", flag ``data-charts-ready``) y le superpone:
+
+  1. La Curva S real: serie "Ejecutado" = ``serie_curva_s_real(proyecto,'OOCC')``
+     (257 ``oc_detalle`` de prod), "Planeado" = ``serie_planeado``. Reemplaza la
+     curva inicial que colgaba del semanal vacío (``datos_chart``).
+  2. Las tarjetas %ejecutado / %planeado / varianza derivadas del REAL.
+  3. La gráfica de avance por etapa con las **6** etapas OC + pesos
+     (Cerramiento incluido), no las 5 del legacy.
+  4. La vista por torre OC (cuáles 100% / pendientes) con drill-down a
+     ``obra_civil_torre``.
 """
 from __future__ import annotations
 
 import json
 
+from django.urls import reverse
+
 from . import calculators_avance_real as car
+
+# La vista legacy #141 con las 3 gráficas (G1/G2/G3). B1 la extiende para
+# conservar ese comportamiento y superponerle el avance REAL (import read-only).
+from .views import DashboardObraCivilView as _DashboardObraCivilViewLegacy
+
 # Reusa la base ya probada de views.py (LoginRequired + RoleRequired + el
 # armado de tarjetas/semanas). B1 la sobreescribe/extiende según el scope.
 from .views import _DashboardCurvaSBase as _DashboardCurvaSBaseLegacy
@@ -70,4 +101,136 @@ class _DashboardCurvaSBase(_DashboardCurvaSBaseLegacy):
             # B1 promueve estas series a la Curva S principal de OC.
             ctx['curva_real_json'] = self.build_curva_real(proyecto, fase)
             ctx['fase_backbone'] = fase
+        return ctx
+
+
+# ==========================================================================
+# B1 — Dashboard de Obra Civil con avance REAL (#139)
+# ==========================================================================
+
+def _curva_s_chart_payload(proyecto, fase=car.FASE_OOCC) -> dict:
+    """Arma el dict ``{labels, planeado, ejecutado}`` de la Curva S REAL.
+
+    Une los ejes de las series "Ejecutado" (avance real por torre distribuido en
+    el tiempo) y "Planeado" (cronograma ``ProgramacionFase``) sobre un eje X
+    común de fechas ordenadas, interpolando con "último valor conocido" (carry
+    forward) para que Chart.js trace dos líneas alineadas.
+
+    Edge (proyecto sin avance): ambas series vacías → ``{labels:[], planeado:[],
+    ejecutado:[]}`` (la gráfica queda vacía, NO lanza).
+    """
+    ejecutado = car.serie_curva_s_real(proyecto, fase)
+    planeado = car.serie_planeado(proyecto, fase)
+
+    # Eje X común = unión ordenada de fechas de ambas series.
+    labels = sorted(set(ejecutado.get('labels', [])) | set(planeado.get('labels', [])))
+    if not labels:
+        return {'labels': [], 'planeado': [], 'ejecutado': []}
+
+    def _carry(series_labels, series_vals):
+        """Mapea cada label del eje común al último valor ≤ él (carry forward)."""
+        pares = list(zip(series_labels, series_vals, strict=False))
+        out = []
+        ult = 0.0
+        idx = 0
+        for lab in labels:
+            while idx < len(pares) and pares[idx][0] <= lab:
+                ult = pares[idx][1]
+                idx += 1
+            out.append(round(ult, 2))
+        return out
+
+    return {
+        'labels': labels,
+        'ejecutado': _carry(ejecutado.get('labels', []), ejecutado.get('ejecutado', [])),
+        'planeado': _carry(planeado.get('labels', []), planeado.get('planeado', [])),
+    }
+
+
+def _tarjetas_real(proyecto, fase=car.FASE_OOCC) -> dict:
+    """Deriva las tarjetas %ejecutado / %planeado / varianza del avance REAL.
+
+    - ``pct_construido``: último punto acumulado de la serie "Ejecutado" real.
+    - ``pct_programado``: último punto de la serie "Planeado" del cronograma.
+    - ``varianza_pct``: ejecutado − planeado (negativo = atraso).
+
+    Edge (sin datos): todo a 0.0, nunca None ni división por cero.
+    """
+    payload = _curva_s_chart_payload(proyecto, fase)
+    pct_ejec = payload['ejecutado'][-1] if payload['ejecutado'] else 0.0
+    pct_plan = payload['planeado'][-1] if payload['planeado'] else 0.0
+    return {
+        'pct_construido': round(pct_ejec, 1),
+        'pct_programado': round(pct_plan, 1),
+        'varianza_pct': round(pct_ejec - pct_plan, 1),
+    }
+
+
+class DashboardObraCivilRealView(_DashboardObraCivilViewLegacy):
+    """Dashboard de Obra Civil con la Curva S y tarjetas del avance REAL (#139).
+
+    Hereda de la vista legacy #141 → conserva sus 3 gráficas (G1 Curva S
+    consolidada, G2 avance por etapa, G3 desviación de materiales), el selector
+    "Consolidada" y el flag ``data-charts-ready``. Sobre eso superpone el avance
+    REAL de los 257 ``oc_detalle`` de prod:
+
+      - ``datos_chart``: pasa a ser la Curva S REAL (Ejecutado/Planeado del
+        backbone), de modo que la línea verde "Ejecutado" deja de salir en 0%.
+      - tarjetas ``pct_construido_total`` / ``pct_programado_total`` /
+        ``varianza_pct_real`` derivadas del REAL.
+      - ``avance_etapas_oc6``: las **6** etapas OC con pesos (incluye
+        Cerramiento), vía ``avance_por_etapa(proyecto,'OOCC')`` del backbone.
+      - ``vista_torres_oc``: lista por torre (% / completa / pendientes) con la
+        URL de drill-down a ``obra_civil_torre`` por torre.
+    """
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        proyecto = ctx['proyecto']
+        fase = car.FASE_OOCC
+
+        # 1. Curva S REAL — reemplaza datos_chart (que colgaba del semanal vacío).
+        chart_real = _curva_s_chart_payload(proyecto, fase)
+        ctx['datos_chart'] = json.dumps(chart_real)
+        # Para los assert/probe del journey: serie ejecutado real cruda + flag.
+        ctx['curva_real_json'] = json.dumps({
+            'fase': fase,
+            'ejecutado': car.serie_curva_s_real(proyecto, fase),
+            'planeado': car.serie_planeado(proyecto, fase),
+        })
+
+        # 2. Tarjetas derivadas del REAL (no del DashboardAvanceSemanal vacío).
+        tarjetas = _tarjetas_real(proyecto, fase)
+        ctx['pct_construido_total'] = tarjetas['pct_construido']
+        ctx['pct_programado_total'] = tarjetas['pct_programado']
+        ctx['varianza_pct_real'] = tarjetas['varianza_pct']
+
+        # 3. Avance por etapa OC — 6 etapas (con Cerramiento) del backbone.
+        avance_etapas6 = car.avance_por_etapa(proyecto, fase)
+        ctx['avance_etapas_oc6'] = avance_etapas6
+        # Promueve la gráfica G2 a las 6 etapas reales (el JS lee graficas_json).
+        # Mantiene la clave 'avance_etapas' legacy (5 etapas) para no romper los
+        # asserts del test #141, pero la gráfica usa las 6 reales vía oc6.
+        try:
+            graficas = json.loads(ctx.get('graficas_json', '{}'))
+        except (TypeError, ValueError):
+            graficas = {}
+        graficas['avance_etapas_oc6'] = avance_etapas6
+        ctx['graficas_json'] = json.dumps(graficas)
+
+        # 4. Vista por torre OC + drill-down a obra_civil_torre.
+        vista = car.vista_por_torre(proyecto, fase)
+        for fila in vista:
+            torre_id = fila.get('torre_id')
+            try:
+                fila['url_detalle'] = reverse(
+                    'construccion:obra_civil_torre',
+                    kwargs={'proyecto_id': proyecto.id, 'torre_id': torre_id},
+                ) if torre_id else ''
+            except Exception:
+                fila['url_detalle'] = ''
+        ctx['vista_torres_oc'] = vista
+        ctx['torres_oc_completas'] = sum(1 for f in vista if f.get('completa'))
+        ctx['torres_oc_total'] = len(vista)
+
         return ctx

--- a/apps/construccion/views_dashboards.py
+++ b/apps/construccion/views_dashboards.py
@@ -80,17 +80,25 @@ class _DashboardCurvaSBase(_DashboardCurvaSBaseLegacy):
     def build_curva_real(self, proyecto, fase):
         """Series reales ejecutado + planeado, listas para el template.
 
-        Devuelve un STRING JSON pre-serializado (guard es-CO: nunca floats
-        crudos en JS inline). B1 lo consume como dataset principal de la Curva S
-        de OC; B2/B3 para Montaje/Tendido.
+        Devuelve un **DICT** (NO un string json.dumps). El parcial base
+        ``_dashboard_fase_base.html`` lo emite con ``{{ curva_real_json|json_script }}``
+        y su JS hace ``JSON.parse(...).ejecutado`` / ``.planeado``. ``json_script``
+        ya serializa+escapa el valor de forma segura (guard es-CO: nunca floats
+        crudos en JS inline), así que el contexto debe traer el dict, no el string.
+        Si pasáramos un string pre-serializado quedaría doble-codificado:
+        ``JSON.parse`` devolvería un string y ``.ejecutado`` sería ``undefined`` →
+        la Curva S no pintaría (bug de integración B2/B4 que reusan este parcial).
+
+        B1 (Obra Civil) usa su propio ``datos_chart`` para el canvas legacy y NO
+        depende de este dict; B2/B3 (Montaje/Tendido) sí lo consumen vía el parcial.
         """
         ejecutado = car.serie_curva_s_real(proyecto, fase)
         planeado = car.serie_planeado(proyecto, fase)
-        return json.dumps({
+        return {
             'fase': fase,
             'ejecutado': ejecutado,   # {'labels':[...], 'ejecutado':[...]}
             'planeado': planeado,     # {'labels':[...], 'planeado':[...]}
-        })
+        }
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)

--- a/apps/construccion/views_dashboards.py
+++ b/apps/construccion/views_dashboards.py
@@ -1,0 +1,73 @@
+"""Vistas de los Dashboards de fase (#139) — partición física de ``views.py``.
+
+``views.py`` ya es magnet (2446 líneas, 4 sub-features lo tocarían). Este módulo
+es el hogar de las vistas de los dashboards de avance real, para que B1–B5
+escriban a archivos separados (``views_dashboards_b*.py``) sin colisión.
+
+F2 (scaffolding) deja aquí:
+  - ``_DashboardCurvaSBase``: re-exporta/extiende la base existente de
+    ``views.py`` con un punto de extensión (``serie_real_source``) que B1
+    cablea al backbone ``calculators_avance_real`` para que la Curva S
+    "Ejecutado" deje de salir en 0% (hoy cuelga de ``DashboardAvanceSemanal``,
+    solo 2 filas en prod).
+
+B1 (#139) EXTIENDE este archivo con ``DashboardObraCivilView`` real y mueve la
+lógica de cableado. B2–B5 importan ``_DashboardCurvaSBase`` desde aquí para sus
+propios dashboards de fase. NO duplicar la base en cada sub-feature.
+"""
+from __future__ import annotations
+
+import json
+
+from . import calculators_avance_real as car
+# Reusa la base ya probada de views.py (LoginRequired + RoleRequired + el
+# armado de tarjetas/semanas). B1 la sobreescribe/extiende según el scope.
+from .views import _DashboardCurvaSBase as _DashboardCurvaSBaseLegacy
+
+
+class _DashboardCurvaSBase(_DashboardCurvaSBaseLegacy):
+    """Base compartida por los dashboards de fase con datos de avance REAL.
+
+    Extiende la base legacy (que arma tarjetas/semanas desde
+    ``DashboardAvanceSemanal``) con un punto de extensión para inyectar las
+    series reales del backbone ``calculators_avance_real``. F2 deja el cableado
+    listo pero conservador: por defecto añade ``curva_real`` al contexto sin
+    alterar el comportamiento existente; B1 decide promover ``curva_real`` a la
+    serie principal de la Curva S de Obra Civil.
+
+    Subclases (B1–B5) definen ``FASE_DEFAULT`` y ``template_name``.
+    """
+
+    #: Fase del backbone (OOCC / MONTAJE / TENDIDO). Por defecto deriva de
+    #: ``FASE_DEFAULT`` de la base legacy. B2/B3 la sobreescriben si difiere.
+    FASE_BACKBONE = None
+
+    def fase_backbone(self):
+        """Resuelve la fase a pasar al backbone de cálculo real."""
+        return (self.FASE_BACKBONE or self.FASE_DEFAULT or car.FASE_OOCC).upper()
+
+    def build_curva_real(self, proyecto, fase):
+        """Series reales ejecutado + planeado, listas para el template.
+
+        Devuelve un STRING JSON pre-serializado (guard es-CO: nunca floats
+        crudos en JS inline). B1 lo consume como dataset principal de la Curva S
+        de OC; B2/B3 para Montaje/Tendido.
+        """
+        ejecutado = car.serie_curva_s_real(proyecto, fase)
+        planeado = car.serie_planeado(proyecto, fase)
+        return json.dumps({
+            'fase': fase,
+            'ejecutado': ejecutado,   # {'labels':[...], 'ejecutado':[...]}
+            'planeado': planeado,     # {'labels':[...], 'planeado':[...]}
+        })
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        proyecto = ctx.get('proyecto')
+        if proyecto is not None:
+            fase = self.fase_backbone()
+            # Aditivo: no rompe el contrato legacy (datos_chart sigue intacto).
+            # B1 promueve estas series a la Curva S principal de OC.
+            ctx['curva_real_json'] = self.build_curva_real(proyecto, fase)
+            ctx['fase_backbone'] = fase
+        return ctx

--- a/apps/construccion/views_dashboards_b2_montaje.py
+++ b/apps/construccion/views_dashboards_b2_montaje.py
@@ -1,0 +1,113 @@
+"""Dashboard de Montaje con avance REAL (#139 · B2).
+
+Sub-feature B2 del bloque "Dashboards de fase". El dashboard de Montaje legacy
+(``views.DashboardMontajeView`` → ``dashboard_curva_s.html``) cuelga de
+``DashboardAvanceSemanal`` (solo 2 filas en prod) → sale en 0%. Esta vista usa
+el backbone ``calculators_avance_real`` (S1) para cablear el avance REAL
+ponderado por torre de Montaje (``MontajeEstructuraTorreDetalle.avance_ponderado``
+con pesos 10/20/45/25) a:
+
+  1. Curva S Montaje real (serie "Ejecutado" del avance real distribuido en el
+     tiempo, NO del semanal) + "Planeado" del cronograma.
+  2. Avance por etapa Montaje: Estructura en sitio 10% · Prearmada 20% ·
+     Torre montada 45% · Revisada 25% (% de torres con la etapa completa).
+  3. Vista por torre Montaje con drill-down a la pata de avance
+     (``construccion:montaje_torre``).
+
+Reusa el parcial base ``_dashboard_fase_base.html`` (S3) vía el template propio
+``dashboard_montaje.html`` y AÑADE un canvas dedicado ``#montaje-etapas-chart``
+(contrato del scope B2). Los datasets viajan PRE-SERIALIZADOS (guard es-CO:
+nunca floats crudos ni JSON crudo en JS inline / x-data).
+
+Coexiste con la URL legacy ``dashboard-montaje/`` (name ``dashboard_montaje``);
+B2 registra ``dashboard-montaje-real/`` (name ``dashboard_montaje_real``) para
+NO colisionar — ver ``urls_dashboards_b2_montaje.py``.
+"""
+from __future__ import annotations
+
+import json
+
+from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
+
+from . import calculators_avance_real as car
+from .models import ProyectoConstruccion
+from .views import _DashboardCurvaSBase as _DashboardCurvaSBaseLegacy
+from .views_dashboards import _DashboardCurvaSBase
+
+
+class DashboardMontajeRealView(_DashboardCurvaSBase):
+    """Dashboard de Montaje con avance real (Curva S + etapas + por torre).
+
+    Hereda la base de avance real de ``views_dashboards`` (que ya inyecta
+    ``curva_real_json`` para la fase indicada). B2 fija la fase MONTAJE y añade
+    el avance por etapa y la vista por torre del backbone, más el dataset
+    dedicado del chart de etapas de Montaje.
+    """
+
+    template_name = 'construccion/dashboard_montaje.html'
+    FASE_DEFAULT = 'MONTAJE'
+    FASE_BACKBONE = car.FASE_MONTAJE  # 'MONTAJE'
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        proyecto = ctx.get('proyecto')
+        fase = car.FASE_MONTAJE
+
+        # --- Avance por etapa Montaje (10/20/45/25) ---
+        # Edge case: proyecto sin montaje → backbone devuelve [] (sin crash).
+        avance_etapas = car.avance_por_etapa(proyecto, fase) if proyecto is not None else []
+
+        # --- Vista por torre Montaje (drill-down a montaje_torre) ---
+        # Edge case: proyecto sin torres/sin montaje → [] (la tabla muestra el
+        # estado vacío del parcial base sin reventar).
+        vista_torres = car.vista_por_torre(proyecto, fase) if proyecto is not None else []
+
+        # "Sin datos" = no hay NINGUNA torre con avance de Montaje. OJO:
+        # avance_por_etapa SIEMPRE devuelve las 4 etapas (al 0% si no hay datos),
+        # así que NO sirve como señal de vacío; la señal real es vista_torres
+        # vacía (no hay MontajeEstructuraTorreDetalle). Así el banner de estado
+        # vacío aparece correctamente para un proyecto sin montaje.
+        montaje_sin_datos = not vista_torres
+
+        ctx.update({
+            # Contexto que consume el parcial base _dashboard_fase_base.html.
+            'fase_codigo': fase,
+            'fase_label': 'Montaje',
+            'avance_etapas': avance_etapas,
+            'vista_torres': vista_torres,
+            # Dataset dedicado del canvas #montaje-etapas-chart (guard es-CO:
+            # json_script en el template, NUNCA floats crudos en JS inline).
+            'montaje_etapas_json': json.dumps(avance_etapas),
+            # Bandera de estado vacío para la UI (loading/success/empty).
+            'montaje_sin_datos': montaje_sin_datos,
+        })
+        return ctx
+
+
+class DashboardMontajeDatosGraficasView(_DashboardCurvaSBaseLegacy):
+    """Endpoint JSON de las gráficas del Dashboard de Montaje real (#139 · B2).
+
+    Sirve los datasets de la Curva S real + avance por etapa Montaje para
+    refrescos async del front sin re-renderizar el template completo. Hereda la
+    base legacy SOLO por los mixins de auth/rol (LoginRequired + RoleRequired);
+    NO usa su ``get_context_data`` (responde JSON directo).
+
+    Edge case: proyecto sin montaje → series/etapas vacías con HTTP 200 (NO 500).
+    """
+
+    template_name = 'construccion/dashboard_montaje.html'  # no se renderiza
+    FASE_DEFAULT = 'MONTAJE'
+
+    def get(self, request, *args, **kwargs):
+        proyecto = get_object_or_404(ProyectoConstruccion, id=self.kwargs['proyecto_id'])
+        fase = car.FASE_MONTAJE
+        payload = {
+            'fase': fase,
+            'curva_real': {
+                'ejecutado': car.serie_curva_s_real(proyecto, fase),
+                'planeado': car.serie_planeado(proyecto, fase),
+            },
+            'avance_etapas': car.avance_por_etapa(proyecto, fase),
+        }
+        return JsonResponse(payload)

--- a/apps/construccion/views_dashboards_b3_tendido.py
+++ b/apps/construccion/views_dashboards_b3_tendido.py
@@ -1,0 +1,158 @@
+"""Dashboard de Tendido (Conductor + Fibra OPGW) — B3 (#139).
+
+Tercer dashboard de fase del bloque dashboards. Replica el patrón del Dashboard
+de Obra Civil (B1) sobre el backbone real ``calculators_avance_real`` para que la
+Curva S "Ejecutado" deje de salir en 0% (hoy cuelga de ``DashboardAvanceSemanal``,
+solo 2 filas en prod) y refleje el avance REAL por torre de Tendido.
+
+Particularidad de Tendido frente a OC/Montaje: el avance se compone de DOS
+secciones independientes con SUMPRODUCT propio —
+
+  - **Conductor** (6 etapas ponderadas): Riega manila · Riega guaya ·
+    Tendido conductor · Grapado · Accesorios · Balizas
+    (``TendidoTorre.avance_conductor``).
+  - **Fibra OPGW** (5 etapas ponderadas): Riega manila fibra · Riega guaya OPGW ·
+    Tendido OPGW · Grapado fibra · Empalmes OPGW
+    (``TendidoTorre.avance_fibra``).
+
+Por eso el dashboard expone DOS gráficas de avance por etapa
+(``#tendido-conductor-chart`` + ``#tendido-fibra-chart``) en vez de una sola, y la
+Curva S real promedia ambas secciones por torre
+(``serie_curva_s_real(proyecto,'TENDIDO')`` ya las pondera 50/50).
+
+Vista por torre: ``vista_por_torre(proyecto,'TENDIDO')`` combina las pendientes de
+ambos sets. Cada fila enlaza al detalle ``construccion:tendido_torre`` (drill-down).
+
+GUARDS es-CO (memorias recurrentes del portafolio): todos los datasets viajan
+PRE-SERIALIZADOS vía ``json.dumps`` + ``{{ ...|json_script }}`` en el template
+(nunca floats crudos ni JSON crudo en JS inline / x-data). La vista NO emite
+floats al JS; el template los lee con ``JSON.parse(...textContent)``.
+"""
+from __future__ import annotations
+
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
+from django.views import View
+
+from apps.core.mixins import RoleRequiredMixin
+
+from . import calculators_avance_real as car
+from .models import ProyectoConstruccion
+from .views import ALL_ADMIN_ROLES, OPERARIO_ROLES
+from .views_dashboards import _DashboardCurvaSBase
+
+
+class DashboardTendidoView(_DashboardCurvaSBase):
+    """Dashboard Curva S de Tendido (#139) — Conductor + Fibra OPGW.
+
+    Extiende ``_DashboardCurvaSBase`` (que ya inyecta ``curva_real_json`` con la
+    serie real ejecutado/planeado de la fase) y añade:
+
+      - ``avance_conductor`` / ``avance_fibra``: las dos listas de avance por
+        etapa (``avance_por_etapa_tendido``) para las 2 gráficas.
+      - ``vista_torres``: avance por torre con pendientes combinadas y drill-down.
+      - JSONs pre-serializados (``etapas_tendido_json``) para el render Chart.js.
+
+    Robusto ante proyecto sin torres / sin tendido: el backbone devuelve listas
+    con pct=0 y la vista por torre vacía — HTTP 200 siempre, sin 500.
+    """
+
+    template_name = 'construccion/dashboard_tendido.html'
+    FASE_DEFAULT = 'TENDIDO'
+    FASE_BACKBONE = car.FASE_TENDIDO
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        proyecto = ctx['proyecto']
+
+        etapas = car.avance_por_etapa_tendido(proyecto)
+        avance_conductor = etapas.get('conductor', [])
+        avance_fibra = etapas.get('fibra', [])
+        vista_torres = car.vista_por_torre(proyecto, car.FASE_TENDIDO)
+
+        # % global de cada sección (promedio del avance real por torre) — para las
+        # tarjetas resumen. Derivado del real, NO del semanal vacío.
+        pct_conductor, pct_fibra = self._pct_secciones(proyecto)
+
+        ctx.update({
+            'fase_codigo': car.FASE_TENDIDO,
+            'fase_label': 'Tendido',
+            'avance_conductor': avance_conductor,
+            'avance_fibra': avance_fibra,
+            'vista_torres': vista_torres,
+            'pct_conductor': pct_conductor,
+            'pct_fibra': pct_fibra,
+            # El parcial base (_dashboard_fase_base.html) hace
+            # ``{{ curva_real_json|json_script:... }}`` y su JS lee
+            # ``curva.ejecutado`` / ``curva.planeado``. ``json_script`` espera un
+            # OBJETO (lo serializa él); si le pasáramos el string que produce
+            # ``_DashboardCurvaSBase.build_curva_real`` quedaría doble-codificado
+            # (JSON.parse devolvería un string, no el dict) y la Curva S no
+            # pintaría. Por eso sobreescribimos con un dict con las claves que el
+            # parcial espera. Guard es-CO igualmente cubierto: json_script escapa
+            # y no hay floats crudos en el JS inline.
+            'curva_real_json': {
+                'ejecutado': car.serie_curva_s_real(proyecto, car.FASE_TENDIDO),
+                'planeado': car.serie_planeado(proyecto, car.FASE_TENDIDO),
+            },
+            # Para que el parcial base NO pinte su gráfica genérica de etapas
+            # (B3 usa dos charts propios) le pasamos avance_etapas vacío.
+            'avance_etapas': [],
+            # Datasets para el Chart.js de las 2 gráficas de etapa de B3. Se
+            # pasa como dict (no string): el template usa ``json_script`` para
+            # serializarlo de forma segura (guard es-CO; sin floats crudos en JS
+            # inline). Pasar un string aquí lo doble-codificaría.
+            'etapas_tendido': {
+                'conductor': avance_conductor,
+                'fibra': avance_fibra,
+            },
+        })
+        return ctx
+
+    @staticmethod
+    def _pct_secciones(proyecto):
+        """(% conductor, % fibra) global = promedio del avance real por torre.
+
+        Reusa las properties del modelo (``avance_conductor``/``avance_fibra``,
+        0..1). Divide por el total de torres del proyecto (no solo las que tienen
+        registro de tendido) para ser coherente con la Curva S real. Si no hay
+        torres, devuelve (0.0, 0.0). NUNCA 500.
+        """
+        n = proyecto.torres.count() or 0
+        if n == 0:
+            return 0.0, 0.0
+        torres = list(
+            proyecto.tendido_torres.select_related('proyecto', 'torre').all()
+        )
+        if not torres:
+            return 0.0, 0.0
+        suma_c = sum(float(t.avance_conductor) for t in torres)
+        suma_f = sum(float(t.avance_fibra) for t in torres)
+        return round((suma_c / n) * 100, 2), round((suma_f / n) * 100, 2)
+
+
+class DashboardTendidoDataView(LoginRequiredMixin, RoleRequiredMixin, View):
+    """GET JSON con los datos de las gráficas del Dashboard de Tendido (#139).
+
+    Single source of truth para el refresh/AJAX y el contrato que valida el E2E:
+      - ``curva_s``: serie real ejecutado + planeado de la fase TENDIDO.
+      - ``avance_conductor`` / ``avance_fibra``: % torres completas por etapa.
+      - ``vista_torres``: avance por torre + pendientes.
+
+    Robusto: proyecto sin torres → listas vacías, HTTP 200 (nunca 500).
+    """
+    allowed_roles = ALL_ADMIN_ROLES + OPERARIO_ROLES
+
+    def get(self, request, proyecto_id, *args, **kwargs):
+        proyecto = get_object_or_404(ProyectoConstruccion, id=proyecto_id)
+        etapas = car.avance_por_etapa_tendido(proyecto)
+        return JsonResponse({
+            'curva_s': {
+                'ejecutado': car.serie_curva_s_real(proyecto, car.FASE_TENDIDO),
+                'planeado': car.serie_planeado(proyecto, car.FASE_TENDIDO),
+            },
+            'avance_conductor': etapas.get('conductor', []),
+            'avance_fibra': etapas.get('fibra', []),
+            'vista_torres': car.vista_por_torre(proyecto, car.FASE_TENDIDO),
+        })

--- a/apps/construccion/views_dashboards_b3_tendido.py
+++ b/apps/construccion/views_dashboards_b3_tendido.py
@@ -83,19 +83,12 @@ class DashboardTendidoView(_DashboardCurvaSBase):
             'vista_torres': vista_torres,
             'pct_conductor': pct_conductor,
             'pct_fibra': pct_fibra,
-            # El parcial base (_dashboard_fase_base.html) hace
-            # ``{{ curva_real_json|json_script:... }}`` y su JS lee
-            # ``curva.ejecutado`` / ``curva.planeado``. ``json_script`` espera un
-            # OBJETO (lo serializa él); si le pasáramos el string que produce
-            # ``_DashboardCurvaSBase.build_curva_real`` quedaría doble-codificado
-            # (JSON.parse devolvería un string, no el dict) y la Curva S no
-            # pintaría. Por eso sobreescribimos con un dict con las claves que el
-            # parcial espera. Guard es-CO igualmente cubierto: json_script escapa
-            # y no hay floats crudos en el JS inline.
-            'curva_real_json': {
-                'ejecutado': car.serie_curva_s_real(proyecto, car.FASE_TENDIDO),
-                'planeado': car.serie_planeado(proyecto, car.FASE_TENDIDO),
-            },
+            # NOTA (F4 integración): ``curva_real_json`` lo inyecta ya como DICT la
+            # base ``_DashboardCurvaSBase.build_curva_real`` (corregido en la fuente
+            # para que NO sea un string json.dumps doble-codificado). El parcial
+            # base lo emite con ``{{ curva_real_json|json_script }}`` y su JS lee
+            # ``curva.ejecutado`` / ``.planeado``. Ya no hace falta el workaround
+            # local de B3 — se eliminó para no divergir de B2/B4.
             # Para que el parcial base NO pinte su gráfica genérica de etapas
             # (B3 usa dos charts propios) le pasamos avance_etapas vacío.
             'avance_etapas': [],

--- a/apps/construccion/views_dashboards_b4_torres.py
+++ b/apps/construccion/views_dashboards_b4_torres.py
@@ -1,0 +1,316 @@
+"""B4 — Vista por torre CONSOLIDADA (cross-fase) + drill-down JSON (#139).
+
+Reúne en una sola tabla, por torre, el avance de las TRES fases del proyecto
+(Obra Civil / Montaje / Tendido) reusando el backbone S1 de B1
+(``calculators_avance_real.vista_por_torre(proyecto, fase)``). Cada fila es una
+torre con su % por fase + estado 100% / pendiente, y un % global por torre
+(promedio de las fases con avance registrado).
+
+Expone además un endpoint drill-down JSON reusable por B1/B2/B3 que, dado
+``?torre=<id>&fase=<OOCC|MONTAJE|TENDIDO>``, devuelve el detalle de lo atrasado
+(etapas pendientes) de esa torre en esa fase — "el punto bajo / lo atrasado".
+
+GUARDS es-CO (memorias recurrentes del portafolio):
+  - La tabla viaja en el contexto como dicts/listas (Django escapa); NO se
+    inyectan floats crudos ni JSON crudo en JS inline. El payload para el JS
+    viaja pre-serializado con ``json_script`` desde el template.
+  - El drill-down responde ``JsonResponse`` (Content-Type application/json),
+    no HTML con números localizados.
+  - Edge: una torre sin avance en una fase → ``pct=0``, ``completa=False``,
+    ``registrada=False`` (no error, no fila fantasma).
+"""
+from __future__ import annotations
+
+import json
+
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
+from django.template.loader import render_to_string
+from django.views.generic import TemplateView, View
+
+from apps.core.mixins import RoleRequiredMixin
+
+from . import calculators_avance_real as car
+from .models import ProyectoConstruccion
+from .views import ALL_ADMIN_ROLES, OPERARIO_ROLES
+
+# Fases que componen la vista consolidada, en orden de presentación.
+# (codigo backbone, label humano)
+FASES_CONSOLIDADO = [
+    (car.FASE_OOCC, 'Obra Civil'),
+    (car.FASE_MONTAJE, 'Montaje'),
+    (car.FASE_TENDIDO, 'Tendido'),
+]
+FASES_VALIDAS = {c for c, _ in FASES_CONSOLIDADO}
+
+
+def _label_fase(codigo: str) -> str:
+    """Etiqueta humana de una fase backbone (o el código si es desconocida)."""
+    codigo = (codigo or '').upper()
+    for c, label in FASES_CONSOLIDADO:
+        if c == codigo:
+            return label
+    return codigo
+
+
+def construir_vista_torres_consolidada(proyecto) -> dict:
+    """Pivota ``vista_por_torre`` de las 3 fases a una matriz torre × fase.
+
+    Devuelve::
+
+        {
+          'fases': [{'codigo','label'}, ...],            # encabezados de columna
+          'torres': [                                    # una fila por torre
+              {
+                'torre_id', 'numero',
+                'global_pct': float,                     # promedio de fases con avance
+                'completa_global': bool,                 # todas las fases con avance al 100%
+                'celdas': {
+                    'OOCC':    {'pct','completa','registrada','pendientes':[...]},
+                    'MONTAJE': {...},
+                    'TENDIDO': {...},
+                },
+              }, ...
+          ],
+        }
+
+    Una torre aparece si tiene avance registrado en AL MENOS una fase. Si una
+    fase no tiene registro para esa torre, su celda es
+    ``{'pct':0.0,'completa':False,'registrada':False,'pendientes':[]}`` —
+    edge "torre sin avance en una fase" resuelto como pendiente, NO como error.
+    """
+    # 1. vista_por_torre por cada fase, indexado por torre_id.
+    por_fase = {}
+    numeros = {}
+    for codigo, _label in FASES_CONSOLIDADO:
+        filas = car.vista_por_torre(proyecto, codigo)
+        idx = {}
+        for fila in filas:
+            tid = fila['torre_id']
+            idx[tid] = fila
+            # El número de torre es estable cross-fase; guardamos el primero.
+            numeros.setdefault(tid, fila.get('numero', ''))
+        por_fase[codigo] = idx
+
+    # 2. Universo de torres = unión de las torres con avance en cualquier fase.
+    torre_ids = set()
+    for idx in por_fase.values():
+        torre_ids.update(idx.keys())
+
+    # 3. Construir una fila por torre con sus 3 celdas.
+    torres_out = []
+    for tid in torre_ids:
+        celdas = {}
+        pcts_con_avance = []
+        completas_flags = []
+        for codigo, _label in FASES_CONSOLIDADO:
+            fila = por_fase[codigo].get(tid)
+            if fila is None:
+                # Torre sin avance registrado en esta fase.
+                celdas[codigo] = {
+                    'pct': 0.0,
+                    'completa': False,
+                    'registrada': False,
+                    'pendientes': [],
+                }
+                completas_flags.append(False)
+            else:
+                pct = float(fila.get('pct', 0.0))
+                celdas[codigo] = {
+                    'pct': pct,
+                    'completa': bool(fila.get('completa', False)),
+                    'registrada': True,
+                    'pendientes': list(fila.get('pendientes', [])),
+                }
+                pcts_con_avance.append(pct)
+                completas_flags.append(bool(fila.get('completa', False)))
+
+        global_pct = (round(sum(pcts_con_avance) / len(pcts_con_avance), 2)
+                      if pcts_con_avance else 0.0)
+        torres_out.append({
+            'torre_id': tid,
+            'numero': numeros.get(tid, ''),
+            'global_pct': global_pct,
+            # "completa_global" solo si TODAS las fases del consolidado están al 100%.
+            'completa_global': all(completas_flags) and bool(completas_flags),
+            'celdas': celdas,
+        })
+
+    # Orden por número de torre (igual criterio que el backbone).
+    torres_out.sort(key=lambda r: str(r['numero']))
+
+    return {
+        'fases': [{'codigo': c, 'label': l} for c, l in FASES_CONSOLIDADO],
+        'torres': torres_out,
+    }
+
+
+def detalle_drilldown_torre(proyecto, torre_id, fase) -> dict:
+    """Detalle del "punto bajo / lo atrasado" de una torre en una fase.
+
+    Reusa ``vista_por_torre`` (mismo origen que la tabla) y extrae la fila de la
+    torre solicitada. Devuelve un dict serializable::
+
+        {
+          'torre_id', 'numero', 'fase', 'fase_label',
+          'pct': float, 'completa': bool, 'registrada': bool,
+          'pendientes': [labels],   # etapas atrasadas (lo que falta)
+          'total_pendientes': int,
+        }
+
+    Edge:
+      - fase inválida → ValueError (la view lo traduce a HTTP 400).
+      - torre sin avance en la fase → ``registrada=False``, ``pendientes=[]``
+        (no es un error: simplemente no hay registro de avance todavía).
+    """
+    fase = (fase or '').upper()
+    if fase not in FASES_VALIDAS:
+        raise ValueError(f"Fase inválida: {fase!r}. Use una de {sorted(FASES_VALIDAS)}.")
+
+    # torre_id es un UUID (PK de TorreConstruccion). Llega como str por el
+    # querystring; comparamos por su representación string contra el backbone
+    # (cuyo torre_id puede ser UUID). NO forzar int (rompía con PK UUID).
+    if torre_id in (None, ''):
+        raise ValueError(f"torre inválida: {torre_id!r}")
+    tid_str = str(torre_id)
+
+    filas = car.vista_por_torre(proyecto, fase)
+    fila = next((f for f in filas if str(f['torre_id']) == tid_str), None)
+
+    if fila is None:
+        # Torre sin avance registrado en esta fase → pendiente, no error.
+        numero = ''
+        from .models import TorreConstruccion
+        torre = TorreConstruccion.objects.filter(
+            proyecto=proyecto, id=tid_str).first()
+        if torre is not None:
+            numero = torre.numero
+        return {
+            'torre_id': tid_str,
+            'numero': numero,
+            'fase': fase,
+            'fase_label': _label_fase(fase),
+            'pct': 0.0,
+            'completa': False,
+            'registrada': False,
+            'pendientes': [],
+            'total_pendientes': 0,
+        }
+
+    pendientes = list(fila.get('pendientes', []))
+    return {
+        'torre_id': tid_str,
+        'numero': fila.get('numero', ''),
+        'fase': fase,
+        'fase_label': _label_fase(fase),
+        'pct': float(fila.get('pct', 0.0)),
+        'completa': bool(fila.get('completa', False)),
+        'registrada': True,
+        'pendientes': pendientes,
+        'total_pendientes': len(pendientes),
+    }
+
+
+class DashboardVistaTorresView(LoginRequiredMixin, RoleRequiredMixin, TemplateView):
+    """Dashboard consolidado: tabla torre × fase (OC / Montaje / Tendido).
+
+    Una fila por torre con el % y estado (100% / pendiente) de cada fase y un %
+    global. Cada celda enlaza al drill-down (lo atrasado por torre+fase).
+    """
+    template_name = 'construccion/dashboard_vista_torres.html'
+    allowed_roles = ALL_ADMIN_ROLES + OPERARIO_ROLES
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        proyecto = get_object_or_404(
+            ProyectoConstruccion, id=self.kwargs['proyecto_id'])
+        consolidado = construir_vista_torres_consolidada(proyecto)
+
+        # Resumen por fase (para tarjetas / leyenda): cuántas torres al 100%.
+        resumen_fases = []
+        for f in consolidado['fases']:
+            codigo = f['codigo']
+            registradas = [t for t in consolidado['torres']
+                           if t['celdas'][codigo]['registrada']]
+            completas = sum(1 for t in registradas
+                            if t['celdas'][codigo]['completa'])
+            resumen_fases.append({
+                'codigo': codigo,
+                'label': f['label'],
+                'completas': completas,
+                'registradas': len(registradas),
+            })
+
+        from django.urls import reverse
+        drilldown_url = reverse(
+            'construccion:dashboard_drilldown_torre',
+            kwargs={'proyecto_id': proyecto.id})
+
+        ctx.update({
+            'proyecto': proyecto,
+            'active_tab': 'vista_torres',
+            'fases': consolidado['fases'],
+            'torres': consolidado['torres'],
+            'resumen_fases': resumen_fases,
+            'total_torres': proyecto.torres.count() or 0,
+            'torres_con_avance': len(consolidado['torres']),
+            # Guard es-CO: la config viaja pre-serializada vía json_script en el
+            # template (NO JSON crudo en x-data / JS inline).
+            'drilldown_cfg': json.dumps({'drilldown_url': drilldown_url}),
+        })
+        return ctx
+
+
+class DrilldownTorreFaseView(LoginRequiredMixin, RoleRequiredMixin, View):
+    """Endpoint drill-down JSON reusable: detalle de lo atrasado por torre+fase.
+
+    GET ``?torre=<id>&fase=<OOCC|MONTAJE|TENDIDO>`` →
+        200 JSON ``{ok:true, detalle:{torre_id,numero,fase,fase_label,pct,
+               completa,registrada,pendientes:[...],total_pendientes}}``
+        400 si falta/es inválido ``torre`` o ``fase``.
+
+    Con ``&format=html`` devuelve el parcial ``_drilldown_torre.html`` ya
+    renderizado (mismo ``detalle``) para que B1/B2/B3 lo inyecten directo en su
+    panel vía htmx/fetch sin re-armar el HTML.
+
+    Reusable por B1/B2/B3: cualquiera de los dashboards de fase puede pegarle
+    para mostrar "el punto bajo / lo atrasado" de una torre sin recalcular.
+    """
+    allowed_roles = ALL_ADMIN_ROLES + OPERARIO_ROLES
+
+    def get(self, request, proyecto_id, *args, **kwargs):
+        proyecto = get_object_or_404(ProyectoConstruccion, id=proyecto_id)
+
+        torre_id = request.GET.get('torre')
+        fase = request.GET.get('fase')
+        quiere_html = request.GET.get('format') == 'html'
+
+        if not torre_id:
+            return self._error("Falta el parámetro 'torre'.", quiere_html)
+        if not fase:
+            return self._error("Falta el parámetro 'fase'.", quiere_html)
+
+        try:
+            detalle = detalle_drilldown_torre(proyecto, torre_id, fase)
+        except ValueError as exc:
+            return self._error(str(exc), quiere_html)
+
+        if quiere_html:
+            html = render_to_string(
+                'construccion/partials/_drilldown_torre.html',
+                {'detalle': detalle}, request=request)
+            from django.http import HttpResponse
+            return HttpResponse(html)
+
+        return JsonResponse({'ok': True, 'detalle': detalle})
+
+    @staticmethod
+    def _error(mensaje, quiere_html):
+        if quiere_html:
+            from django.http import HttpResponse
+            html = render_to_string(
+                'construccion/partials/_drilldown_torre.html',
+                {'detalle': None, 'error': mensaje})
+            return HttpResponse(html, status=400)
+        return JsonResponse({'ok': False, 'error': mensaje}, status=400)

--- a/apps/construccion/views_dashboards_b5_general.py
+++ b/apps/construccion/views_dashboards_b5_general.py
@@ -1,0 +1,194 @@
+"""B5 (#139) — Dashboard GENERAL del proyecto (7 fases).
+
+Vista consolidada de las 7 fases de un ``ProyectoConstruccion``:
+  - Gráfica global agregando las 7 fases (Ingeniería, Actividades Preliminares,
+    Obra Civil, Montaje, Tendido, SPT y Pintura, Detalles Finales) + el global
+    ponderado.
+  - Curva S consolidada REAL del proyecto (no la de ``DashboardAvanceSemanal``,
+    que en prod solo tiene 2 filas): se construye agregando las series reales
+    por torre de las fases con anclaje temporal (OOCC / Montaje / Tendido) que
+    expone el backbone ``calculators_avance_real``.
+  - Drill-down: cada fase enlaza a SU dashboard de fase. Los names de URL los
+    crean B1–B4 y F4 los cablea en ``urls.py``. Si un name no resuelve aún en
+    el entorno aislado, el template degrada el enlace a "#" sin romper la página
+    (ver ``DRILLDOWN_URL_NAMES`` + ``_safe_reverse``).
+
+Reusa el backbone PURO ``calculators_avance_real.avance_general`` (ya en la
+base). NO duplica lógica de cálculo: todo el % por fase y el global ponderado
+(pesos de ``ProgramacionFase.peso_pct``, fallback equiponderado) viven allí.
+
+GUARDS es-CO (memorias recurrentes del portafolio):
+  - Los datasets viajan PRE-SERIALIZADOS vía ``json.dumps`` + ``json_script`` en
+    el template. NUNCA floats crudos ni JSON crudo dentro de ``x-data`` / JS
+    inline (coma decimal es-CO rompe el ``<script>`` entero).
+"""
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.shortcuts import get_object_or_404
+from django.urls import NoReverseMatch, reverse
+from django.views.generic import TemplateView
+
+from apps.core.mixins import RoleRequiredMixin
+
+from . import calculators_avance_real as car
+from .models import ProyectoConstruccion
+from .views import ALL_ADMIN_ROLES, OPERARIO_ROLES
+
+
+#: Drill-down: sección de fase del backbone -> name de URL del dashboard de esa
+#: fase (creados por B1–B4, cableados por F4 en urls.py). Las fases sin
+#: dashboard propio (Ingeniería, Preliminares, SPT, Detalles Finales) no tienen
+#: entrada → el template no muestra botón de drill-down para ellas.
+DRILLDOWN_URL_NAMES = {
+    'OBRA_CIVIL': 'construccion:dashboard_obra_civil',
+    'MONTAJE': 'construccion:dashboard_montaje_real',
+    'TENDIDO': 'construccion:dashboard_tendido',
+}
+
+#: Vista consolidada de torres (B4) — enlace global, no por fase.
+VISTA_TORRES_URL_NAME = 'construccion:dashboard_vista_torres'
+
+#: Fases del backbone con serie temporal real por torre (las que alimentan la
+#: Curva S consolidada real). Las otras 4 fases no tienen un origen de avance
+#: real distribuible en el tiempo (no rompen, simplemente no aportan curva).
+FASES_CON_CURVA_REAL = (car.FASE_OOCC, car.FASE_MONTAJE, car.FASE_TENDIDO)
+
+
+def _safe_reverse(name, **kwargs):
+    """``reverse`` que devuelve None si el name aún no está registrado.
+
+    En el entorno aislado de la sub-feature B5 los names de B1–B4 pueden no
+    resolver todavía (F4 garantiza el wiring al integrar). El template degrada
+    el enlace a deshabilitado en ese caso, sin romper la página.
+    """
+    if not name:
+        return None
+    try:
+        return reverse(name, kwargs=kwargs)
+    except NoReverseMatch:
+        return None
+
+
+def curva_s_consolidada_real(proyecto) -> dict:
+    """Curva S consolidada REAL del proyecto agregando las fases con datos.
+
+    A diferencia de ``calculators.curva_s_consolidada`` (que cuelga de
+    ``DashboardAvanceSemanal``, solo 2 filas en prod), esta función agrega las
+    series reales por torre de ``serie_curva_s_real`` para OOCC + Montaje +
+    Tendido. Cada fase aporta su avance acumulado al global como promedio simple
+    de las fases con datos en cada fecha (denominador = número de fases que ya
+    tienen algún avance), de modo que el % consolidado nunca excede 100.
+
+    Devuelve ``{'labels': [iso], 'ejecutado': [float]}``. Edge: proyecto sin
+    avance real en ninguna fase → arreglos vacíos (NO error).
+    """
+    # incremento_por_fecha[fecha] = suma de los incrementos de cada fase en esa
+    # fecha, dividido por el número total de fases con datos.
+    series = []
+    for fase in FASES_CON_CURVA_REAL:
+        s = car.serie_curva_s_real(proyecto, fase)
+        if s.get('labels'):
+            series.append(s)
+
+    if not series:
+        return {'labels': [], 'ejecutado': []}
+
+    n_fases = len(series)
+
+    # Convertir cada curva acumulada de fase a incrementos por fecha.
+    incrementos = defaultdict(float)
+    fechas = set()
+    for s in series:
+        labels = s['labels']
+        valores = s['ejecutado']
+        prev = 0.0
+        for i, fecha in enumerate(labels):
+            actual = valores[i]
+            incrementos[fecha] += (actual - prev) / n_fases
+            prev = actual
+            fechas.add(fecha)
+
+    labels = sorted(fechas)
+    ejecutado = []
+    acum = 0.0
+    for f in labels:
+        acum += incrementos[f]
+        ejecutado.append(round(acum, 2))
+    return {'labels': labels, 'ejecutado': ejecutado}
+
+
+class DashboardGeneralView(LoginRequiredMixin, RoleRequiredMixin, TemplateView):
+    """Dashboard GENERAL del proyecto — 7 fases + global ponderado + curva S real.
+
+    URL: ``/<proyecto_id>/dashboard-general/`` (ver
+    ``urls_dashboards_b5_general.py``).
+    """
+
+    template_name = 'construccion/dashboard_general.html'
+    allowed_roles = ALL_ADMIN_ROLES + OPERARIO_ROLES
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        proyecto = get_object_or_404(
+            ProyectoConstruccion, id=self.kwargs['proyecto_id']
+        )
+
+        # 1) Las 7 fases + global ponderado (backbone puro, con fallback
+        #    equiponderado si todos los pesos están en 0 — estado de prod).
+        general = car.avance_general(proyecto)
+        fases = general['fases']
+        global_pct = general['global_pct']
+
+        # Enriquecer cada fase con su URL de drill-down (si existe y resuelve).
+        fases_ui = []
+        for f in fases:
+            drill = _safe_reverse(
+                DRILLDOWN_URL_NAMES.get(f['seccion']),
+                proyecto_id=proyecto.id,
+            )
+            fases_ui.append({
+                'seccion': f['seccion'],
+                'label': f['label'],
+                'pct': f['pct'],
+                'peso': f['peso'],
+                'drill_url': drill,            # None si no hay dashboard / no resuelve
+                'completa': f['pct'] >= 100.0,
+            })
+
+        # 2) Curva S consolidada real del proyecto.
+        curva_real = curva_s_consolidada_real(proyecto)
+
+        # Pesos efectivos: equiponderado si todos en 0 (mismo criterio del
+        # backbone) — para que la UI explique de dónde sale el global.
+        total_peso = sum(f['peso'] for f in fases)
+        pesos_equiponderados = total_peso == 0
+
+        # 3) Dataset pre-serializado para el chart global (#general-fases-chart)
+        #    y para la curva S — guard es-CO: viaja como JSON, no floats inline.
+        chart_payload = json.dumps({
+            'fases': [
+                {'label': f['label'], 'pct': f['pct'], 'seccion': f['seccion']}
+                for f in fases_ui
+            ],
+            'global_pct': global_pct,
+            'curva_s': curva_real,   # {'labels':[...], 'ejecutado':[...]}
+        })
+
+        ctx.update({
+            'proyecto': proyecto,
+            'fases': fases_ui,
+            'global_pct': global_pct,
+            'pesos_equiponderados': pesos_equiponderados,
+            'tiene_avance': global_pct > 0,
+            'tiene_curva_s': bool(curva_real['labels']),
+            'vista_torres_url': _safe_reverse(
+                VISTA_TORRES_URL_NAME, proyecto_id=proyecto.id
+            ),
+            'general_chart_json': chart_payload,
+            'active_tab': 'dashboard_general',
+        })
+        return ctx

--- a/templates/construccion/_dashboard_fase_base.html
+++ b/templates/construccion/_dashboard_fase_base.html
@@ -1,0 +1,173 @@
+{% comment %}
+Parcial base reutilizable para los Dashboards de fase (#139 · S3).
+
+Reutilizado por los dashboards de Obra Civil (B1), Montaje (B2), Tendido (B3) y
+Vista por torre (B4). Provee el esqueleto común:
+  - canvas #curva-s-chart           (serie Ejecutado real + Planeado)
+  - canvas #avance-etapas-chart     (% torres completas por etapa)
+  - bloque vista-por-torre          (cuáles 100% / pendientes)
+  - atributo [data-charts-ready]    (gate del E2E: 'true' cuando los charts cargan)
+  - atributo [data-fase]            (OOCC / MONTAJE / TENDIDO)
+
+GUARDS es-CO (memorias recurrentes del portafolio):
+  - Los datasets viajan PRE-SERIALIZADOS vía {{ ...|json_script }} (NO floats
+    crudos ni JSON crudo dentro de x-data / JS inline). El JS los lee con
+    JSON.parse(document.getElementById('id').textContent).
+  - No coma decimal localizada en números inline.
+
+Contexto esperado (lo provee la vista que incluye este parcial):
+  - fase_codigo        : str  'OOCC' | 'MONTAJE' | 'TENDIDO'
+  - fase_label         : str  etiqueta humana
+  - curva_real_json    : str  JSON {'ejecutado':{labels,ejecutado}, 'planeado':{labels,planeado}}
+  - avance_etapas      : list [{etapa,label,pct,completas,totales}]
+  - vista_torres       : list [{torre_id,numero,pct,completa,pendientes:[...]}]
+  - El que incluye puede pasar overrides con `{% include ... with fase_codigo=... %}`.
+
+Las sub-features pueden agregar canvas adicionales (p.ej. #tendido-fibra-chart
+en B3) en su propio template, alrededor de este include.
+{% endcomment %}
+{% load l10n %}
+
+{% comment %} Datasets pre-serializados — guard es-CO. {% endcomment %}
+{{ curva_real_json|json_script:"dashboard-fase-curva-data" }}
+{{ avance_etapas|json_script:"dashboard-fase-etapas-data" }}
+
+<div class="space-y-6 dashboard-fase-base"
+     data-fase="{{ fase_codigo|default:'OOCC' }}"
+     data-charts-ready="false">
+
+    {% comment %} === Curva S real (Ejecutado vs Planeado) === {% endcomment %}
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-4">
+        <div class="flex items-center justify-between mb-1">
+            <h2 class="font-semibold">Curva S — {{ fase_label|default:'Avance' }}</h2>
+            <span class="text-xs text-gray-500 dark:text-gray-400">Ejecutado real vs. Planeado</span>
+        </div>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">
+            "Ejecutado" refleja el avance real ponderado por torre, distribuido en
+            el tiempo. "Planeado" sale del cronograma de la fase.
+        </p>
+        <div class="relative" style="height: 400px;">
+            <canvas id="curva-s-chart" width="1200" height="400"></canvas>
+        </div>
+    </div>
+
+    {% comment %} === Avance por etapa === {% endcomment %}
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-4">
+        <h2 class="font-semibold mb-1">Avance por etapa — {{ fase_label|default:'Fase' }}</h2>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">
+            % de torres con la etapa completa.
+        </p>
+        <div class="relative" style="height: 320px;">
+            <canvas id="avance-etapas-chart" width="1200" height="320"></canvas>
+        </div>
+        <div class="mt-3 grid grid-cols-2 md:grid-cols-6 gap-2 text-sm">
+            {% for e in avance_etapas %}
+            <div class="rounded border border-gray-200 dark:border-gray-700 p-2 text-center" data-etapa="{{ e.etapa }}">
+                <p class="font-medium text-gray-700 dark:text-gray-200">{{ e.label }}</p>
+                <p class="text-lg font-bold text-blue-700 dark:text-blue-300">{{ e.pct }}%</p>
+                <p class="text-xs text-gray-500">{{ e.completas }} / {{ e.totales }} torres</p>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+
+    {% comment %} === Vista por torre === {% endcomment %}
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-4">
+        <h2 class="font-semibold mb-3">Vista por torre</h2>
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+                <thead class="bg-gray-50 dark:bg-gray-900">
+                    <tr>
+                        <th class="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Torre</th>
+                        <th class="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">% avance</th>
+                        <th class="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Estado</th>
+                        <th class="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Pendientes</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                    {% for t in vista_torres %}
+                    <tr data-torre-pct="{{ t.pct }}" data-torre-id="{{ t.torre_id }}">
+                        <td class="px-3 py-2 font-medium text-gray-700 dark:text-gray-200">{{ t.numero }}</td>
+                        <td class="px-3 py-2">{{ t.pct }}%</td>
+                        <td class="px-3 py-2">
+                            {% if t.completa %}
+                            <span class="inline-flex items-center px-2 py-0.5 rounded-full bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300 text-xs font-semibold">100%</span>
+                            {% else %}
+                            <span class="inline-flex items-center px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300 text-xs font-semibold">Pendiente</span>
+                            {% endif %}
+                        </td>
+                        <td class="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">
+                            {% if t.pendientes %}{{ t.pendientes|join:", " }}{% else %}—{% endif %}
+                        </td>
+                    </tr>
+                    {% empty %}
+                    <tr><td colspan="4" class="px-3 py-4 text-center text-gray-400">Sin datos de avance para esta fase.</td></tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    {% comment %}
+    Render de los charts. Lee los datasets pre-serializados (NO floats inline).
+    Marca [data-charts-ready=true] al terminar — gate del E2E. Las sub-features
+    pueden sobreescribir/extender este script (p.ej. añadir un 2do chart de
+    fibra en B3) en su propio template.
+    {% endcomment %}
+    <script>
+    (function () {
+        function readJSON(id) {
+            var el = document.getElementById(id);
+            if (!el) { return null; }
+            try { return JSON.parse(el.textContent); } catch (e) { return null; }
+        }
+        function renderDashboardFase() {
+            var root = document.querySelector('.dashboard-fase-base');
+            if (!root || typeof Chart === 'undefined') { return; }
+            var curva = readJSON('dashboard-fase-curva-data') || {};
+            var etapas = readJSON('dashboard-fase-etapas-data') || [];
+
+            var ejec = (curva.ejecutado) || { labels: [], ejecutado: [] };
+            var plan = (curva.planeado) || { labels: [], planeado: [] };
+
+            var elCurva = document.getElementById('curva-s-chart');
+            if (elCurva) {
+                new Chart(elCurva.getContext('2d'), {
+                    type: 'line',
+                    data: {
+                        labels: ejec.labels && ejec.labels.length ? ejec.labels : plan.labels,
+                        datasets: [
+                            { label: 'Ejecutado', data: ejec.ejecutado || [], borderColor: '#2563eb', tension: 0.2 },
+                            { label: 'Planeado', data: plan.planeado || [], borderColor: '#9ca3af', borderDash: [6, 4], tension: 0.2 }
+                        ]
+                    },
+                    options: { responsive: true, maintainAspectRatio: false,
+                        scales: { y: { beginAtZero: true, max: 100 } } }
+                });
+            }
+
+            var elEtapas = document.getElementById('avance-etapas-chart');
+            if (elEtapas && etapas.length) {
+                new Chart(elEtapas.getContext('2d'), {
+                    type: 'bar',
+                    data: {
+                        labels: etapas.map(function (e) { return e.label; }),
+                        datasets: [{ label: '% torres completas',
+                            data: etapas.map(function (e) { return e.pct; }),
+                            backgroundColor: '#3b82f6' }]
+                    },
+                    options: { responsive: true, maintainAspectRatio: false,
+                        scales: { y: { beginAtZero: true, max: 100 } } }
+                });
+            }
+
+            root.setAttribute('data-charts-ready', 'true');
+        }
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', renderDashboardFase);
+        } else {
+            renderDashboardFase();
+        }
+    })();
+    </script>
+</div>

--- a/templates/construccion/dashboard_curva_s.html
+++ b/templates/construccion/dashboard_curva_s.html
@@ -49,7 +49,12 @@
         </div>
         <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-3 text-center">
             <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">% Ejecutado</p>
-            <p class="text-2xl font-bold text-green-700 dark:text-green-300">{{ pct_construido_total }}%</p>
+            <p class="text-2xl font-bold text-green-700 dark:text-green-300" data-pct-ejecutado>{{ pct_construido_total }}%</p>
+            {% if varianza_pct_real is not None %}
+            <p class="text-xs mt-0.5 {% if varianza_pct_real < 0 %}text-red-600 dark:text-red-400{% elif varianza_pct_real > 0 %}text-green-600 dark:text-green-400{% else %}text-gray-500{% endif %}" data-varianza-pct>
+                {% if varianza_pct_real >= 0 %}+{% endif %}{{ varianza_pct_real }}% vs plan
+            </p>
+            {% endif %}
         </div>
         <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-3 text-center">
             <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Tasa / semana</p>
@@ -91,17 +96,79 @@
         <div class="relative" style="height: 320px;">
             <canvas id="avance-etapas-chart" width="1200" height="320"></canvas>
         </div>
-        <!-- Resumen textual (también alimenta los assert_contains del journey) -->
-        <div class="mt-3 grid grid-cols-2 md:grid-cols-5 gap-2 text-sm">
+        <!-- Resumen textual de las 6 etapas REALES de OC (B1 #139): Cerramiento,
+             Excavación, Solado, Acero, Vaciado, Compactación. Si no hay datos
+             reales (avance_etapas_oc6 vacío) cae a las 5 legacy de #141 para no
+             romper los assert_contains existentes. También alimenta el journey. -->
+        <div class="mt-3 grid grid-cols-2 md:grid-cols-6 gap-2 text-sm" data-etapas-oc6>
+            {% for e in avance_etapas_oc6 %}
+            <div class="rounded border border-gray-200 dark:border-gray-700 p-2 text-center" data-etapa="{{ e.etapa }}">
+                <p class="font-medium text-gray-700 dark:text-gray-200">{{ e.label }}</p>
+                <p class="text-lg font-bold text-blue-700 dark:text-blue-300">{{ e.pct }}%</p>
+                <p class="text-xs text-gray-500">{{ e.completas }} / {{ e.totales }} torres</p>
+            </div>
+            {% empty %}
             {% for e in avance_etapas %}
-            <div class="rounded border border-gray-200 dark:border-gray-700 p-2 text-center">
+            <div class="rounded border border-gray-200 dark:border-gray-700 p-2 text-center" data-etapa="{{ e.etapa }}">
                 <p class="font-medium text-gray-700 dark:text-gray-200">{{ e.label }}</p>
                 <p class="text-lg font-bold text-blue-700 dark:text-blue-300">{{ e.pct }}%</p>
                 <p class="text-xs text-gray-500">{{ e.completas }} / {{ e.totales }} torres</p>
             </div>
             {% endfor %}
+            {% endfor %}
         </div>
     </div>
+
+    <!-- B1 · Vista por torre de Obra Civil (#139) — cuáles 100% / pendientes,
+         con drill-down a obra_civil_torre del punto bajo -->
+    {% if fase_activa == 'OOCC' %}
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-4" data-vista-torres-oc>
+        <div class="flex items-center justify-between mb-1">
+            <h2 class="font-semibold">Avance por torre — Obra Civil</h2>
+            <span class="text-sm text-gray-500">
+                <span class="font-semibold text-green-700 dark:text-green-300">{{ torres_oc_completas }}</span>
+                / {{ torres_oc_total }} torres al 100%
+            </span>
+        </div>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">
+            % ponderado de avance por torre (promedio de sus patas). Clic en una
+            torre para ver el detalle de obra civil y sus etapas pendientes.
+        </p>
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+                <thead class="bg-gray-50 dark:bg-gray-900">
+                    <tr>
+                        <th class="px-3 py-2 text-left font-semibold">Torre</th>
+                        <th class="px-3 py-2 text-right font-semibold">% Avance</th>
+                        <th class="px-3 py-2 text-center font-semibold">Estado</th>
+                        <th class="px-3 py-2 text-left font-semibold">Etapas pendientes</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                    {% for t in vista_torres_oc %}
+                    <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                        data-torre-pct="{{ t.pct }}"
+                        data-torre-completa="{% if t.completa %}true{% else %}false{% endif %}">
+                        <td class="px-3 py-2 font-medium">
+                            {% if t.url_detalle %}
+                            <a href="{{ t.url_detalle }}" class="text-blue-600 hover:underline">Torre {{ t.numero }}</a>
+                            {% else %}Torre {{ t.numero }}{% endif %}
+                        </td>
+                        <td class="px-3 py-2 text-right font-bold {% if t.completa %}text-green-600 dark:text-green-400{% else %}text-gray-700 dark:text-gray-200{% endif %}">{{ t.pct }}%</td>
+                        <td class="px-3 py-2 text-center">
+                            {% if t.completa %}<span class="inline-flex items-center px-2 py-0.5 rounded-full bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300 text-xs font-semibold">✓ Completa</span>
+                            {% else %}<span class="inline-flex items-center px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300 text-xs font-semibold">En curso</span>{% endif %}
+                        </td>
+                        <td class="px-3 py-2 text-left text-xs text-gray-600 dark:text-gray-300">{{ t.pendientes|join:", "|default:"—" }}</td>
+                    </tr>
+                    {% empty %}
+                    <tr><td colspan="4" class="px-3 py-8 text-center text-gray-500">Sin avance de obra civil registrado en las torres.</td></tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+    {% endif %}
 
     <!-- G3 · Desviación de materiales en vaciado -->
     <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-4">
@@ -269,7 +336,13 @@ function dashboardCurvaS(cfg) {
         renderTodo() {
             this.renderChart(this.chartInicial);
             if (this.mostrarGraficas141 && this.graficas141) {
-                this.renderEtapas(this.graficas141.avance_etapas || []);
+                // B1 #139: la gráfica G2 usa las 6 etapas REALES de OC
+                // (avance_etapas_oc6, con Cerramiento) cuando hay datos; si no,
+                // cae a las 5 legacy de #141.
+                var etapasG2 = (this.graficas141.avance_etapas_oc6 && this.graficas141.avance_etapas_oc6.length)
+                    ? this.graficas141.avance_etapas_oc6
+                    : (this.graficas141.avance_etapas || []);
+                this.renderEtapas(etapasG2);
                 this.renderDesviacion(this.graficas141.desviacion_materiales || []);
             }
             // Marcar listo solo tras instanciar lo que corresponde (probe E2E

--- a/templates/construccion/dashboard_general.html
+++ b/templates/construccion/dashboard_general.html
@@ -1,0 +1,211 @@
+{% extends "base.html" %}
+{% load l10n %}
+
+{% comment %}
+B5 (#139) — Dashboard GENERAL del proyecto (7 fases).
+
+Provee:
+  - Gráfica global agregando las 7 fases  -> canvas #general-fases-chart
+  - Curva S consolidada real del proyecto -> canvas #general-curva-s-chart
+  - Tarjeta del global ponderado + drill-down por fase a su dashboard.
+
+GUARDS es-CO (memorias recurrentes):
+  - El dataset viaja PRE-SERIALIZADO vía {{ general_chart_json|json_script }}
+    (string JSON), NUNCA floats crudos ni JSON crudo en JS inline. El JS lo lee
+    con JSON.parse(document.getElementById('...').textContent).
+  - Los números visibles van dentro de {% localize off %} para no emitir la coma
+    decimal es-CO en contextos que el navegador no espera.
+
+Contexto (lo provee DashboardGeneralView):
+  proyecto, fases[{seccion,label,pct,peso,drill_url,completa}], global_pct,
+  pesos_equiponderados, tiene_avance, tiene_curva_s, vista_torres_url,
+  general_chart_json (str).
+{% endcomment %}
+
+{% block title %}Dashboard General — {{ proyecto.nombre }}{% endblock %}
+
+{% block content %}
+{% localize off %}
+
+{% comment %} Dataset pre-serializado — guard es-CO. {% endcomment %}
+{{ general_chart_json|json_script:"general-chart-data" }}
+
+<div class="space-y-6 dashboard-general"
+     data-fase="GENERAL"
+     data-charts-ready="false">
+
+    {% comment %} === Header + global ponderado === {% endcomment %}
+    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div>
+            <h1 class="text-2xl font-bold text-gray-800 dark:text-gray-100">
+                Dashboard General
+            </h1>
+            <p class="text-sm text-gray-500 dark:text-gray-400">
+                {{ proyecto.nombre }} — avance consolidado de las 7 fases.
+            </p>
+        </div>
+        <div class="flex items-center gap-4">
+            <div class="text-right">
+                <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Avance global</p>
+                <p class="text-3xl font-extrabold text-blue-700 dark:text-blue-300"
+                   data-global-pct="{{ global_pct }}">{{ global_pct }}%</p>
+                {% if pesos_equiponderados %}
+                <p class="text-[11px] text-amber-600 dark:text-amber-400">
+                    Pesos equiponderados (1/7) — sin pesos definidos en el cronograma.
+                </p>
+                {% else %}
+                <p class="text-[11px] text-gray-400">Ponderado por ProgramacionFase.peso_pct</p>
+                {% endif %}
+            </div>
+            {% if vista_torres_url %}
+            <a href="{{ vista_torres_url }}"
+               class="inline-flex items-center px-3 py-2 rounded-md bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-sm font-medium text-gray-700 dark:text-gray-200">
+                Vista por torre
+            </a>
+            {% endif %}
+        </div>
+    </div>
+
+    {% if not tiene_avance %}
+    <div class="rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-900/20 dark:border-amber-800 p-4 text-sm text-amber-800 dark:text-amber-200"
+         data-estado="sin-avance">
+        Aún no hay avance registrado en ninguna fase de este proyecto. Las
+        gráficas aparecerán a medida que se registre obra civil, montaje, tendido
+        u otras fases.
+    </div>
+    {% endif %}
+
+    {% comment %} === Gráfica global de las 7 fases === {% endcomment %}
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-4">
+        <div class="flex items-center justify-between mb-1">
+            <h2 class="font-semibold">Avance por fase</h2>
+            <span class="text-xs text-gray-500 dark:text-gray-400">% de avance real de cada una de las 7 fases</span>
+        </div>
+        <div class="relative" style="height: 380px;">
+            <canvas id="general-fases-chart" width="1200" height="380"></canvas>
+        </div>
+    </div>
+
+    {% comment %} === Tarjetas por fase con drill-down === {% endcomment %}
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+        {% for f in fases %}
+        <div class="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3"
+             data-fase-seccion="{{ f.seccion }}" data-fase-pct="{{ f.pct }}">
+            <div class="flex items-center justify-between">
+                <p class="font-medium text-gray-700 dark:text-gray-200">{{ f.label }}</p>
+                {% if f.completa %}
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300 text-xs font-semibold">100%</span>
+                {% endif %}
+            </div>
+            <p class="text-2xl font-bold text-blue-700 dark:text-blue-300 mt-1">{{ f.pct }}%</p>
+            <div class="mt-1 h-2 w-full rounded bg-gray-100 dark:bg-gray-700 overflow-hidden">
+                <div class="h-2 bg-blue-500" style="width: {{ f.pct }}%;"></div>
+            </div>
+            <div class="mt-2 flex items-center justify-between text-xs">
+                <span class="text-gray-400">Peso: {{ f.peso }}%</span>
+                {% if f.drill_url %}
+                <a href="{{ f.drill_url }}"
+                   class="text-blue-600 dark:text-blue-400 hover:underline font-medium"
+                   data-drilldown="{{ f.seccion }}">Ver detalle →</a>
+                {% else %}
+                <span class="text-gray-300 dark:text-gray-600" data-drilldown-disabled="{{ f.seccion }}">Sin dashboard</span>
+                {% endif %}
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+
+    {% comment %} === Curva S consolidada real === {% endcomment %}
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-4">
+        <div class="flex items-center justify-between mb-1">
+            <h2 class="font-semibold">Curva S consolidada (real)</h2>
+            <span class="text-xs text-gray-500 dark:text-gray-400">Avance real acumulado del proyecto</span>
+        </div>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">
+            Agrega el avance real por torre de Obra Civil, Montaje y Tendido,
+            distribuido en el tiempo.
+        </p>
+        {% if tiene_curva_s %}
+        <div class="relative" style="height: 360px;">
+            <canvas id="general-curva-s-chart" width="1200" height="360"></canvas>
+        </div>
+        {% else %}
+        <p class="text-sm text-gray-400 py-8 text-center" data-estado="sin-curva">
+            Sin avance temporal aún para construir la curva consolidada.
+        </p>
+        {% endif %}
+    </div>
+
+</div>
+
+{% endlocalize %}
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+<script>
+(function () {
+    function readJSON(id) {
+        var el = document.getElementById(id);
+        if (!el) { return null; }
+        try { return JSON.parse(el.textContent); } catch (e) { return null; }
+    }
+    function render() {
+        var root = document.querySelector('.dashboard-general');
+        if (!root) { return; }
+        if (typeof Chart === 'undefined') {
+            console.warn('Chart.js todavía no cargado');
+            return;
+        }
+        var data = readJSON('general-chart-data') || {};
+        var fases = data.fases || [];
+        var curva = data.curva_s || { labels: [], ejecutado: [] };
+
+        var elFases = document.getElementById('general-fases-chart');
+        if (elFases && fases.length) {
+            new Chart(elFases.getContext('2d'), {
+                type: 'bar',
+                data: {
+                    labels: fases.map(function (f) { return f.label; }),
+                    datasets: [{
+                        label: '% avance real',
+                        data: fases.map(function (f) { return f.pct; }),
+                        backgroundColor: '#3b82f6'
+                    }]
+                },
+                options: {
+                    responsive: true, maintainAspectRatio: false,
+                    scales: { y: { beginAtZero: true, max: 100 } }
+                }
+            });
+        }
+
+        var elCurva = document.getElementById('general-curva-s-chart');
+        if (elCurva && curva.labels && curva.labels.length) {
+            new Chart(elCurva.getContext('2d'), {
+                type: 'line',
+                data: {
+                    labels: curva.labels,
+                    datasets: [{
+                        label: 'Ejecutado (real)',
+                        data: curva.ejecutado || [],
+                        borderColor: '#2563eb',
+                        tension: 0.2,
+                        fill: false
+                    }]
+                },
+                options: {
+                    responsive: true, maintainAspectRatio: false,
+                    scales: { y: { beginAtZero: true, max: 100 } }
+                }
+            });
+        }
+
+        root.setAttribute('data-charts-ready', 'true');
+    }
+    if (document.readyState === 'complete') {
+        render();
+    } else {
+        window.addEventListener('load', render);
+    }
+})();
+</script>
+{% endblock %}

--- a/templates/construccion/dashboard_montaje.html
+++ b/templates/construccion/dashboard_montaje.html
@@ -1,0 +1,186 @@
+{% extends "base.html" %}
+{% load l10n %}
+
+{% comment %}
+Dashboard de Montaje con avance REAL (#139 · B2).
+
+Reutiliza el parcial base S3 ``_dashboard_fase_base.html`` (Curva S
+#curva-s-chart + #avance-etapas-chart + vista por torre + [data-charts-ready] +
+[data-fase]) y AÑADE el canvas dedicado del scope B2 ``#montaje-etapas-chart``
+con las 4 etapas de Montaje (Estructura en sitio 10% · Prearmada 20% · Torre
+montada 45% · Revisada 25%) y el drill-down por torre a ``montaje_torre``.
+
+Contexto (lo provee DashboardMontajeRealView):
+  - proyecto, fase_codigo='MONTAJE', fase_label='Montaje'
+  - curva_real_json (str JSON: ejecutado/planeado)  ← base de avance real
+  - avance_etapas (list)  ← consumida por el parcial base y por mi chart
+  - vista_torres (list)   ← consumida por el parcial base
+  - montaje_etapas_json (str JSON)  ← dataset dedicado de #montaje-etapas-chart
+  - montaje_sin_datos (bool)
+
+GUARDS es-CO (memorias recurrentes del portafolio):
+  - Datasets vía {{ ...|json_script }} (NUNCA floats crudos ni JSON crudo en JS
+    inline / x-data). El JS los lee con JSON.parse(...textContent).
+  - {% localize off %} alrededor de cualquier número renderizado en JS.
+{% endcomment %}
+
+{% block title %}Dashboard Montaje — {{ proyecto.nombre }}{% endblock %}
+
+{% block content %}
+{% comment %} Chart.js (mismo CDN que dashboard_curva_s.html). {% endcomment %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+
+<div class="max-w-7xl mx-auto px-4 py-6 space-y-6"
+     data-dashboard="montaje" data-fase="MONTAJE">
+
+    <div class="flex items-center justify-between">
+        <div>
+            <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
+                Dashboard de Montaje
+            </h1>
+            <p class="text-sm text-gray-500 dark:text-gray-400">
+                {{ proyecto.nombre }} — avance real ponderado por torre
+            </p>
+        </div>
+        <a href="{% url 'construccion:montaje_lista' proyecto_id=proyecto.id %}"
+           class="text-sm text-blue-700 dark:text-blue-300 hover:underline">
+            Ir a la matriz de Montaje →
+        </a>
+    </div>
+
+    {% comment %} Estado vacío: proyecto sin montaje → mensaje, sin crash. {% endcomment %}
+    {% if montaje_sin_datos %}
+    <div class="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-4 text-sm text-amber-800 dark:text-amber-200"
+         data-montaje-empty="true">
+        Aún no hay registros de avance de Montaje para este proyecto. La Curva S y
+        las etapas aparecerán cuando se cargue el avance por torre.
+    </div>
+    {% endif %}
+
+    {% comment %} === Parcial base (Curva S real + etapas + vista por torre) === {% endcomment %}
+    {% include "construccion/_dashboard_fase_base.html" with fase_codigo='MONTAJE' fase_label='Montaje' %}
+
+    {% comment %}
+    === Canvas dedicado de etapas de Montaje (#montaje-etapas-chart) ===
+    Contrato del scope B2. Dataset pre-serializado (guard es-CO). El parcial base
+    ya pinta #avance-etapas-chart; este chart es el específico de Montaje con sus
+    4 etapas + pesos para el tablero gerencial.
+    {% endcomment %}
+    {{ montaje_etapas_json|json_script:"montaje-etapas-data" }}
+
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-4"
+         data-block="montaje-etapas">
+        <div class="flex items-center justify-between mb-1">
+            <h2 class="font-semibold">Etapas de Montaje</h2>
+            <span class="text-xs text-gray-500 dark:text-gray-400">
+                Estructura 10% · Prearmada 20% · Torre montada 45% · Revisada 25%
+            </span>
+        </div>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">
+            % de torres con cada etapa de Montaje completa.
+        </p>
+        <div class="relative" style="height: 320px;">
+            <canvas id="montaje-etapas-chart" width="1200" height="320"></canvas>
+        </div>
+        <div class="mt-3 grid grid-cols-2 md:grid-cols-4 gap-2 text-sm">
+            {% for e in avance_etapas %}
+            <div class="rounded border border-gray-200 dark:border-gray-700 p-2 text-center"
+                 data-montaje-etapa="{{ e.etapa }}">
+                <p class="font-medium text-gray-700 dark:text-gray-200">{{ e.label }}</p>
+                <p class="text-lg font-bold text-indigo-700 dark:text-indigo-300">{{ e.pct }}%</p>
+                <p class="text-xs text-gray-500">{{ e.completas }} / {{ e.totales }} torres</p>
+            </div>
+            {% empty %}
+            <p class="col-span-full text-center text-gray-400 text-xs py-2">
+                Sin datos de etapas de Montaje.
+            </p>
+            {% endfor %}
+        </div>
+    </div>
+
+    {% comment %}
+    === Drill-down por torre a montaje_torre ===
+    Tabla de torres de Montaje con enlace al detalle de la torre (la vista
+    por-torre del parcial base es de solo lectura; aquí agregamos el link de
+    drill-down que pide el scope B2).
+    {% endcomment %}
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-4"
+         data-block="montaje-drill">
+        <h2 class="font-semibold mb-3">Drill-down por torre</h2>
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+                <thead class="bg-gray-50 dark:bg-gray-900">
+                    <tr>
+                        <th class="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Torre</th>
+                        <th class="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">% Montaje</th>
+                        <th class="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Pendientes</th>
+                        <th class="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Detalle</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                    {% for t in vista_torres %}
+                    <tr data-montaje-torre-id="{{ t.torre_id }}" data-montaje-torre-pct="{{ t.pct }}">
+                        <td class="px-3 py-2 font-medium text-gray-700 dark:text-gray-200">{{ t.numero }}</td>
+                        <td class="px-3 py-2">{{ t.pct }}%</td>
+                        <td class="px-3 py-2 text-xs text-gray-500 dark:text-gray-400">
+                            {% if t.pendientes %}{{ t.pendientes|join:", " }}{% else %}—{% endif %}
+                        </td>
+                        <td class="px-3 py-2">
+                            <a href="{% url 'construccion:montaje_torre' proyecto_id=proyecto.id torre_id=t.torre_id %}"
+                               class="text-blue-700 dark:text-blue-300 hover:underline"
+                               data-drill-montaje="{{ t.torre_id }}">
+                                Ver torre →
+                            </a>
+                        </td>
+                    </tr>
+                    {% empty %}
+                    <tr>
+                        <td colspan="4" class="px-3 py-4 text-center text-gray-400">
+                            Sin torres con avance de Montaje.
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+(function () {
+    function readJSON(id) {
+        var el = document.getElementById(id);
+        if (!el) { return null; }
+        try { return JSON.parse(el.textContent); } catch (e) { return null; }
+    }
+    function renderMontajeEtapas() {
+        var el = document.getElementById('montaje-etapas-chart');
+        if (!el || typeof Chart === 'undefined') { return; }
+        var etapas = readJSON('montaje-etapas-data') || [];
+        if (!etapas.length) { return; }
+        new Chart(el.getContext('2d'), {
+            type: 'bar',
+            data: {
+                labels: etapas.map(function (e) { return e.label; }),
+                datasets: [{
+                    label: '% torres con etapa completa',
+                    data: etapas.map(function (e) { return e.pct; }),
+                    backgroundColor: '#6366f1'
+                }]
+            },
+            options: {
+                responsive: true, maintainAspectRatio: false,
+                scales: { y: { beginAtZero: true, max: 100 } }
+            }
+        });
+    }
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', renderMontajeEtapas);
+    } else {
+        renderMontajeEtapas();
+    }
+})();
+</script>
+{% endblock %}

--- a/templates/construccion/dashboard_tendido.html
+++ b/templates/construccion/dashboard_tendido.html
@@ -1,0 +1,199 @@
+{% extends "base.html" %}
+{% load l10n %}
+
+{% comment %}
+Dashboard de Tendido (Conductor + Fibra OPGW) — B3 (#139).
+
+Reusa el parcial base de fase (_dashboard_fase_base.html · S3) para la Curva S
+real + la vista por torre, y añade las DOS gráficas de avance por etapa propias
+de Tendido (Conductor 6 etapas + Fibra OPGW 5 etapas), que la base genérica
+(una sola gráfica) no cubre.
+
+GUARDS es-CO (memorias recurrentes del portafolio):
+  - {% localize off %} en todo el bloque (evita coma decimal localizada que
+    rompe el JS inline / el render de inputs).
+  - Datasets de las 2 gráficas PRE-SERIALIZADOS vía {{ ...|json_script }}; el JS
+    los lee con JSON.parse(textContent). NUNCA floats crudos ni JSON crudo dentro
+    de x-data / atributos HTML.
+  - Sin x-data en este template (no usamos Alpine aquí): el render es JS vanilla.
+
+Contrato de selectores (BLUEPRINT — Selectores template):
+  #tendido-conductor-chart, #tendido-fibra-chart, [data-fase], [data-charts-ready],
+  [data-torre-pct]  (los 3 últimos los aporta el parcial base + esta vista).
+
+Contexto esperado (DashboardTendidoView):
+  fase_codigo='TENDIDO', fase_label='Tendido', curva_real_json (str JSON),
+  avance_conductor / avance_fibra (list), vista_torres (list), pct_conductor,
+  pct_fibra, etapas_tendido_json (str JSON {'conductor':[...], 'fibra':[...]}).
+{% endcomment %}
+
+{% block title %}Dashboard Tendido — {{ proyecto.nombre }}{% endblock %}
+
+{% block content %}
+{% localize off %}
+<div class="space-y-6" data-dashboard="tendido">
+
+    {% comment %} Header {% endcomment %}
+    <div class="flex items-center gap-4">
+        <div class="flex-1">
+            <h1 class="text-2xl font-bold text-gray-900 dark:text-white">🔌 Dashboard Tendido</h1>
+            <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                Proyecto: <span class="font-medium">{{ proyecto.nombre }}</span>
+                · Total torres: <span class="font-medium">{{ total_torres }}</span>
+            </p>
+        </div>
+    </div>
+
+    {% comment %} Tarjetas resumen por sección — % global real de cada una. {% endcomment %}
+    <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-3 text-center">
+            <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">% Conductor (real)</p>
+            <p class="text-2xl font-bold text-blue-700 dark:text-blue-300" data-pct-conductor="{{ pct_conductor }}">{{ pct_conductor }}%</p>
+        </div>
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-3 text-center">
+            <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">% Fibra OPGW (real)</p>
+            <p class="text-2xl font-bold text-purple-700 dark:text-purple-300" data-pct-fibra="{{ pct_fibra }}">{{ pct_fibra }}%</p>
+        </div>
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-3 text-center">
+            <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">% Ejecutado total</p>
+            <p class="text-2xl font-bold text-green-700 dark:text-green-300">{{ pct_construido_total }}%</p>
+        </div>
+    </div>
+
+    {% comment %}
+    Parcial base: Curva S real (Ejecutado vs Planeado) + vista por torre.
+    Le pasamos avance_etapas vacío (la vista ya lo deja []) para que NO pinte su
+    gráfica genérica de etapas — B3 usa sus dos charts propios abajo. El parcial
+    consume curva_real_json/fase_codigo/fase_label/vista_torres del contexto y
+    marca [data-charts-ready=true] al renderizar la Curva S.
+    {% endcomment %}
+    {% include "construccion/_dashboard_fase_base.html" %}
+
+    {% comment %} === Gráfica de avance por etapa — Conductor === {% endcomment %}
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-4"
+         data-fase="TENDIDO" data-seccion="CONDUCTOR">
+        <h2 class="font-semibold mb-1">Avance por etapa — Conductor</h2>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">
+            % de torres con la etapa de conductor completa (6 etapas ponderadas).
+        </p>
+        <div class="relative" style="height: 320px;">
+            <canvas id="tendido-conductor-chart" width="1200" height="320"></canvas>
+        </div>
+        <div class="mt-3 grid grid-cols-2 md:grid-cols-6 gap-2 text-sm">
+            {% for e in avance_conductor %}
+            <div class="rounded border border-gray-200 dark:border-gray-700 p-2 text-center" data-etapa-conductor="{{ e.etapa }}">
+                <p class="font-medium text-gray-700 dark:text-gray-200">{{ e.label }}</p>
+                <p class="text-lg font-bold text-blue-700 dark:text-blue-300">{{ e.pct }}%</p>
+                <p class="text-xs text-gray-500">{{ e.completas }} / {{ e.totales }} torres</p>
+            </div>
+            {% empty %}
+            <p class="col-span-full text-center text-gray-400 text-sm">Sin datos de tendido (conductor).</p>
+            {% endfor %}
+        </div>
+    </div>
+
+    {% comment %} === Gráfica de avance por etapa — Fibra OPGW === {% endcomment %}
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-4"
+         data-fase="TENDIDO" data-seccion="FIBRA">
+        <h2 class="font-semibold mb-1">Avance por etapa — Fibra OPGW</h2>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">
+            % de torres con la etapa de fibra OPGW completa (5 etapas ponderadas).
+        </p>
+        <div class="relative" style="height: 320px;">
+            <canvas id="tendido-fibra-chart" width="1200" height="320"></canvas>
+        </div>
+        <div class="mt-3 grid grid-cols-2 md:grid-cols-5 gap-2 text-sm">
+            {% for e in avance_fibra %}
+            <div class="rounded border border-gray-200 dark:border-gray-700 p-2 text-center" data-etapa-fibra="{{ e.etapa }}">
+                <p class="font-medium text-gray-700 dark:text-gray-200">{{ e.label }}</p>
+                <p class="text-lg font-bold text-purple-700 dark:text-purple-300">{{ e.pct }}%</p>
+                <p class="text-xs text-gray-500">{{ e.completas }} / {{ e.totales }} torres</p>
+            </div>
+            {% empty %}
+            <p class="col-span-full text-center text-gray-400 text-sm">Sin datos de tendido (fibra OPGW).</p>
+            {% endfor %}
+        </div>
+    </div>
+
+    {% comment %}
+    Drill-down: enlaces por torre al detalle de tendido. El parcial base ya pinta
+    la tabla por torre (data-torre-pct / data-torre-id); aquí añadimos los enlaces
+    explícitos al detalle tendido_torre por si la torre tiene pendientes.
+    {% endcomment %}
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-4">
+        <h2 class="font-semibold mb-3">Drill-down por torre — detalle de Tendido</h2>
+        <div class="flex flex-wrap gap-2">
+            {% for t in vista_torres %}
+            <a href="{% url 'construccion:tendido_torre' proyecto_id=proyecto.id torre_id=t.torre_id %}"
+               data-drilldown-torre="{{ t.torre_id }}" data-torre-pct="{{ t.pct }}"
+               class="px-3 py-1 rounded-full border text-xs font-medium
+                      {% if t.completa %}bg-green-100 text-green-700 border-green-300 dark:bg-green-900/40 dark:text-green-300{% else %}bg-amber-50 text-amber-700 border-amber-300 dark:bg-amber-900/30 dark:text-amber-300{% endif %}">
+                Torre {{ t.numero }} · {{ t.pct }}%
+            </a>
+            {% empty %}
+            <p class="text-gray-400 text-sm">Sin torres con registro de tendido.</p>
+            {% endfor %}
+        </div>
+    </div>
+
+    {% comment %} Datasets de las 2 gráficas serializados con json_script (guard es-CO). {% endcomment %}
+    {{ etapas_tendido|json_script:"tendido-etapas-data" }}
+
+    {% comment %}
+    Chart.js (mismo CDN que dashboard_curva_s.html). JS vanilla: lee el JSON
+    pre-serializado y pinta las dos gráficas de etapa. NO toca [data-charts-ready]
+    (lo gobierna el parcial base con la Curva S — gate del E2E).
+    {% endcomment %}
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+    <script>
+    (function () {
+        function readJSON(id) {
+            var el = document.getElementById(id);
+            if (!el) { return null; }
+            try { return JSON.parse(el.textContent); } catch (e) { return null; }
+        }
+        function barChart(canvasId, etapas, color) {
+            if (typeof Chart === 'undefined') { return; }
+            var canvas = document.getElementById(canvasId);
+            if (!canvas || !canvas.getContext) { return; }
+            var ctx = canvas.getContext('2d');
+            if (!ctx) { return; }
+            new Chart(ctx, {
+                type: 'bar',
+                data: {
+                    labels: etapas.map(function (e) { return e.label; }),
+                    datasets: [{
+                        label: '% torres completas',
+                        data: etapas.map(function (e) { return e.pct; }),
+                        backgroundColor: color
+                    }]
+                },
+                options: {
+                    responsive: false, maintainAspectRatio: false,
+                    scales: { y: { beginAtZero: true, max: 100,
+                        ticks: { callback: function (v) { return v + '%'; } } } },
+                    plugins: {
+                        legend: { display: false },
+                        tooltip: { callbacks: { afterLabel: function (item) {
+                            var e = etapas[item.dataIndex] || {};
+                            return (e.completas != null) ? (e.completas + ' / ' + e.totales + ' torres') : '';
+                        } } }
+                    }
+                }
+            });
+        }
+        function renderTendido() {
+            var data = readJSON('tendido-etapas-data') || { conductor: [], fibra: [] };
+            barChart('tendido-conductor-chart', data.conductor || [], '#2563eb');
+            barChart('tendido-fibra-chart', data.fibra || [], '#9333ea');
+        }
+        if (document.readyState === 'complete') {
+            renderTendido();
+        } else {
+            window.addEventListener('load', renderTendido, { once: true });
+        }
+    })();
+    </script>
+</div>
+{% endlocalize %}
+{% endblock %}

--- a/templates/construccion/dashboard_vista_torres.html
+++ b/templates/construccion/dashboard_vista_torres.html
@@ -1,0 +1,213 @@
+{% extends "base.html" %}
+{% load l10n %}
+
+{% block title %}Vista por torre — {{ proyecto.nombre }}{% endblock %}
+
+{% block content %}
+{% comment %}
+B4 (#139) — Vista por torre CONSOLIDADA (cross-fase) + drill-down.
+
+Tabla torre × fase (Obra Civil / Montaje / Tendido) con % y estado 100%/pendiente
+por celda + un % global por torre. Cada celda con avance abre el drill-down (lo
+atrasado por torre+fase) consultando el endpoint JSON reusable.
+
+GUARDS es-CO:
+  - Todo el bloque numérico va dentro de {% localize off %} → sin coma decimal.
+  - La URL del drill-down viaja pre-serializada vía json_script (NO JS inline con
+    JSON crudo / floats crudos). El JS la lee con JSON.parse(textContent).
+  - No se usa x-data con JSON crudo (lección recurrente "algo rompe Alpine").
+{% endcomment %}
+{% localize off %}
+
+{% comment %} Config pre-serializada para el JS (guard es-CO). {% endcomment %}
+{{ drilldown_cfg|json_script:"vista-torres-cfg" }}
+
+<div class="space-y-6" data-vista-torres data-charts-ready="true">
+
+    <!-- Header -->
+    <div class="flex items-center gap-4">
+        <div class="flex-1">
+            <h1 class="text-2xl font-bold text-gray-900 dark:text-white">🗼 Vista por torre — consolidada</h1>
+            <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                Proyecto: <span class="font-medium">{{ proyecto.nombre }}</span>
+                · Total torres: <span class="font-medium">{{ total_torres }}</span>
+                · Con avance: <span class="font-medium">{{ torres_con_avance }}</span>
+            </p>
+        </div>
+    </div>
+
+    <!-- Resumen por fase: cuántas torres al 100% -->
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+        {% for rf in resumen_fases %}
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-3 text-center"
+             data-resumen-fase="{{ rf.codigo }}">
+            <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ rf.label }}</p>
+            <p class="text-2xl font-bold text-blue-700 dark:text-blue-300">{{ rf.completas }} / {{ rf.registradas }}</p>
+            <p class="text-xs text-gray-500">torres al 100%</p>
+        </div>
+        {% endfor %}
+    </div>
+
+    <!-- Tabla consolidada torre × fase -->
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-4">
+        <h2 class="font-semibold mb-3">Avance por torre y fase</h2>
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm" data-tabla-vista-torres>
+                <thead class="bg-gray-50 dark:bg-gray-900">
+                    <tr>
+                        <th class="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Torre</th>
+                        {% for f in fases %}
+                        <th class="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400" data-col-fase="{{ f.codigo }}">{{ f.label }}</th>
+                        {% endfor %}
+                        <th class="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Global</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                    {% for t in torres %}
+                    <tr data-torre-id="{{ t.torre_id }}" data-torre-global-pct="{{ t.global_pct }}">
+                        <td class="px-3 py-2 font-medium text-gray-700 dark:text-gray-200">{{ t.numero }}</td>
+                        {% for f in fases %}
+                        <td class="px-3 py-2" data-cell-fase="{{ f.codigo }}">
+                            {% comment %} Django no permite lookup dict por variable → for+if. {% endcomment %}
+                            {% for codigo, celda in t.celdas.items %}{% if codigo == f.codigo %}
+                            {% if celda.registrada %}
+                            <button type="button"
+                                    class="js-drilldown inline-flex items-center gap-2 group"
+                                    data-torre-id="{{ t.torre_id }}"
+                                    data-torre-numero="{{ t.numero }}"
+                                    data-fase="{{ f.codigo }}"
+                                    data-fase-label="{{ f.label }}">
+                                <span class="font-medium {% if celda.completa %}text-green-700 dark:text-green-300{% else %}text-amber-700 dark:text-amber-300{% endif %}"
+                                      data-cell-pct>{{ celda.pct }}%</span>
+                                {% if celda.completa %}
+                                <span class="inline-flex items-center px-2 py-0.5 rounded-full bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300 text-xs font-semibold" data-cell-estado>100%</span>
+                                {% else %}
+                                <span class="inline-flex items-center px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300 text-xs font-semibold group-hover:underline" data-cell-estado>Pendiente</span>
+                                {% endif %}
+                            </button>
+                            {% else %}
+                            <span class="text-gray-400 dark:text-gray-500 text-xs" data-cell-estado="sin-registro">— sin registro</span>
+                            {% endif %}
+                            {% endif %}{% endfor %}
+                        </td>
+                        {% endfor %}
+                        <td class="px-3 py-2">
+                            <span class="font-bold {% if t.completa_global %}text-green-700 dark:text-green-300{% else %}text-gray-700 dark:text-gray-200{% endif %}" data-cell-global>{{ t.global_pct }}%</span>
+                        </td>
+                    </tr>
+                    {% empty %}
+                    <tr><td colspan="{{ fases|length|add:'2' }}" class="px-3 py-6 text-center text-gray-400" data-empty>
+                        Sin datos de avance para ninguna torre todavía.
+                    </td></tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-3">
+            Clic en una celda con avance para ver el detalle de lo atrasado de esa torre en esa fase.
+        </p>
+    </div>
+
+    <!-- Panel drill-down (se llena vía fetch al endpoint JSON reusable) -->
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-4 hidden"
+         id="drilldown-panel" data-drilldown-panel>
+        <div class="flex items-center justify-between mb-3">
+            <h2 class="font-semibold">Detalle — lo atrasado</h2>
+            <button type="button" id="drilldown-cerrar" data-drilldown-cerrar
+                    class="text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-200">Cerrar ✕</button>
+        </div>
+        <div id="drilldown-body" data-drilldown-body>
+            <p class="text-sm text-gray-400">Seleccione una celda…</p>
+        </div>
+    </div>
+</div>
+{% endlocalize %}
+{% endblock %}
+
+{% block extra_js %}
+<script>
+(function () {
+    "use strict";
+
+    function readJSON(id) {
+        var el = document.getElementById(id);
+        if (!el) { return null; }
+        try { return JSON.parse(el.textContent); } catch (e) { return null; }
+    }
+
+    var cfg = readJSON("vista-torres-cfg") || {};
+    var drilldownUrl = cfg.drilldown_url || "";
+
+    var panel = document.getElementById("drilldown-panel");
+    var body = document.getElementById("drilldown-body");
+    var cerrar = document.getElementById("drilldown-cerrar");
+
+    function esc(s) {
+        var d = document.createElement("div");
+        d.textContent = (s === null || s === undefined) ? "" : String(s);
+        return d.innerHTML;
+    }
+
+    function renderDetalle(d) {
+        if (!d) {
+            body.innerHTML = '<p class="text-sm text-red-600">No se pudo cargar el detalle.</p>';
+            return;
+        }
+        var header = '<div class="mb-2">'
+            + '<span class="font-semibold">Torre ' + esc(d.numero) + '</span>'
+            + ' · <span class="text-gray-500">' + esc(d.fase_label) + '</span>'
+            + ' · <span class="font-medium">' + esc(d.pct) + '%</span>'
+            + '</div>';
+        var cuerpo;
+        if (!d.registrada) {
+            cuerpo = '<p class="text-sm text-gray-500" data-dd-sin-registro>Esta torre aún no tiene avance registrado en esta fase.</p>';
+        } else if (d.completa) {
+            cuerpo = '<p class="text-sm text-green-700 dark:text-green-300" data-dd-completa>Fase completa al 100%. No hay etapas atrasadas.</p>';
+        } else if (d.pendientes && d.pendientes.length) {
+            var items = d.pendientes.map(function (p) {
+                return '<li class="px-2 py-1 rounded bg-amber-50 dark:bg-amber-900/30 text-amber-800 dark:text-amber-200">' + esc(p) + '</li>';
+            }).join("");
+            cuerpo = '<p class="text-sm mb-2 text-gray-600 dark:text-gray-300">'
+                + esc(d.total_pendientes) + ' etapa(s) atrasada(s):</p>'
+                + '<ul class="space-y-1 text-sm" data-dd-pendientes>' + items + '</ul>';
+        } else {
+            cuerpo = '<p class="text-sm text-gray-500">Sin etapas atrasadas registradas.</p>';
+        }
+        body.innerHTML = header + cuerpo;
+    }
+
+    function abrirDrilldown(torreId, fase) {
+        if (!drilldownUrl) { return; }
+        body.innerHTML = '<p class="text-sm text-gray-400" data-dd-loading>Cargando…</p>';
+        panel.classList.remove("hidden");
+        var sep = drilldownUrl.indexOf("?") >= 0 ? "&" : "?";
+        var url = drilldownUrl + sep + "torre=" + encodeURIComponent(torreId)
+            + "&fase=" + encodeURIComponent(fase);
+        fetch(url, { headers: { "X-Requested-With": "XMLHttpRequest" } })
+            .then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
+            .then(function (res) {
+                if (res.ok && res.j && res.j.ok) {
+                    renderDetalle(res.j.detalle);
+                } else {
+                    var msg = (res.j && res.j.error) ? res.j.error : "Error al cargar el detalle.";
+                    body.innerHTML = '<p class="text-sm text-red-600" data-dd-error>' + esc(msg) + '</p>';
+                }
+            })
+            .catch(function () {
+                body.innerHTML = '<p class="text-sm text-red-600" data-dd-error>Error de red al cargar el detalle.</p>';
+            });
+    }
+
+    document.addEventListener("click", function (ev) {
+        var btn = ev.target.closest ? ev.target.closest(".js-drilldown") : null;
+        if (btn) {
+            abrirDrilldown(btn.getAttribute("data-torre-id"), btn.getAttribute("data-fase"));
+        }
+    });
+
+    if (cerrar) {
+        cerrar.addEventListener("click", function () { panel.classList.add("hidden"); });
+    }
+})();
+</script>
+{% endblock %}

--- a/templates/construccion/partials/_drilldown_torre.html
+++ b/templates/construccion/partials/_drilldown_torre.html
@@ -1,0 +1,56 @@
+{% load l10n %}
+{% comment %}
+B4 (#139) — Parcial drill-down: detalle de "lo atrasado" de una torre en una fase.
+
+Reusable por B1/B2/B3: cualquier dashboard de fase puede inyectar este parcial
+pegándole al endpoint ``construccion:dashboard_drilldown_torre`` con
+``?torre=<id>&fase=<OOCC|MONTAJE|TENDIDO>&format=html``.
+
+Contexto esperado:
+  - detalle : dict | None  con
+      {torre_id, numero, fase, fase_label, pct, completa, registrada,
+       pendientes:[labels], total_pendientes}
+  - error   : str (opcional) — mensaje si la consulta fue inválida.
+
+GUARDS es-CO: el bloque numérico va dentro de {% localize off %} (el % no debe
+salir con coma decimal). Sin floats crudos en JS — este parcial es HTML puro.
+{% endcomment %}
+{% localize off %}
+<div data-drilldown-torre
+     {% if detalle %}data-torre-id="{{ detalle.torre_id }}" data-fase="{{ detalle.fase }}"{% endif %}>
+    {% if error %}
+        <p class="text-sm text-red-600" data-dd-error>{{ error }}</p>
+    {% elif not detalle %}
+        <p class="text-sm text-gray-400" data-dd-vacio>Seleccione una celda para ver el detalle.</p>
+    {% else %}
+        <div class="mb-2">
+            <span class="font-semibold">Torre {{ detalle.numero }}</span>
+            · <span class="text-gray-500 dark:text-gray-400">{{ detalle.fase_label }}</span>
+            · <span class="font-medium {% if detalle.completa %}text-green-700 dark:text-green-300{% else %}text-amber-700 dark:text-amber-300{% endif %}">{{ detalle.pct }}%</span>
+        </div>
+
+        {% if not detalle.registrada %}
+            <p class="text-sm text-gray-500 dark:text-gray-400" data-dd-sin-registro>
+                Esta torre aún no tiene avance registrado en esta fase.
+            </p>
+        {% elif detalle.completa %}
+            <p class="text-sm text-green-700 dark:text-green-300" data-dd-completa>
+                Fase completa al 100%. No hay etapas atrasadas.
+            </p>
+        {% elif detalle.pendientes %}
+            <p class="text-sm mb-2 text-gray-600 dark:text-gray-300">
+                {{ detalle.total_pendientes }} etapa(s) atrasada(s):
+            </p>
+            <ul class="space-y-1 text-sm" data-dd-pendientes>
+                {% for p in detalle.pendientes %}
+                <li class="px-2 py-1 rounded bg-amber-50 dark:bg-amber-900/30 text-amber-800 dark:text-amber-200">{{ p }}</li>
+                {% endfor %}
+            </ul>
+        {% else %}
+            <p class="text-sm text-gray-500 dark:text-gray-400" data-dd-sin-pendientes>
+                Sin etapas atrasadas registradas.
+            </p>
+        {% endif %}
+    {% endif %}
+</div>
+{% endlocalize %}


### PR DESCRIPTION
## Resumen
Bloque `dashboards` (vía /modulo) — reescribe el Dashboard de Construcción para que **consuma el avance REAL** registrado por torre, no la tabla de snapshots semanales manual (que estaba vacía → todo en 0%). Cubre el issue #139 completo.

## Causa raíz resuelta
Las métricas (% ejecutado, Curva S, varianza) leían solo de `DashboardAvanceSemanal` (2 filas en prod) → 0%, ignorando los 257 `oc_detalle` / 65 montaje / 65 tendido de avance real. Ahora derivan del avance real ponderado por torre, distribuido en el tiempo (como pidió Ana Sofía: "el ejecutado se toma de lo terminado en cada torre").

## Sub-features (5)
- **B1** Backbone de cálculo real + cablear Dashboard Obra Civil (6 etapas, vista por torre, drill-down)
- **B2** Dashboard Montaje (4 etapas 10/20/45/25)
- **B3** Dashboard Tendido (Conductor + Fibra OPGW, 2 gráficas)
- **B4** Vista por torre consolidada cross-fase + drill-down
- **B5** Dashboard GENERAL del proyecto (7 fases: ingeniería→detalles finales)

## Scaffolding
`calculators_avance_real.py` (backbone puro), partición `views_dashboards*.py`, parcial base `_dashboard_fase_base.html`, migración `0027` (backfill snapshot real).

## Issues padre
Refs #139

## Tests
58 tests de dashboards verdes (B1-B5). `manage.py check` limpio, `makemigrations --check` sin drift en construccion (solo 0027). Pre-existentes no tocados: drift en app `lineas`, fails `regexp_replace` SQLite (idénticos en base).

## Smoke
F6 corre E2E post-merge: valida que la Curva S "Ejecutado" deja de ser 0% en los 3 dashboards + el general.

## NO usar Closes
Issues se asignan al validador (anasofiamc1-cpu) en F7. El validador cierra al validar.

🤖 Generado vía /modulo
