### PR TITLE
test: alinear labels del sidebar a nombres validados + quitar xfail (Refs #166)

### DIFF
--- a/templates/construccion/tendido_torre.html
+++ b/templates/construccion/tendido_torre.html
@@ -63,9 +63,11 @@
               <label class="text-xs">F.T (m)<br>{{ tiro_form.flecha_tendido_m }}</label>
               <label class="text-xs md:col-span-1">Observaciones<br>{{ tiro_form.observaciones }}</label>
               {% if tiro_form.instance.pk %}
-              {# fila guardada: el checkbox DELETE del formset (can_delete=True) va
-                 OCULTO; el botón rojo lo togglea y atenúa la fila SIN sacarla del DOM
-                 (para que el inlineformset la procese como borrada al guardar). #}
+              {% comment %}
+                fila guardada: el checkbox DELETE del formset (can_delete=True) va
+                OCULTO; el botón rojo lo togglea y atenúa la fila SIN sacarla del DOM
+                (para que el inlineformset la procese como borrada al guardar).
+              {% endcomment %}
               <span class="hidden" data-tiro-delete-saved>{{ tiro_form.DELETE }}</span>
               <button type="button" data-remove-tiro
                       class="text-xs text-red-600 hover:text-red-800 justify-self-start"

--- a/tests/unit/test_sidebar_modulos.py
+++ b/tests/unit/test_sidebar_modulos.py
@@ -38,9 +38,12 @@ SIDEBAR_NUEVOS_MODULOS = [
     ("construccion:dashboard_montaje", "Dashboard Montaje"),
     ("construccion:spt_pintura", "SPT y Pintura"),
     ("construccion:tendido_lista", "CANT Tendido"),
-    ("construccion:trinchos_cunetas", "Trinchos y Cunetas"),
+    # #149 renombró el display de "Trinchos y Cunetas" → "Obras de Protección"
+    # (validado por el cliente); el url_name `trinchos_cunetas` se conserva.
+    ("construccion:trinchos_cunetas", "Obras de Protección"),
     ("construccion:actividades_finales", "Actividades Finales"),
-    ("construccion:indicadores_financieros", "Indicadores Financieros"),
+    # El display del dashboard B3 es "Indicadores en General" (slug indicadores-financieros).
+    ("construccion:indicadores_financieros", "Indicadores en General"),
 ]
 
 
@@ -93,7 +96,6 @@ class TestPlaceholdersResponden200:
 class TestSidebarTemplateRendering:
     """Issue #73: el sidebar muestra los 9 items con sus labels visibles."""
 
-    @pytest.mark.xfail(reason="Trinchos y Cunetas (#80) no surfaceado en el sidebar; gap UI a decidir, tracking #166", strict=False)
     def test_sidebar_contiene_9_modulos_nuevos(self, admin_client, proyecto_construccion):
         # Cualquier vista que use base.html renderiza el sidebar.
         url = reverse(


### PR DESCRIPTION
## Qué
`test_sidebar_contiene_9_modulos_nuevos` estaba en `xfail` (issue #166, destapado por el gate CI de blindaje DEV-25). Esperaba labels viejos que la UI ya renombró:

| Test esperaba | Sidebar muestra (validado por cliente) |
|---|---|
| "Trinchos y Cunetas" | **"Obras de Protección"** (#149) |
| "Indicadores Financieros" | **"Indicadores en General"** |

## Decisión
El módulo SÍ está en el sidebar; el **test estaba stale**. Se alinean los 2 labels a los nombres que el cliente validó en #149 y se quita el `xfail`. **No se toca la UI** (no se revierte el rename validado). `trinchos_cunetas` y `obras-proteccion` son el mismo módulo (la URL conserva `name='trinchos_cunetas'`).

Refs #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)