### PR TITLE
ci(deploy): build en GitHub-hosted x86 nativo (sin QEMU) — Sprint 3B

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   changes:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     outputs:
       should_deploy: ${{ steps.filter.outputs.src }}
     steps:
@@ -46,7 +46,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.should_deploy == 'true' || github.event_name == 'workflow_dispatch' }}
     name: Build, Migrate & Deploy
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
@@ -78,8 +78,8 @@ jobs:
           context: .
           push: true
           tags: ${{ env.IMAGE_NAME }}:${{ github.sha }},${{ env.IMAGE_NAME }}:latest
-          cache-from: type=local,src=/Volumes/Indunnova/buildkit-cache/${{ github.event.repository.name }}
-          cache-to: type=local,dest=/Volumes/Indunnova/buildkit-cache/${{ github.event.repository.name }},mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Create env-vars file
         run: |


### PR DESCRIPTION
Top-6 por volumen de deploys (14d). Build amd64 nativo en `ubuntu-latest` en vez de QEMU sobre Colima ARM (~14 min → ~4-6 min esperado; elimina el OOM intermitente #19 y libera el runner de la mini). Cache local `/Volumes` reemplazado por `type=gha` (action-style) o removido (CLI-style, donde gha no aplica). Secrets/gcloud/migraciones vía Cloud Run job: sin cambios.

**Verificado post-push:** contenido remoto == parcheado local (sha256), sin `self-hosted`, sin `/Volumes`, sin binfmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCDuquYJpFXvZcwwngY3rH