### PR TITLE
feat: Presupuesto Detallado bi-modal — vista matriz 12 meses + filtro mes (Refs #120)

### DIFF
--- a/apps/construccion/tests_a3_fin_bimodal.py
+++ b/apps/construccion/tests_a3_fin_bimodal.py
@@ -1,0 +1,152 @@
+"""A3 (#120) — UI Construcción: espejo bi-modal (matriz 12 meses + filtro mes).
+
+``PresupuestoPlaneadoConstruccionView`` debe exponer el MISMO contrato bi-modal
+que el lado Mantenimiento (A2), alimentando el partial COMPARTIDO
+``financiero/_presupuesto_bimodal_tabla.html``. Cubre:
+
+- happy: con datos finv2_bd bucketeados, ?vista=matriz renderiza la matriz +
+  contenedor [data-vista='matriz'] + meses fiscales.
+- filtro mes: ?vista=mes&mes=julio → contenedor [data-vista='mes'] + mes_sel.
+- edge: ?vista=xxx → 'matriz'; ?mes=nofiscal → primer mes fiscal.
+- empty state: presupuesto sin finv2_bd → tiene_datos_bd False (empty).
+- contexto: matrix_rows con 12 valores/fila + totales_columna de 12.
+
+Mismo estilo que tests_b4_fin_views.py (TestCase + superuser que pasa
+RoleRequiredMixin + SubModuloRequiredMixin). Archivo por-issue (flat, no toca
+el tests.py compartido).
+"""
+import uuid
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from apps.contratos.models import Contrato
+from apps.construccion.models import ProyectoConstruccion
+from apps.construccion.models_fin import PresupuestoDetalladoConstruccion
+from apps.financiero.importers_finv2 import MESES_FISCALES_KEYS
+
+User = get_user_model()
+
+
+def _datos_con_meses():
+    return {
+        'finv2_bd': {
+            'rubros': {
+                'Ingresos Operacionales': {
+                    'total': -175.0,
+                    'meses': {'julio': -100.0, 'agosto': -50.0, 'enero': -25.0},
+                    'cuentas': [],
+                },
+                'Personal': {
+                    'total': 300.0,
+                    'meses': {'septiembre': 200.0, 'marzo': 100.0},
+                    'cuentas': [],
+                },
+            },
+            'total': 125.0,
+            'cuentas_count': 2,
+            'cuentas_no_mapeadas': [],
+            'filas_sin_mes': 0,
+        }
+    }
+
+
+class TestA3FinBimodalConstruccion(TestCase):
+    ANIO = 2026
+
+    def setUp(self):
+        contrato = Contrato.objects.create(
+            codigo=f"CONS-{uuid.uuid4().hex[:10]}",
+            nombre='Contrato test A3 #120',
+            unidad_negocio='CONSTRUCCION',
+        )
+        self.proyecto = ProyectoConstruccion.objects.create(
+            contrato=contrato, nombre='Proyecto A3 bi-modal',
+        )
+        try:
+            self.user = User.objects.create_superuser(
+                username='qa_a3', email='qa_a3@instelec.com', password='x',
+            )
+        except TypeError:
+            self.user = User(is_superuser=True, is_staff=True)
+            if hasattr(self.user, 'email'):
+                self.user.email = 'qa_a3@instelec.com'
+            self.user.set_password('x')
+            self.user.save()
+        self.client = Client()
+        self.client.force_login(self.user)
+
+    def _url(self):
+        return reverse('construccion:fin_presupuesto_planeado',
+                       kwargs={'proyecto_id': self.proyecto.id})
+
+    def _crear_presupuesto(self, datos):
+        return PresupuestoDetalladoConstruccion.objects.create(
+            proyecto=self.proyecto, anio=self.ANIO,
+            tipo=PresupuestoDetalladoConstruccion.Tipo.PLANEADO, datos=datos,
+        )
+
+    # ----- happy --------------------------------------------------------- #
+    def test_a3_happy_matriz_render(self):
+        self._crear_presupuesto(_datos_con_meses())
+        resp = self.client.get(f'{self._url()}?anio={self.ANIO}&vista=matriz')
+        self.assertEqual(resp.status_code, 200)
+        html = resp.content.decode()
+        self.assertIn('data-vista="matriz"', html)
+        self.assertIn('Julio', html)
+        self.assertIn('Junio', html)
+        self.assertIn('Ingresos Operacionales', html)
+        self.assertEqual(resp.context['vista'], 'matriz')
+
+    def test_a3_filtro_mes_render(self):
+        self._crear_presupuesto(_datos_con_meses())
+        resp = self.client.get(
+            f'{self._url()}?anio={self.ANIO}&vista=mes&mes=julio')
+        self.assertEqual(resp.status_code, 200)
+        html = resp.content.decode()
+        self.assertIn('data-vista="mes"', html)
+        self.assertEqual(resp.context['mes_sel'], 'julio')
+        self.assertTrue(any(r['rubro'] == 'Ingresos Operacionales'
+                            for r in resp.context['mes_rows']))
+
+    # ----- edge ---------------------------------------------------------- #
+    def test_a3_edge_vista_invalida_cae_a_matriz(self):
+        self._crear_presupuesto(_datos_con_meses())
+        resp = self.client.get(f'{self._url()}?anio={self.ANIO}&vista=zzz')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.context['vista'], 'matriz')
+
+    def test_a3_edge_mes_invalido_cae_a_primer_mes(self):
+        self._crear_presupuesto(_datos_con_meses())
+        resp = self.client.get(
+            f'{self._url()}?anio={self.ANIO}&vista=mes&mes=nofiscal')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.context['mes_sel'], MESES_FISCALES_KEYS[0])
+
+    # ----- empty --------------------------------------------------------- #
+    def test_a3_empty_sin_finv2_bd(self):
+        """Presupuesto sin finv2_bd → tiene_datos_bd False (empty del partial)."""
+        self._crear_presupuesto({'ingreso': {'enero': 100}})
+        resp = self.client.get(f'{self._url()}?anio={self.ANIO}&vista=matriz')
+        self.assertEqual(resp.status_code, 200)
+        self.assertFalse(resp.context['tiene_datos_bd'])
+        self.assertEqual(resp.context['matrix_rows'], [])
+
+    # ----- contexto ------------------------------------------------------ #
+    def test_a3_contexto_matrix_coherente(self):
+        self._crear_presupuesto(_datos_con_meses())
+        resp = self.client.get(f'{self._url()}?anio={self.ANIO}&vista=matriz')
+        ctx = resp.context
+        self.assertEqual(len(ctx['meses_fiscales']), 12)
+        self.assertEqual(len(ctx['totales_columna']), 12)
+        for fila in ctx['matrix_rows']:
+            self.assertEqual(len(fila['meses']), 12)
+        idx_julio = MESES_FISCALES_KEYS.index('julio')
+        self.assertEqual(ctx['totales_columna'][idx_julio], -100.0)
+
+    def test_a3_proyecto_inexistente_404(self):
+        url = reverse('construccion:fin_presupuesto_planeado',
+                      kwargs={'proyecto_id': uuid.uuid4()})
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 404)

--- a/apps/construccion/views_fin.py
+++ b/apps/construccion/views_fin.py
@@ -53,7 +53,12 @@ from .importers import (
     PresupuestoConstruccionExcelImporter,
     detect_excel_format_construccion,
 )
-from apps.financiero.importers_finv2 import build_rubro_display_rows
+from apps.financiero.importers_finv2 import (
+    MESES_FISCALES_KEYS,
+    build_mes_filter_rows,
+    build_rubro_display_rows,
+    build_rubro_matrix_rows,
+)
 
 
 # Roles administrativos con acceso al financiero (espejo de views.py::ALL_ADMIN_ROLES).
@@ -179,6 +184,47 @@ class ProyectoFinMixin(LoginRequiredMixin, RoleRequiredMixin, SubModuloRequiredM
             'utilidad_pct': utilidad_pct.quantize(Decimal('0.01')),
         }
 
+    # ----- A3 (#120): contexto bi-modal (matriz / filtro mes) ------------
+    def _bimodal_context(self, datos):
+        """Mismo contrato que el lado Mantenimiento (#120 A2).
+
+        Alimenta el partial COMPARTIDO
+        ``financiero/_presupuesto_bimodal_tabla.html`` con la matriz rubro × 12
+        meses (julio→junio) y el filtro por mes, leyendo ``?vista=`` y ``?mes=``.
+        """
+        vista = self.request.GET.get('vista', 'matriz')
+        if vista not in ('matriz', 'mes'):
+            vista = 'matriz'
+
+        matrix_rows, totales_columna, meses_fiscales, total_general = (
+            build_rubro_matrix_rows(datos)
+        )
+
+        mes_sel = self.request.GET.get('mes') or MESES_FISCALES_KEYS[0]
+        if mes_sel not in MESES_FISCALES_KEYS:
+            mes_sel = MESES_FISCALES_KEYS[0]
+        mes_rows, mes_total, mes_label = build_mes_filter_rows(datos, mes_sel)
+
+        hidden = {
+            k: v for k, v in self.request.GET.items()
+            if k not in ('vista', 'mes') and v
+        }
+        base_qs = ''.join(f'{k}={v}&' for k, v in hidden.items())
+
+        return {
+            'vista': vista,
+            'matrix_rows': matrix_rows,
+            'totales_columna': totales_columna,
+            'meses_fiscales': meses_fiscales,
+            'matrix_total': total_general,
+            'mes_sel': mes_sel,
+            'mes_rows': mes_rows,
+            'mes_total': mes_total,
+            'mes_label': mes_label,
+            'bimodal_base_qs': base_qs,
+            'bimodal_hidden_params': hidden,
+        }
+
     @staticmethod
     def _sumar_seccion(datos, keys):
         """Suma todos los valores numéricos de la primera key presente en ``datos``.
@@ -291,6 +337,9 @@ class PresupuestoPlaneadoConstruccionView(ProyectoFinMixin, TemplateView):
         ctx['rubro_rows'] = rubro_rows
         ctx['rubro_total'] = rubro_total
         ctx['tiene_datos_bd'] = bool(rubro_rows)
+        # A3 (#120): vista bi-modal (matriz 12 meses + filtro mes), espejo de
+        # Mantenimiento, reusando el partial compartido.
+        ctx.update(self._bimodal_context(ctx['datos']))
         return ctx
 
     def post(self, request, *args, **kwargs):

--- a/apps/financiero/importers_finv2.py
+++ b/apps/financiero/importers_finv2.py
@@ -15,7 +15,19 @@ en las otras llaves del mismo JSONField).
 Reusa el patrón de detección de columnas y lectura openpyxl de
 ``apps.financiero.importers`` (``_normalize_name`` / ``load_workbook
 read_only``).
+
+A1 (#120) — Bucketing mensual
+-----------------------------
+Además del total anual por cuenta/rubro, el importer acumula el ``Neto`` por
+**mes fiscal** (orden julio→junio, ``MESES_FISCALES``) leyendo la columna D
+``Fecha`` (con fallback a la columna F ``Periodo`` YYYYMM). Las filas sin fecha
+reconocible caen en el bucket ``sin_mes``: cuentan en el total ANUAL pero NO en
+ninguna columna de la matriz mensual. ``build_rubro_matrix_rows`` arma la matriz
+rubro × 12 meses + totales por columna; ``build_rubro_display_rows`` conserva la
+vista plana (fallback). La paridad ``sum(meses) + sin_mes == total`` la garantiza
+el acumulado por fila (un test la verifica).
 """
+import datetime
 import unicodedata
 
 from openpyxl import load_workbook
@@ -36,6 +48,39 @@ _BD_SHEET_NAMES = ('bd', 'base de datos', 'base datos')
 _HEADER_CTA = 'cta equivalente'   # columna O
 _HEADER_NETO = 'neto'             # columna C
 _HEADER_DESC = 'desc auxiliar'    # columna B
+_HEADER_FECHA = 'fecha'           # columna D
+_HEADER_PERIODO = 'periodo'       # columna F (YYYYMM)
+
+
+# --------------------------------------------------------------------------- #
+# Año fiscal — orden julio → junio (oráculo: hoja 'Presupuesto' del xlsx #120)
+# --------------------------------------------------------------------------- #
+# Cada item: (key estable, etiqueta humana, número de mes calendario 1..12).
+# El orden de la lista ES el orden de columnas de la matriz (12 meses).
+MESES_FISCALES = [
+    ('julio', 'Julio', 7),
+    ('agosto', 'Agosto', 8),
+    ('septiembre', 'Septiembre', 9),
+    ('octubre', 'Octubre', 10),
+    ('noviembre', 'Noviembre', 11),
+    ('diciembre', 'Diciembre', 12),
+    ('enero', 'Enero', 1),
+    ('febrero', 'Febrero', 2),
+    ('marzo', 'Marzo', 3),
+    ('abril', 'Abril', 4),
+    ('mayo', 'Mayo', 5),
+    ('junio', 'Junio', 6),
+]
+
+# Llaves fiscales en orden (julio..junio) — usado para iterar buckets.
+MESES_FISCALES_KEYS = [m[0] for m in MESES_FISCALES]
+
+# {numero_mes_calendario: key_fiscal}, p.ej. {7: 'julio', 1: 'enero'}.
+_MES_NUM_A_KEY = {num: key for key, _label, num in MESES_FISCALES}
+
+# Bucket para filas sin fecha reconocible — entra solo en el total ANUAL,
+# nunca en una columna mensual de la matriz (requerimiento #120).
+SIN_MES_KEY = 'sin_mes'
 
 
 def _norm(value) -> str:
@@ -58,6 +103,44 @@ def _to_number(value):
         return float(value)
     except (ValueError, TypeError):
         return 0.0
+
+
+def _mes_fiscal_de(fecha_val, periodo_val):
+    """Determina la key fiscal (julio..junio) de una fila.
+
+    Prioridad: columna D ``Fecha`` (datetime/date) → fallback columna F
+    ``Periodo`` (YYYYMM). Si ninguna es interpretable, devuelve ``None``
+    (la fila cuenta solo en el total anual, bucket ``sin_mes``).
+    """
+    # 1) Fecha (col D): datetime/date directo.
+    if isinstance(fecha_val, (datetime.datetime, datetime.date)):
+        return _MES_NUM_A_KEY.get(fecha_val.month)
+
+    # 1b) Fecha como string (algunos export traen texto): intentar parsear.
+    if isinstance(fecha_val, str):
+        s = fecha_val.strip()
+        for fmt in ('%Y-%m-%d', '%d/%m/%Y', '%d-%m-%Y', '%Y/%m/%d'):
+            try:
+                d = datetime.datetime.strptime(s[:10], fmt)
+                return _MES_NUM_A_KEY.get(d.month)
+            except (ValueError, TypeError):
+                continue
+
+    # 2) Fallback: Periodo YYYYMM (col F). Puede venir como int o str.
+    if periodo_val is not None:
+        p = str(periodo_val).strip()
+        # Aceptar formas tipo "202407" o "202407.0".
+        if '.' in p:
+            p = p.split('.', 1)[0]
+        digits = ''.join(ch for ch in p if ch.isdigit())
+        if len(digits) >= 6:
+            try:
+                mes_num = int(digits[4:6])
+                if 1 <= mes_num <= 12:
+                    return _MES_NUM_A_KEY.get(mes_num)
+            except (ValueError, TypeError):
+                pass
+    return None
 
 
 class ContableCompleteImporter:
@@ -104,10 +187,10 @@ class ContableCompleteImporter:
         return None
 
     def _locate_columns(self, sheet):
-        """Detecta los índices (1-based) de las columnas O, C y B por encabezado.
+        """Detecta los índices (1-based) de las columnas O, C, B, D y F.
 
         Si no encuentra por nombre, cae a los índices fijos del layout #120
-        (C=3, B=2, O=15).
+        (C=3, B=2, D=4, F=6, O=15).
         """
         headers = {}
         for col in range(1, 30):
@@ -118,6 +201,8 @@ class ContableCompleteImporter:
         cta_col = headers.get(_HEADER_CTA)
         neto_col = headers.get(_HEADER_NETO)
         desc_col = headers.get(_HEADER_DESC) or headers.get('descripcion')
+        fecha_col = headers.get(_HEADER_FECHA)
+        periodo_col = headers.get(_HEADER_PERIODO)
 
         # Fallback a índices fijos del layout documentado en #120.
         if not cta_col:
@@ -126,8 +211,12 @@ class ContableCompleteImporter:
             neto_col = 3   # C
         if not desc_col:
             desc_col = 2   # B
+        if not fecha_col:
+            fecha_col = 4  # D
+        if not periodo_col:
+            periodo_col = 6  # F
 
-        return cta_col, neto_col, desc_col
+        return cta_col, neto_col, desc_col, fecha_col, periodo_col
 
     # ------------------------------------------------------------------ #
     # Entry point
@@ -177,7 +266,8 @@ class ContableCompleteImporter:
                 f"No se encontró hoja 'BD'; usando hoja activa '{sheet.title}'."
             )
 
-        cta_col, neto_col, desc_col = self._locate_columns(sheet)
+        cta_col, neto_col, desc_col, fecha_col, periodo_col = \
+            self._locate_columns(sheet)
 
         # --- Edge case 2: columna O (Cta equivalente) ausente / vacía ---
         # Validamos leyendo el encabezado real de la columna detectada.
@@ -191,16 +281,21 @@ class ContableCompleteImporter:
 
         mapeo_tabla = self._build_mapeo(mapeo)
 
-        # --- Agrupación por cuenta equivalente (col O) sumando Neto (col C) ---
-        # grupos[cta] = {'descripcion': str, 'total': float}
+        # --- Agrupación por cuenta equivalente (col O) sumando Neto (col C),
+        #     bucketeada por mes fiscal (col D Fecha / fallback col F Periodo) ---
+        # grupos[cta] = {'descripcion': str, 'total': float,
+        #                'meses': {key_fiscal|sin_mes: float}}
         grupos = {}
         filas_validas = 0
-        max_col = max(cta_col, neto_col, desc_col)
+        filas_sin_mes = 0
+        max_col = max(cta_col, neto_col, desc_col, fecha_col, periodo_col)
 
         for row in sheet.iter_rows(min_row=2, max_col=max_col, values_only=True):
             cta_val = row[cta_col - 1] if len(row) >= cta_col else None
             neto_val = row[neto_col - 1] if len(row) >= neto_col else None
             desc_val = row[desc_col - 1] if len(row) >= desc_col else None
+            fecha_val = row[fecha_col - 1] if len(row) >= fecha_col else None
+            periodo_val = row[periodo_col - 1] if len(row) >= periodo_col else None
 
             # Validar que la fila tenga O, C, B (requerimiento #120 paso 1).
             if cta_val is None or neto_val is None:
@@ -212,10 +307,16 @@ class ContableCompleteImporter:
             neto = _to_number(neto_val)
             filas_validas += 1
 
+            mes_key = _mes_fiscal_de(fecha_val, periodo_val)
+            if mes_key is None:
+                mes_key = SIN_MES_KEY
+                filas_sin_mes += 1
+
             grupo = grupos.setdefault(
-                cta_str, {'descripcion': '', 'total': 0.0}
+                cta_str, {'descripcion': '', 'total': 0.0, 'meses': {}}
             )
             grupo['total'] += neto
+            grupo['meses'][mes_key] = grupo['meses'].get(mes_key, 0.0) + neto
             if not grupo['descripcion'] and desc_val:
                 grupo['descripcion'] = str(desc_val).strip()
 
@@ -229,24 +330,35 @@ class ContableCompleteImporter:
             )
 
         # --- Mapeo cuenta → rubro y construcción de la estructura datos ---
-        rubros = {}  # rubro -> {'total': float, 'cuentas': [ {...} ]}
+        # rubro -> {'total': float, 'meses': {key: float}, 'cuentas': [ {...} ]}
+        rubros = {}
         no_mapeadas = []
+
+        def _round_meses(meses):
+            """Redondea cada bucket mensual a 2 decimales (incluye sin_mes)."""
+            return {k: round(v, 2) for k, v in meses.items()}
 
         for cta, info in sorted(grupos.items()):
             rubro = self._rubro_para(cta, mapeo_tabla)
             if rubro == RUBRO_NO_CLASIFICADO:
                 no_mapeadas.append(cta)
-            destino = rubros.setdefault(rubro, {'total': 0.0, 'cuentas': []})
+            destino = rubros.setdefault(
+                rubro, {'total': 0.0, 'meses': {}, 'cuentas': []}
+            )
             destino['total'] += info['total']
+            for mk, mv in info['meses'].items():
+                destino['meses'][mk] = destino['meses'].get(mk, 0.0) + mv
             destino['cuentas'].append({
                 'cta_equivalente': cta,
                 'descripcion': info['descripcion'],
                 'total': round(info['total'], 2),
+                'meses': _round_meses(info['meses']),
             })
 
         total_general = round(sum(r['total'] for r in rubros.values()), 2)
         for r in rubros.values():
             r['total'] = round(r['total'], 2)
+            r['meses'] = _round_meses(r['meses'])
 
         datos = {
             'finv2_bd': {
@@ -254,6 +366,7 @@ class ContableCompleteImporter:
                 'total': total_general,
                 'cuentas_count': len(grupos),
                 'cuentas_no_mapeadas': no_mapeadas,
+                'filas_sin_mes': filas_sin_mes,
             }
         }
 
@@ -265,6 +378,11 @@ class ContableCompleteImporter:
             self.warnings.append(
                 f'{len(no_mapeadas)} cuentas sin mapeo se agruparon en '
                 f'"{RUBRO_NO_CLASIFICADO}".'
+            )
+        if filas_sin_mes:
+            self.warnings.append(
+                f'{filas_sin_mes} movimientos sin fecha reconocible (col D / '
+                f'col F) cuentan solo en el total anual, no en la matriz mensual.'
             )
 
         return {
@@ -321,3 +439,81 @@ def build_rubro_display_rows(datos):
             'cuentas': info.get('cuentas', []),
         })
     return rows, total_general
+
+
+def build_rubro_matrix_rows(datos):
+    """Construye la matriz rubro × 12 meses fiscales desde ``datos['finv2_bd']``.
+
+    Devuelve ``(rows, totales_columna, meses_fiscales, total_general)`` donde:
+
+    - ``rows``: lista de filas, una por rubro (orden desc por total), cada una::
+
+          {'rubro': str,
+           'meses': [float, ...],        # 12 valores, orden julio..junio
+           'total': float,               # total ANUAL del rubro (incl. sin_mes)
+           'pct': float}
+
+    - ``totales_columna``: lista de 12 floats (suma por columna mensual).
+    - ``meses_fiscales``: ``MESES_FISCALES`` (para render del encabezado).
+    - ``total_general``: total anual de todos los rubros.
+
+    Tolerante a datos vacíos / legacy sin la llave ``finv2_bd`` (→ filas vacías)
+    y a rubros legacy sin la sub-llave ``meses`` (→ matriz de ceros, el total
+    anual se respeta). Las filas con bucket ``sin_mes`` NO aparecen en ninguna
+    columna mensual pero SÍ suman al total anual (paridad la valida el test).
+    """
+    bloque = (datos or {}).get('finv2_bd') or {}
+    rubros = bloque.get('rubros') or {}
+    total_general = bloque.get('total') or 0.0
+
+    rows = []
+    totales_columna = [0.0] * len(MESES_FISCALES_KEYS)
+
+    for rubro, info in sorted(
+        rubros.items(), key=lambda kv: kv[1].get('total', 0), reverse=True
+    ):
+        meses_dict = info.get('meses') or {}
+        fila_meses = []
+        for i, key in enumerate(MESES_FISCALES_KEYS):
+            valor = round(meses_dict.get(key, 0.0) or 0.0, 2)
+            fila_meses.append(valor)
+            totales_columna[i] += valor
+
+        rubro_total = info.get('total', 0.0)
+        pct = (rubro_total / total_general * 100) if total_general else 0.0
+        rows.append({
+            'rubro': rubro,
+            'meses': fila_meses,
+            'total': rubro_total,
+            'pct': round(pct, 1),
+        })
+
+    totales_columna = [round(v, 2) for v in totales_columna]
+    return rows, totales_columna, MESES_FISCALES, total_general
+
+
+def build_mes_filter_rows(datos, mes_key):
+    """Filas de un único mes fiscal (vista 'Filtro Mes').
+
+    Devuelve ``(rows, total_mes, mes_label)``: una fila por rubro con su valor
+    en ``mes_key`` (orden desc), excluyendo rubros con 0 en ese mes. Si
+    ``mes_key`` no es un mes fiscal válido, devuelve ``([], 0.0, '')``.
+    """
+    label = next((lbl for k, lbl, _n in MESES_FISCALES if k == mes_key), '')
+    if not label:
+        return [], 0.0, ''
+
+    bloque = (datos or {}).get('finv2_bd') or {}
+    rubros = bloque.get('rubros') or {}
+
+    rows = []
+    total_mes = 0.0
+    for rubro, info in rubros.items():
+        valor = round((info.get('meses') or {}).get(mes_key, 0.0) or 0.0, 2)
+        if valor == 0.0:
+            continue
+        rows.append({'rubro': rubro, 'total': valor})
+        total_mes += valor
+
+    rows.sort(key=lambda r: r['total'], reverse=True)
+    return rows, round(total_mes, 2), label

--- a/apps/financiero/tests/test_a2_ui_mantenimiento.py
+++ b/apps/financiero/tests/test_a2_ui_mantenimiento.py
@@ -1,0 +1,139 @@
+"""A2 (#120) — UI Mantenimiento: vista bi-modal (matriz 12 meses + filtro mes).
+
+Verifica la vista ``PresupuestoPlaneadoViewV2`` y el partial compartido
+``_presupuesto_bimodal_tabla.html`` (también usado por Construcción en A3):
+
+- happy: con datos contables bucketeados, ?vista=matriz renderiza la matriz
+  rubro × 12 meses (encabezados julio..junio, contenedor [data-vista='matriz']).
+- filtro mes: ?vista=mes&mes=julio renderiza el contenedor [data-vista='mes'] +
+  el mes seleccionado en el select.
+- edge (param inválido): ?vista=xxx cae a 'matriz'; ?mes=nofiscal cae a julio.
+- empty state: sin datos contables → mensaje "Aún no hay datos contables".
+- contexto: la view expone matrix_rows/meses_fiscales/mes_sel/vista coherentes.
+
+Corre bajo dev_lite (spatialite). El partial reusa Alpine, no toca JS aparte.
+"""
+import pytest
+from django.urls import reverse
+
+from apps.financiero.importers_finv2 import MESES_FISCALES_KEYS
+from apps.financiero.models import PresupuestoDetallado
+
+
+def _datos_con_meses():
+    """Estructura finv2_bd con buckets mensuales (como la deja A1)."""
+    return {
+        'finv2_bd': {
+            'rubros': {
+                'Ingresos Operacionales': {
+                    'total': -175.0,
+                    'meses': {'julio': -100.0, 'agosto': -50.0, 'enero': -25.0},
+                    'cuentas': [],
+                },
+                'Personal': {
+                    'total': 300.0,
+                    'meses': {'septiembre': 200.0, 'marzo': 100.0},
+                    'cuentas': [],
+                },
+            },
+            'total': 125.0,
+            'cuentas_count': 2,
+            'cuentas_no_mapeadas': [],
+            'filas_sin_mes': 0,
+        }
+    }
+
+
+def _crear_presupuesto(anio, datos):
+    return PresupuestoDetallado.objects.create(
+        anio=anio, tipo='PLANEADO', contrato=None, datos=datos,
+    )
+
+
+@pytest.mark.django_db
+class TestA2UIMantenimiento:
+
+    def test_a2_happy_matriz_12_meses_render(self, client, admin_user):
+        """?vista=matriz: render con contenedor matriz + encabezados fiscales."""
+        client.force_login(admin_user)
+        _crear_presupuesto(2026, _datos_con_meses())
+        url = reverse('financiero:cargar_bd_contable')
+        resp = client.get(f'{url}?anio=2026&tab=planeado&vista=matriz')
+        assert resp.status_code == 200
+        html = resp.content.decode()
+        assert "data-vista=\"matriz\"" in html
+        # Encabezados de los 12 meses fiscales (julio primero, junio último).
+        assert 'Julio' in html and 'Junio' in html
+        assert 'Ingresos Operacionales' in html
+        # La columna TOTAL existe.
+        assert 'TOTAL' in html
+
+    def test_a2_filtro_mes_render(self, client, admin_user):
+        """?vista=mes&mes=julio: render del contenedor de filtro mes."""
+        client.force_login(admin_user)
+        _crear_presupuesto(2026, _datos_con_meses())
+        url = reverse('financiero:cargar_bd_contable')
+        resp = client.get(f'{url}?anio=2026&tab=planeado&vista=mes&mes=julio')
+        assert resp.status_code == 200
+        html = resp.content.decode()
+        assert "data-vista=\"mes\"" in html
+        assert resp.context['vista'] == 'mes'
+        assert resp.context['mes_sel'] == 'julio'
+        # Solo Ingresos Operacionales tuvo movimiento en julio.
+        assert any(r['rubro'] == 'Ingresos Operacionales'
+                   for r in resp.context['mes_rows'])
+
+    def test_a2_edge_vista_invalida_cae_a_matriz(self, client, admin_user):
+        """?vista=xxx (no válida) → la view normaliza a 'matriz'."""
+        client.force_login(admin_user)
+        _crear_presupuesto(2026, _datos_con_meses())
+        url = reverse('financiero:cargar_bd_contable')
+        resp = client.get(f'{url}?anio=2026&tab=planeado&vista=xxx')
+        assert resp.status_code == 200
+        assert resp.context['vista'] == 'matriz'
+
+    def test_a2_edge_mes_invalido_cae_a_primer_mes_fiscal(self, client, admin_user):
+        """?mes=nofiscal → la view cae al primer mes fiscal (julio)."""
+        client.force_login(admin_user)
+        _crear_presupuesto(2026, _datos_con_meses())
+        url = reverse('financiero:cargar_bd_contable')
+        resp = client.get(f'{url}?anio=2026&tab=planeado&vista=mes&mes=nofiscal')
+        assert resp.status_code == 200
+        assert resp.context['mes_sel'] == MESES_FISCALES_KEYS[0]
+
+    def test_a2_empty_state_sin_datos(self, client, admin_user):
+        """Sin presupuesto cargado → empty state, sin matriz."""
+        client.force_login(admin_user)
+        url = reverse('financiero:cargar_bd_contable')
+        resp = client.get(f'{url}?anio=2099&tab=planeado&vista=matriz')
+        assert resp.status_code == 200
+        assert resp.context['tiene_datos_bd'] is False
+        html = resp.content.decode()
+        assert 'Aún no hay datos contables' in html
+
+    def test_a2_contexto_matrix_rows_coherente(self, client, admin_user):
+        """La view expone matrix_rows con 12 valores por fila + totales_columna."""
+        client.force_login(admin_user)
+        _crear_presupuesto(2026, _datos_con_meses())
+        url = reverse('financiero:cargar_bd_contable')
+        resp = client.get(f'{url}?anio=2026&tab=planeado&vista=matriz')
+        ctx = resp.context
+        assert len(ctx['meses_fiscales']) == 12
+        assert len(ctx['totales_columna']) == 12
+        for fila in ctx['matrix_rows']:
+            assert len(fila['meses']) == 12
+        # Total de columna julio = -100 (solo Ingresos Operacionales).
+        idx_julio = MESES_FISCALES_KEYS.index('julio')
+        assert ctx['totales_columna'][idx_julio] == -100.0
+
+    def test_a2_base_qs_preserva_anio_y_tab(self, client, admin_user):
+        """bimodal_base_qs / hidden params preservan anio+tab al togglear."""
+        client.force_login(admin_user)
+        _crear_presupuesto(2026, _datos_con_meses())
+        url = reverse('financiero:cargar_bd_contable')
+        resp = client.get(f'{url}?anio=2026&tab=planeado&vista=matriz')
+        base_qs = resp.context['bimodal_base_qs']
+        assert 'anio=2026' in base_qs
+        assert 'tab=planeado' in base_qs
+        # vista/mes NO deben estar en el base (los agrega el enlace).
+        assert 'vista=' not in base_qs

--- a/apps/financiero/tests/test_finv2_matriz.py
+++ b/apps/financiero/tests/test_finv2_matriz.py
@@ -1,0 +1,257 @@
+"""A1 (#120) — Bucketing mensual del importer contable + matriz rubro × 12 meses.
+
+Cubre el sub-item A1 del Sprint A (Presupuesto bi-modal matriz + filtro mes):
+
+- happy: BD con fechas en ≥3 meses fiscales → ``meses`` por rubro poblado en las
+  columnas correctas (julio..junio) y matriz armada por ``build_rubro_matrix_rows``.
+- edge1: fila sin fecha (col D y col F vacías) NO rompe; cae en ``sin_mes`` y NO
+  aparece en ninguna columna mensual, pero SÍ suma al total anual.
+- edge2: datos legacy SIN la sub-llave ``meses`` (estructura previa a A1) →
+  ``build_rubro_matrix_rows`` tolera y devuelve matriz de ceros sin reventar.
+- paridad: para cada rubro, ``sum(meses_matriz) + sin_mes == total`` anual.
+- fallback Periodo: fila sin Fecha pero con col F ``Periodo`` YYYYMM se bucketea.
+
+Estos tests son PUROS (no tocan BD): ``ContableCompleteImporter._build_mapeo``
+captura la excepción de acceso a ``MapeoCtaRubro`` y cae al dict semilla, así que
+corren sin Postgres (gotcha del repo: venv local no corre tests con psycopg).
+"""
+import datetime
+import io
+
+from openpyxl import Workbook
+
+from apps.financiero.importers_finv2 import (
+    MESES_FISCALES,
+    MESES_FISCALES_KEYS,
+    SIN_MES_KEY,
+    ContableCompleteImporter,
+    build_mes_filter_rows,
+    build_rubro_matrix_rows,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers de fixtures Excel en memoria (espejo de test_b1.py)
+# --------------------------------------------------------------------------- #
+_HEADERS = [
+    'Auxiliar', 'Desc. auxiliar', 'Neto', 'Fecha', 'Docto.', 'Periodo',
+    'Tercero movto.', 'Razón social', 'Desc. C.O.', 'Usuario',
+    'C.O. movto.', 'Notas', 'C.Costo', 'Desc. C.Costo', 'Cta equivalente',
+]
+
+
+def _excel_bytes(rows, sheet_name='BD', headers=None, name='bd.xlsx'):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = sheet_name
+    ws.append(headers or _HEADERS)
+    for r in rows:
+        ws.append(r)
+    buf = io.BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+    buf.name = name
+    buf.size = len(buf.getvalue())
+    return buf
+
+
+def _row(neto, cta_equiv, fecha=None, periodo=None, desc='', auxiliar='X'):
+    """Fila BD: C=Neto(3), D=Fecha(4), F=Periodo(6), O=cta_equiv(15)."""
+    r = [auxiliar, desc, neto, fecha, None, periodo, None, None, None, None,
+         None, None, None, None, cta_equiv]
+    return r
+
+
+def _idx(mes_key):
+    """Índice de columna de un mes fiscal en la matriz (0..11)."""
+    return MESES_FISCALES_KEYS.index(mes_key)
+
+
+# --------------------------------------------------------------------------- #
+# happy path
+# --------------------------------------------------------------------------- #
+def test_a1_happy_bucketea_por_mes_fiscal():
+    """Movimientos en julio/agosto/enero → buckets mensuales por rubro correctos."""
+    rows = [
+        _row(-100, 'Ingresos Operacionales', fecha=datetime.datetime(2024, 7, 15)),
+        _row(-50, 'Ingresos Operacionales', fecha=datetime.datetime(2024, 8, 3)),
+        _row(-25, 'Ingresos Operacionales', fecha=datetime.datetime(2025, 1, 9)),
+    ]
+    res = ContableCompleteImporter().procesar_bd_completa(_excel_bytes(rows))
+    assert res['exito'] is True
+
+    bloque = res['datos']['finv2_bd']
+    meses = bloque['rubros']['Ingresos Operacionales']['meses']
+    assert meses['julio'] == -100
+    assert meses['agosto'] == -50
+    assert meses['enero'] == -25
+    # Total anual = suma de los 3 buckets.
+    assert bloque['rubros']['Ingresos Operacionales']['total'] == -175
+
+    rows_m, totales_col, meses_fiscales, total_general = \
+        build_rubro_matrix_rows(res['datos'])
+    assert meses_fiscales == MESES_FISCALES
+    assert len(rows_m) == 1
+    fila = rows_m[0]
+    assert len(fila['meses']) == 12
+    assert fila['meses'][_idx('julio')] == -100
+    assert fila['meses'][_idx('agosto')] == -50
+    assert fila['meses'][_idx('enero')] == -25
+    # Columnas sin movimiento = 0.
+    assert fila['meses'][_idx('diciembre')] == 0.0
+    # Totales por columna coherentes.
+    assert totales_col[_idx('julio')] == -100
+    assert total_general == -175
+
+
+def test_a1_orden_columnas_es_julio_a_junio():
+    """El primer mes de la matriz es julio y el último junio (año fiscal)."""
+    assert MESES_FISCALES_KEYS[0] == 'julio'
+    assert MESES_FISCALES_KEYS[-1] == 'junio'
+    assert len(MESES_FISCALES_KEYS) == 12
+
+
+# --------------------------------------------------------------------------- #
+# edge1 — fila sin fecha
+# --------------------------------------------------------------------------- #
+def test_a1_edge1_fila_sin_fecha_va_a_sin_mes_no_a_columna():
+    """Fila sin Fecha ni Periodo → bucket sin_mes; suma al anual, no a la matriz."""
+    rows = [
+        _row(-200, 'salarios', fecha=datetime.datetime(2024, 9, 1)),
+        _row(-80, 'salarios'),  # sin fecha ni periodo
+    ]
+    res = ContableCompleteImporter().procesar_bd_completa(_excel_bytes(rows))
+    assert res['exito'] is True
+
+    bloque = res['datos']['finv2_bd']
+    meses = bloque['rubros']['Personal']['meses']
+    assert meses['septiembre'] == -200
+    assert meses[SIN_MES_KEY] == -80
+    assert bloque['rubros']['Personal']['total'] == -280
+    assert bloque['filas_sin_mes'] == 1
+
+    rows_m, totales_col, _mf, total_general = build_rubro_matrix_rows(res['datos'])
+    fila = rows_m[0]
+    # La matriz mensual NO incluye el sin_mes en ninguna columna.
+    assert sum(fila['meses']) == -200
+    # Pero el total anual de la fila SÍ lo incluye.
+    assert fila['total'] == -280
+    assert total_general == -280
+    # sin_mes no aparece como columna.
+    assert len(fila['meses']) == 12
+
+
+# --------------------------------------------------------------------------- #
+# edge2 — datos legacy sin 'meses'
+# --------------------------------------------------------------------------- #
+def test_a1_edge2_datos_legacy_sin_meses_da_matriz_de_ceros():
+    """Estructura previa a A1 (rubros sin 'meses') → matriz de ceros, sin crash."""
+    datos_legacy = {
+        'finv2_bd': {
+            'rubros': {
+                'Personal': {'total': 5000.0, 'cuentas': []},  # sin 'meses'
+                'Ingresos Operacionales': {'total': -9000.0, 'cuentas': []},
+            },
+            'total': -4000.0,
+            'cuentas_count': 2,
+            'cuentas_no_mapeadas': [],
+        }
+    }
+    rows_m, totales_col, meses_fiscales, total_general = \
+        build_rubro_matrix_rows(datos_legacy)
+    assert len(rows_m) == 2
+    for fila in rows_m:
+        assert fila['meses'] == [0.0] * 12
+    assert totales_col == [0.0] * 12
+    # El total anual del rubro y general se respetan aunque no haya meses.
+    assert total_general == -4000.0
+    totales_anuales = {f['rubro']: f['total'] for f in rows_m}
+    assert totales_anuales['Personal'] == 5000.0
+
+
+def test_a1_edge2b_datos_vacios_no_rompen():
+    """datos None / sin finv2_bd → matriz vacía sin excepción."""
+    for datos in (None, {}, {'otra_llave': 1}):
+        rows_m, totales_col, meses_fiscales, total_general = \
+            build_rubro_matrix_rows(datos)
+        assert rows_m == []
+        assert totales_col == [0.0] * 12
+        assert total_general == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# paridad sum(meses) + sin_mes == total
+# --------------------------------------------------------------------------- #
+def test_a1_paridad_suma_meses_mas_sin_mes_igual_total():
+    """Para cada rubro: Σ(buckets mensuales) + sin_mes == total anual."""
+    rows = [
+        _row(-100, 'Ingresos Operacionales', fecha=datetime.datetime(2024, 7, 1)),
+        _row(-60, 'Ingresos Operacionales', fecha=datetime.datetime(2024, 12, 1)),
+        _row(-40, 'Ingresos Operacionales'),  # sin_mes
+        _row(300, 'salarios', fecha=datetime.datetime(2025, 2, 1)),
+        _row(150, 'salarios', fecha=datetime.datetime(2025, 6, 1)),
+    ]
+    res = ContableCompleteImporter().procesar_bd_completa(_excel_bytes(rows))
+    bloque = res['datos']['finv2_bd']
+
+    for rubro, info in bloque['rubros'].items():
+        suma_buckets = round(sum(info['meses'].values()), 2)
+        assert suma_buckets == info['total'], f'paridad rota en {rubro}'
+
+    # Paridad también a nivel matriz: Σ columnas + Σ(sin_mes) == total general.
+    rows_m, totales_col, _mf, total_general = build_rubro_matrix_rows(res['datos'])
+    suma_columnas = round(sum(totales_col), 2)
+    suma_sin_mes = round(
+        sum((info['meses'].get(SIN_MES_KEY, 0.0)
+             for info in bloque['rubros'].values())), 2)
+    assert round(suma_columnas + suma_sin_mes, 2) == total_general
+
+
+# --------------------------------------------------------------------------- #
+# fallback col F (Periodo YYYYMM)
+# --------------------------------------------------------------------------- #
+def test_a1_fallback_periodo_yyyymm_cuando_no_hay_fecha():
+    """Sin Fecha (col D) pero con Periodo '202410' (col F) → octubre."""
+    rows = [
+        _row(-70, 'salarios', periodo='202410'),
+        _row(-30, 'salarios', periodo=202503),  # int, marzo
+    ]
+    res = ContableCompleteImporter().procesar_bd_completa(_excel_bytes(rows))
+    meses = res['datos']['finv2_bd']['rubros']['Personal']['meses']
+    assert meses['octubre'] == -70
+    assert meses['marzo'] == -30
+    assert SIN_MES_KEY not in meses  # ninguna fila cayó a sin_mes
+
+
+def test_a1_fecha_como_string_se_parsea():
+    """Fecha en texto 'YYYY-MM-DD' (algunos export) se bucketea igual."""
+    rows = [_row(-90, 'salarios', fecha='2024-11-20')]
+    res = ContableCompleteImporter().procesar_bd_completa(_excel_bytes(rows))
+    meses = res['datos']['finv2_bd']['rubros']['Personal']['meses']
+    assert meses['noviembre'] == -90
+
+
+# --------------------------------------------------------------------------- #
+# build_mes_filter_rows (vista 'Filtro Mes')
+# --------------------------------------------------------------------------- #
+def test_a1_filtro_mes_devuelve_solo_rubros_con_valor():
+    """build_mes_filter_rows: solo rubros con movimiento en el mes pedido."""
+    rows = [
+        _row(-100, 'Ingresos Operacionales', fecha=datetime.datetime(2024, 7, 1)),
+        _row(-50, 'salarios', fecha=datetime.datetime(2024, 8, 1)),
+    ]
+    res = ContableCompleteImporter().procesar_bd_completa(_excel_bytes(rows))
+
+    filas_jul, total_jul, label = build_mes_filter_rows(res['datos'], 'julio')
+    assert label == 'Julio'
+    assert total_jul == -100
+    rubros_jul = {f['rubro'] for f in filas_jul}
+    assert rubros_jul == {'Ingresos Operacionales'}  # Personal no tuvo julio
+
+
+def test_a1_filtro_mes_invalido_devuelve_vacio():
+    """Mes no fiscal → ([], 0.0, '') sin excepción."""
+    filas, total, label = build_mes_filter_rows({'finv2_bd': {'rubros': {}}}, 'nofiscal')
+    assert filas == []
+    assert total == 0.0
+    assert label == ''

--- a/apps/financiero/views_finv2_presupuesto.py
+++ b/apps/financiero/views_finv2_presupuesto.py
@@ -18,7 +18,14 @@ from django.views import View
 from apps.core.mixins import RoleRequiredMixin
 
 from .forms_finv2 import CargarBDContableForm, MapeoCtaRubroForm
-from .importers_finv2 import ContableCompleteImporter, build_rubro_display_rows
+from .importers_finv2 import (
+    MESES_FISCALES,
+    MESES_FISCALES_KEYS,
+    ContableCompleteImporter,
+    build_mes_filter_rows,
+    build_rubro_display_rows,
+    build_rubro_matrix_rows,
+)
 from .models_finv2_mapeo import MapeoCtaRubro
 from .views import PresupuestoDetalladoBaseView
 
@@ -51,7 +58,56 @@ class PresupuestoPlaneadoViewV2(PresupuestoDetalladoBaseView):
         context['mapeos'] = MapeoCtaRubro.objects.all()
         context['mapeo_form'] = MapeoCtaRubroForm()
         context['active_tab'] = self.request.GET.get('tab', 'cargar')
+
+        # A2 (#120) — vista bi-modal: matriz 12 meses (julio→junio) + filtro mes.
+        context.update(self._build_bimodal_context(obj.datos))
         return context
+
+    # ------------------------------------------------------------------ #
+    # A2 (#120) — contexto bi-modal (matriz / filtro mes)
+    # ------------------------------------------------------------------ #
+    def _build_bimodal_context(self, datos):
+        """Arma el contexto compartido por el partial _presupuesto_bimodal_tabla.
+
+        Lee ``?vista=`` (matriz|mes, default matriz) y ``?mes=`` (key fiscal).
+        Devuelve un dict consumido por el partial — mismo contrato que usa
+        Construcción (A3), para no divergir.
+        """
+        vista = self.request.GET.get('vista', 'matriz')
+        if vista not in ('matriz', 'mes'):
+            vista = 'matriz'
+
+        matrix_rows, totales_columna, meses_fiscales, total_general = (
+            build_rubro_matrix_rows(datos)
+        )
+
+        # Filtro mes: validar contra las keys fiscales; default = primer mes.
+        mes_sel = self.request.GET.get('mes') or MESES_FISCALES_KEYS[0]
+        if mes_sel not in MESES_FISCALES_KEYS:
+            mes_sel = MESES_FISCALES_KEYS[0]
+        mes_rows, mes_total, mes_label = build_mes_filter_rows(datos, mes_sel)
+
+        # Querystring base (sin vista/mes) para los enlaces del toggle + hidden
+        # params del form de filtro (preserva anio/tab/contrato al navegar).
+        hidden = {
+            k: v for k, v in self.request.GET.items()
+            if k not in ('vista', 'mes') and v
+        }
+        base_qs = ''.join(f'{k}={v}&' for k, v in hidden.items())
+
+        return {
+            'vista': vista,
+            'matrix_rows': matrix_rows,
+            'totales_columna': totales_columna,
+            'meses_fiscales': meses_fiscales,
+            'matrix_total': total_general,
+            'mes_sel': mes_sel,
+            'mes_rows': mes_rows,
+            'mes_total': mes_total,
+            'mes_label': mes_label,
+            'bimodal_base_qs': base_qs,
+            'bimodal_hidden_params': hidden,
+        }
 
     # ------------------------------------------------------------------ #
     # POST — carga de BD contable

--- a/templates/construccion/financiero_presupuesto_planeado.html
+++ b/templates/construccion/financiero_presupuesto_planeado.html
@@ -64,6 +64,9 @@ Incluye: _financiero_cargar_bd.html (pestaña 1) + _financiero_presupuesto_tabla
         {% include "construccion/_financiero_cargar_bd.html" %}
     </div>
     <div x-show="tab === 'tabla'" x-cloak class="space-y-6">
+        {% comment %} A3 (#120): vista bi-modal (Matriz 12 meses | Filtro Mes),
+        espejo de Mantenimiento — partial COMPARTIDO con financiero. {% endcomment %}
+        {% include "financiero/_presupuesto_bimodal_tabla.html" %}
         {% include "construccion/_financiero_presupuesto_tabla.html" %}
     </div>
 </main>

--- a/templates/financiero/_presupuesto_bimodal_tabla.html
+++ b/templates/financiero/_presupuesto_bimodal_tabla.html
@@ -1,0 +1,181 @@
+{% comment %}
+A2/A3 (#120) — Partial COMPARTIDO de la vista bi-modal del Presupuesto Planeado:
+  - Vista Matriz : tabla rubro × 12 meses fiscales (julio→junio) + columna TOTAL
+                   + fila de totales por columna.
+  - Filtro Mes   : select de mes + tabla reducida (rubro · total) del mes elegido.
+Lo incluyen tanto Mantenimiento (presupuesto_planeado_v2.html, financiero) como
+Construcción (financiero_presupuesto_planeado.html, construccion) para no divergir.
+
+Contexto requerido (ambas vistas lo proveen con el MISMO contrato):
+  tiene_datos_bd : bool          — hay datos contables cargados
+  vista          : 'matriz'|'mes'— pestaña activa (desde ?vista=)
+  matrix_rows    : [{rubro, meses[12], total, pct}]   (orden julio→junio)
+  totales_columna: [float × 12]
+  meses_fiscales : [(key, label, num) × 12]
+  matrix_total   : float
+  mes_sel        : key fiscal del mes filtrado
+  mes_rows       : [{rubro, total}]  del mes filtrado
+  mes_total      : float
+  mes_label      : etiqueta humana del mes filtrado
+  bimodal_base_qs: querystring base SIN vista/mes (p.ej. 'anio=2024&tab=planeado&')
+                   para construir los enlaces del toggle / submit del filtro.
+
+Estados UI: loading (x-show mientras navega), empty (sin datos), error (sin
+matriz pese a tener datos). Sin {# #} multilínea (anti-regresión del repo).
+{% endcomment %}
+{% load humanize %}
+
+<div x-data="{ vista: '{{ vista|default:"matriz" }}', cargando: false }"
+     class="space-y-4">
+
+    {% if not tiene_datos_bd %}
+    {% comment %} Empty state {% endcomment %}
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-8 text-center border border-gray-200 dark:border-gray-700">
+        <p class="text-gray-500 dark:text-gray-400">
+            Aún no hay datos contables cargados para construir la matriz mensual.
+        </p>
+        <button type="button" @click="tab = 'cargar'"
+                class="mt-3 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm font-medium">
+            Cargar Base de Datos Contable
+        </button>
+    </div>
+    {% else %}
+
+    {% comment %} Toggle Vista Matriz | Filtro Mes {% endcomment %}
+    <div class="flex flex-wrap items-center justify-between gap-3">
+        <div class="inline-flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden text-sm">
+            <a href="?{{ bimodal_base_qs }}vista=matriz&mes={{ mes_sel }}"
+               @click="cargando = true"
+               :class="vista === 'matriz' ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300'"
+               class="px-4 py-2 font-medium transition">Vista Matriz</a>
+            <a href="?{{ bimodal_base_qs }}vista=mes&mes={{ mes_sel }}"
+               @click="cargando = true"
+               :class="vista === 'mes' ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300'"
+               class="px-4 py-2 font-medium transition border-l border-gray-300 dark:border-gray-600">Filtro Mes</a>
+        </div>
+        <span class="text-sm text-gray-500 dark:text-gray-400">
+            Año fiscal julio → junio · Total ${{ matrix_total|floatformat:0|intcomma }}
+        </span>
+    </div>
+
+    {% comment %} Loading state (visible mientras navega el toggle/filtro) {% endcomment %}
+    <div x-show="cargando" x-cloak
+         class="flex items-center gap-2 text-sm text-blue-600 dark:text-blue-400">
+        <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.4 0 0 5.4 0 12h4z"></path>
+        </svg>
+        Cargando…
+    </div>
+
+    {% comment %} ============ Vista MATRIZ (rubro × 12 meses) ============ {% endcomment %}
+    <div data-vista="matriz" x-show="vista === 'matriz'" x-cloak>
+        {% if matrix_rows %}
+        <section class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700">
+            <div class="overflow-x-auto">
+                <table class="min-w-full text-xs sm:text-sm">
+                    <thead class="bg-gray-50 dark:bg-gray-900">
+                        <tr>
+                            <th class="px-3 py-2 text-left font-medium text-gray-600 dark:text-gray-300 sticky left-0 bg-gray-50 dark:bg-gray-900">Rubro</th>
+                            {% for key, label, num in meses_fiscales %}
+                            <th class="px-3 py-2 text-right font-medium text-gray-600 dark:text-gray-300 whitespace-nowrap">{{ label }}</th>
+                            {% endfor %}
+                            <th class="px-3 py-2 text-right font-semibold text-gray-700 dark:text-gray-200 whitespace-nowrap">TOTAL</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                        {% for fila in matrix_rows %}
+                        <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/40">
+                            <td class="px-3 py-2 text-gray-900 dark:text-white whitespace-nowrap sticky left-0 bg-white dark:bg-gray-800">{{ fila.rubro }}</td>
+                            {% for valor in fila.meses %}
+                            <td class="px-3 py-2 text-right text-gray-600 dark:text-gray-300 whitespace-nowrap">${{ valor|floatformat:0|intcomma }}</td>
+                            {% endfor %}
+                            <td class="px-3 py-2 text-right font-semibold text-gray-900 dark:text-white whitespace-nowrap">${{ fila.total|floatformat:0|intcomma }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                    <tfoot class="bg-gray-100 dark:bg-gray-800 font-semibold">
+                        <tr>
+                            <td class="px-3 py-2 text-gray-900 dark:text-white sticky left-0 bg-gray-100 dark:bg-gray-800">TOTAL</td>
+                            {% for total_col in totales_columna %}
+                            <td class="px-3 py-2 text-right text-gray-900 dark:text-white whitespace-nowrap">${{ total_col|floatformat:0|intcomma }}</td>
+                            {% endfor %}
+                            <td class="px-3 py-2 text-right text-gray-900 dark:text-white whitespace-nowrap">${{ matrix_total|floatformat:0|intcomma }}</td>
+                        </tr>
+                    </tfoot>
+                </table>
+            </div>
+        </section>
+        {% else %}
+        {% comment %} Error/degradado: hay datos contables pero la matriz vino vacía {% endcomment %}
+        <div class="rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-4 text-sm text-amber-800 dark:text-amber-300">
+            No se pudo construir la matriz mensual con los datos cargados. Verifique
+            que la Base de Datos contable incluya la columna Fecha (D) o Periodo (F).
+        </div>
+        {% endif %}
+    </div>
+
+    {% comment %} ============ Filtro MES ============ {% endcomment %}
+    <div data-vista="mes" x-show="vista === 'mes'" x-cloak class="space-y-3">
+        <form method="get" class="flex flex-wrap items-end gap-2 text-sm"
+              @submit="cargando = true">
+            {% comment %} Reinyectar params base (anio/tab/contrato) como hidden {% endcomment %}
+            {% for k, v in bimodal_hidden_params.items %}
+            <input type="hidden" name="{{ k }}" value="{{ v }}">
+            {% endfor %}
+            <input type="hidden" name="vista" value="mes">
+            <label class="flex flex-col">
+                <span class="text-xs text-gray-500">Mes fiscal</span>
+                <select name="mes"
+                        class="rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white text-sm"
+                        onchange="this.form.submit()">
+                    {% for key, label, num in meses_fiscales %}
+                    <option value="{{ key }}" {% if key == mes_sel %}selected{% endif %}>{{ label }}</option>
+                    {% endfor %}
+                </select>
+            </label>
+            <button type="submit"
+                    class="px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm font-medium">Ver mes</button>
+        </form>
+
+        {% if mes_rows %}
+        <section class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700">
+            <div class="px-4 py-3 flex items-center justify-between border-b border-gray-200 dark:border-gray-700">
+                <h3 class="text-base font-semibold text-gray-900 dark:text-white">{{ mes_label }}</h3>
+                <span class="text-sm font-bold text-gray-700 dark:text-gray-200">${{ mes_total|floatformat:0|intcomma }}</span>
+            </div>
+            <div class="overflow-x-auto">
+                <table class="min-w-full text-sm">
+                    <thead class="bg-gray-50 dark:bg-gray-900">
+                        <tr>
+                            <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Rubro</th>
+                            <th class="px-4 py-2 text-right font-medium text-gray-600 dark:text-gray-300">Total {{ mes_label }}</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                        {% for fila in mes_rows %}
+                        <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/40">
+                            <td class="px-4 py-2 text-gray-900 dark:text-white">{{ fila.rubro }}</td>
+                            <td class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">${{ fila.total|floatformat:0|intcomma }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                    <tfoot class="bg-gray-100 dark:bg-gray-800 font-semibold">
+                        <tr>
+                            <td class="px-4 py-2 text-gray-900 dark:text-white">TOTAL</td>
+                            <td class="px-4 py-2 text-right text-gray-900 dark:text-white">${{ mes_total|floatformat:0|intcomma }}</td>
+                        </tr>
+                    </tfoot>
+                </table>
+            </div>
+        </section>
+        {% else %}
+        {% comment %} Empty para el mes elegido (no es error: el mes no tuvo movimientos) {% endcomment %}
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6 text-center text-gray-500 dark:text-gray-400 border border-gray-200 dark:border-gray-700">
+            No hay movimientos contables en {{ mes_label }}.
+        </div>
+        {% endif %}
+    </div>
+
+    {% endif %}
+</div>

--- a/templates/financiero/presupuesto_planeado_v2.html
+++ b/templates/financiero/presupuesto_planeado_v2.html
@@ -67,7 +67,10 @@ Servida por PresupuestoPlaneadoViewV2 (financiero:cargar_bd_contable).
             </button>
         </div>
         {% else %}
-        <!-- Tabla de rubros -->
+        <!-- A2 (#120): vista bi-modal (Matriz 12 meses | Filtro Mes) -->
+        {% include "financiero/_presupuesto_bimodal_tabla.html" %}
+
+        <!-- Tabla de rubros (vista plana / detalle expandible por cuenta) -->
         <section class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700">
             <div class="px-4 py-3 flex items-center justify-between border-b border-gray-200 dark:border-gray-700">
                 <h2 class="text-lg font-semibold text-gray-900 dark:text-white">


### PR DESCRIPTION
## Qué (v1.0 completa del reclamo del cliente, rebote ×2)
El cliente pidió **ambas** vistas del Presupuesto Detallado: matriz anual (rubro × 12 meses) **y** filtro por mes. Hoy solo había tabla plana.

### Cambios
- **A1 backend** (`importers_finv2.py`): bucketing mensual del importer contable (col Fecha; fallback Periodo). `build_rubro_matrix_rows` + `build_mes_filter_rows`, `MESES_FISCALES` julio→junio, filas sin fecha solo en anual. Vista plana conservada (fallback).
- **A2 UI Mantenimiento**: partial **compartido** `_presupuesto_bimodal_tabla.html` con toggle Matriz | Filtro Mes + estados loading/empty/error.
- **A3 UI Construcción**: reusa el MISMO partial (no diverge).

### Validación
26 tests por-issue verdes + suite 75 passed, sin migración. 3 journeys E2E (matriz 12 meses + filtro mes, mant + constr).

### 🔁 Reproceso
Causa del FIX_INCOMPLETO previo: el importer sumaba Neto en un total anual único; la matriz/filtro requieren bucketing mensual. Resuelto en A1.

Refs #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)