### PR TITLE
Cablear filtro semestre + carga real de vanos por linea (bounce 2) - Refs #102

### DIFF
--- a/apps/campo/tests_issue_102.py
+++ b/apps/campo/tests_issue_102.py
@@ -1,0 +1,193 @@
+"""
+Tests #102 (bounce=2, FIX_INCOMPLETO) — Wiring de ``?semestre=S1|S2|TA`` en
+``RegistroAvanceCreateView._build_context()``.
+
+Causa raíz (F2): la vista NUNCA leía ``request.GET.get('semestre')`` ni
+consultaba ``VanoSemestre`` — el dropdown "Período" del template
+(``lineas/_filtro_semestre.html``, construido en mayo por B2.1) era un
+gancho visual sin efecto real; las 4 stats (total/pendientes/ejecutados/
+porcentaje) siempre se calculaban desde ``Vano.objects.filter(linea=linea)``
+global, sin importar el semestre elegido.
+
+Cubre:
+- Wiring real: ``?semestre=S1`` vs ``?semestre=S2`` de la MISMA línea
+  devuelven ``total_vanos`` DISTINTO (discriminante — antes del fix ambos
+  daban el mismo número).
+- Sin ``?semestre=``: comportamiento IDÉNTICO al actual (regresión, mismo
+  contrato que B1.2/#101 — ``tests_b12.py``).
+- Semestre inválido / minúsculas: mismo criterio case-insensitive que
+  ``filter_vanos_by_semestre`` (ya testeado en ``tests_b21.py``).
+- Estado independiente por semestre se refleja en ``vanos_ejecutados``/
+  ``porcentaje`` filtrados (marcar EJECUTADO en S1 no afecta el cálculo de S2).
+- Dato legacy: línea con Vano preexistentes pero SIN VanoSemestre (nunca
+  configurada por B2.1) — filtrada da grid vacío + stats en 0 sin 500 por
+  división por cero.
+"""
+
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
+
+from apps.campo.views import RegistroAvanceCreateView
+from apps.lineas.models import Linea, Vano
+from apps.lineas.models_b21 import VanoSemestre
+from apps.usuarios.models import Usuario
+
+
+def _invoke_get_context(user, linea_id=None, semestre=None):
+    """Mismo patrón que ``apps/campo/tests_b12.py`` — llama
+    ``get_context_data`` directo vía ``RequestFactory``, sin renderizar el
+    template (evita depender de includes de otras sub-features)."""
+    rf = RequestFactory()
+    query = {}
+    if linea_id is not None:
+        query["linea_id"] = linea_id
+    if semestre is not None:
+        query["semestre"] = semestre
+    request = rf.get(reverse("campo:avance_registrar"), query)
+    request.user = user
+
+    view = RegistroAvanceCreateView()
+    view.setup(request)
+    return view.get_context_data()
+
+
+def _linea(codigo="LT-102"):
+    return Linea.objects.create(
+        codigo=codigo,
+        nombre=f"Línea {codigo}",
+        cliente=Linea.Cliente.TRANSELCA,
+        activa=True,
+    )
+
+
+class RegistroAvanceCreateViewFiltroSemestreTests(TestCase):
+    """Tests del wiring #102 sobre ``RegistroAvanceCreateView``."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin = Usuario.objects.create_user(
+            email="admin_102@test.com",
+            password="testpass123!",
+            first_name="Admin",
+            last_name="102",
+            rol="admin",
+            is_staff=True,
+            is_superuser=True,
+        )
+
+        # Línea LN733-equivalente: S1=18 vanos (1..18, todos pendientes),
+        # S2=8 vanos (subconjunto de S1: 2,3,4,5,7,12,16,17) — mismo
+        # discriminante state-independent que usa el journey de F2/F3
+        # (no depende de que se haya marcado ningún estado todavía).
+        cls.linea = _linea("LT-102-733")
+        for i in range(1, 19):
+            Vano.objects.create(linea=cls.linea, numero=str(i))
+        s1_numeros = set(range(1, 19))
+        s2_numeros = {2, 3, 4, 5, 7, 12, 16, 17}
+        for n in s1_numeros:
+            vano = cls.linea.vanos.get(numero=str(n))
+            VanoSemestre.objects.create(vano=vano, semestre="S1")
+        for n in s2_numeros:
+            vano = cls.linea.vanos.get(numero=str(n))
+            VanoSemestre.objects.create(vano=vano, semestre="S2")
+
+        # Línea legacy: tiene Vano pero NUNCA se configuraron VanoSemestre
+        # (dato real posible — B2.1 es opt-in por vano, ver modal de
+        # configuración en views_b21.py).
+        cls.linea_legacy = _linea("LT-102-LEGACY")
+        for i in range(1, 6):
+            Vano.objects.create(linea=cls.linea_legacy, numero=str(i))
+
+    # ------------------------------------------------------------------
+    # Wiring real — discriminante S1 vs S2
+    # ------------------------------------------------------------------
+    def test_filtro_s1_vs_s2_misma_linea_totales_distintos(self):
+        ctx_s1 = _invoke_get_context(self.admin, linea_id=str(self.linea.id), semestre="S1")
+        ctx_s2 = _invoke_get_context(self.admin, linea_id=str(self.linea.id), semestre="S2")
+
+        self.assertEqual(ctx_s1["total_vanos"], 18)
+        self.assertEqual(ctx_s2["total_vanos"], 8)
+        self.assertNotEqual(ctx_s1["total_vanos"], ctx_s2["total_vanos"])
+        self.assertEqual(ctx_s1["semestre"], "S1")
+        self.assertEqual(ctx_s2["semestre"], "S2")
+
+    def test_filtro_s1_grid_tiene_18_vanos_s2_tiene_8(self):
+        ctx_s1 = _invoke_get_context(self.admin, linea_id=str(self.linea.id), semestre="S1")
+        ctx_s2 = _invoke_get_context(self.admin, linea_id=str(self.linea.id), semestre="S2")
+        self.assertEqual(len(ctx_s1["vanos"]), 18)
+        self.assertEqual(len(ctx_s2["vanos"]), 8)
+
+    def test_filtro_pendientes_coincide_con_total_sin_estados_marcados(self):
+        ctx_s1 = _invoke_get_context(self.admin, linea_id=str(self.linea.id), semestre="S1")
+        self.assertEqual(ctx_s1["vanos_pendientes"], 18)
+        self.assertEqual(ctx_s1["vanos_ejecutados"], 0)
+        self.assertEqual(ctx_s1["porcentaje"], 0)
+
+    # ------------------------------------------------------------------
+    # Estado independiente por semestre (marcar S1 no afecta cálculo S2)
+    # ------------------------------------------------------------------
+    def test_marcar_ejecutado_en_s1_no_afecta_stats_de_s2(self):
+        vs1 = VanoSemestre.objects.filter(
+            vano__linea=self.linea, vano__numero="2", semestre="S1"
+        ).get()
+        vs1.marcar(VanoSemestre.Estado.EJECUTADO)
+
+        ctx_s1 = _invoke_get_context(self.admin, linea_id=str(self.linea.id), semestre="S1")
+        ctx_s2 = _invoke_get_context(self.admin, linea_id=str(self.linea.id), semestre="S2")
+
+        self.assertEqual(ctx_s1["vanos_ejecutados"], 1)
+        self.assertEqual(ctx_s1["porcentaje"], round(1 / 18 * 100))
+        # El vano #2 en S2 sigue PENDIENTE — aislamiento entre semestres.
+        self.assertEqual(ctx_s2["vanos_ejecutados"], 0)
+
+    # ------------------------------------------------------------------
+    # Regresión — sin filtro, comportamiento IDÉNTICO al actual
+    # ------------------------------------------------------------------
+    def test_sin_filtro_usa_conteo_global_de_vano_no_vanosemestre(self):
+        """Sin ?semestre=, las stats deben venir de Vano.objects global (18
+        vanos únicos en la línea) — NO de VanoSemestre (que tendría 18+8=26
+        filas si se sumaran S1+S2). Prueba que el path viejo no se tocó."""
+        ctx = _invoke_get_context(self.admin, linea_id=str(self.linea.id))
+        self.assertEqual(ctx["total_vanos"], 18)  # NO 26
+        self.assertEqual(len(ctx["vanos"]), 18)
+        self.assertEqual(ctx["semestre"], "")
+
+    def test_semestre_ausente_devuelve_string_vacio_en_contexto(self):
+        ctx = _invoke_get_context(self.admin, linea_id=str(self.linea.id))
+        self.assertIn("semestre", ctx)
+        self.assertEqual(ctx["semestre"], "")
+
+    # ------------------------------------------------------------------
+    # Edge cases del parámetro
+    # ------------------------------------------------------------------
+    def test_semestre_invalido_se_comporta_como_sin_filtro(self):
+        ctx = _invoke_get_context(self.admin, linea_id=str(self.linea.id), semestre="XX")
+        self.assertEqual(ctx["total_vanos"], 18)
+        self.assertEqual(ctx["semestre"], "")
+
+    def test_semestre_minuscula_aceptado_case_insensitive(self):
+        ctx = _invoke_get_context(self.admin, linea_id=str(self.linea.id), semestre="s1")
+        self.assertEqual(ctx["total_vanos"], 18)
+        self.assertEqual(ctx["semestre"], "S1")
+
+    def test_semestre_con_espacios_se_normaliza(self):
+        ctx = _invoke_get_context(self.admin, linea_id=str(self.linea.id), semestre="  s2  ")
+        self.assertEqual(ctx["total_vanos"], 8)
+        self.assertEqual(ctx["semestre"], "S2")
+
+    # ------------------------------------------------------------------
+    # Dato legacy: Vano preexistente sin VanoSemestre configurado
+    # ------------------------------------------------------------------
+    def test_linea_legacy_sin_vanosemestre_filtrada_da_vacio_sin_crashear(self):
+        ctx = _invoke_get_context(self.admin, linea_id=str(self.linea_legacy.id), semestre="S1")
+        self.assertEqual(ctx["total_vanos"], 0)
+        self.assertEqual(len(ctx["vanos"]), 0)
+        self.assertEqual(ctx["porcentaje"], 0)  # sin división por cero
+        self.assertFalse(ctx.get("error"))
+
+    def test_linea_legacy_sin_filtro_sigue_mostrando_sus_5_vanos(self):
+        # Regresión: el dato legacy (Vano sin VanoSemestre) NO debe
+        # desaparecer del path sin filtro.
+        ctx = _invoke_get_context(self.admin, linea_id=str(self.linea_legacy.id))
+        self.assertEqual(ctx["total_vanos"], 5)
+        self.assertEqual(len(ctx["vanos"]), 5)

--- a/apps/campo/views.py
+++ b/apps/campo/views.py
@@ -821,7 +821,8 @@ class RegistroAvanceCreateView(LoginRequiredMixin, RoleRequiredMixin, TemplateVi
         from django.db.models import Count
 
         from apps.cuadrillas.models import CuadrillaMiembro
-        from apps.lineas.models import Linea, Vano
+        from apps.lineas.models import Linea, Vano, VanoSemestre
+        from apps.lineas.models_b21 import filter_vanos_by_semestre
 
         context = super().get_context_data(**kwargs)
         usuario = self.request.user
@@ -903,6 +904,17 @@ class RegistroAvanceCreateView(LoginRequiredMixin, RoleRequiredMixin, TemplateVi
         # att_04). No requiere ``distinct=True``: el ``prefetch_related`` de
         # abajo corre como queries separadas (no JOIN), asi que esta
         # anotacion es el unico JOIN/GROUP BY sobre esta queryset.
+        #
+        # #102 (bounce=2) — ``?semestre=S1|S2|TA`` filtra el grid vía
+        # ``filter_vanos_by_semestre`` (ya existía en apps/lineas/models_b21.py
+        # pero 0 callers en apps/campo — el dropdown de la vista era un
+        # gancho visual sin efecto real). Sin el parámetro (o inválido), el
+        # queryset queda IDÉNTICO al comportamiento anterior — backward
+        # compatible, 0 cambio para requests históricos sin ?semestre=.
+        semestre = self.request.GET.get('semestre', '').strip().upper()
+        if semestre not in dict(VanoSemestre.Semestre.choices):
+            semestre = ''
+
         vanos = (
             Vano.objects
             .filter(linea=linea)
@@ -911,6 +923,8 @@ class RegistroAvanceCreateView(LoginRequiredMixin, RoleRequiredMixin, TemplateVi
             .annotate(num_novedades=Count('historial'))
             .order_by('numero')
         )
+        if semestre:
+            vanos = filter_vanos_by_semestre(vanos, semestre)
 
         # Materializar para reusar y para que ``{% if vanos %}`` del template
         # no dispare un COUNT(*) adicional. Orden numérico real: ``numero`` es
@@ -924,31 +938,64 @@ class RegistroAvanceCreateView(LoginRequiredMixin, RoleRequiredMixin, TemplateVi
 
         context['linea'] = linea
         context['vanos'] = vanos_list
+        context['semestre'] = semestre
 
-        # Calculate stats — usar el QuerySet base (no la lista) para que el
-        # GROUP BY corra en la BD.
-        estados = (
-            Vano.objects
-            .filter(linea=linea)
-            .values('estado')
-            .annotate(count=Count('estado'))
-        )
-        stats = {e['estado']: e['count'] for e in estados}
+        if semestre:
+            # #102 — con filtro activo, las 4 stats principales se calculan
+            # desde VanoSemestre (estado POR SEMESTRE), no desde Vano.estado
+            # global — es justo el gap que #102 reportó: antes S1 y S2
+            # mostraban el mismo número porque estas 4 líneas seguían
+            # leyendo el queryset global sin filtrar.
+            estados = (
+                VanoSemestre.objects
+                .filter(vano__linea=linea, semestre=semestre)
+                .values('estado')
+                .annotate(count=Count('estado'))
+            )
+            stats = {e['estado']: e['count'] for e in estados}
+            total = sum(stats.values())
+            context['total_vanos'] = total
+            context['vanos_ejecutados'] = stats.get(VanoSemestre.Estado.EJECUTADO, 0)
+            context['vanos_pendientes'] = stats.get(VanoSemestre.Estado.PENDIENTE, 0)
+            # SIN_PERMISO y EN_ESPERA existen como choices en VanoSemestre.Estado
+            # (mismos valores string que Vano.Estado) — se pueden leer de la
+            # misma agregación filtrada por semestre.
+            context['vanos_sin_permiso'] = stats.get(VanoSemestre.Estado.SIN_PERMISO, 0)
+            context['vanos_en_espera'] = stats.get(VanoSemestre.Estado.EN_ESPERA, 0)
+            # SECCIONADO/ESPECIAL (#177) son estados de ``Vano`` que NO
+            # existen como choice en ``VanoSemestre.Estado`` — el modelo
+            # B2.1 no traqueó esa clasificación por semestre (gap de
+            # modelo pre-existente, fuera de alcance de #102). Se dejan en
+            # 0 en vez de mezclar con el conteo global (que rompería la
+            # suma total_vanos = Σ categorías del donut).
+            context['vanos_seccionados'] = 0
+            context['vanos_especiales'] = 0
+        else:
+            # Sin filtro — comportamiento IDÉNTICO al actual (backward
+            # compatible). Usa el QuerySet base (no la lista) para que el
+            # GROUP BY corra en la BD.
+            estados = (
+                Vano.objects
+                .filter(linea=linea)
+                .values('estado')
+                .annotate(count=Count('estado'))
+            )
+            stats = {e['estado']: e['count'] for e in estados}
 
-        total = len(vanos_list)
-        context['total_vanos'] = total
-        context['vanos_ejecutados'] = stats.get(Vano.Estado.EJECUTADO, 0)
-        context['vanos_pendientes'] = stats.get(Vano.Estado.PENDIENTE, 0)
-        context['vanos_sin_permiso'] = stats.get(Vano.Estado.SIN_PERMISO, 0)
-        context['vanos_en_espera'] = stats.get(Vano.Estado.EN_ESPERA, 0)
-        # Issue #177 (sub-item A8) — Seccionado/Especial reemplazan a
-        # "No Ejecutado" en el resumen de 6 categorías. El dato legacy
-        # 'no_ejecutado' (1 vano en prod) NO se cuenta en ninguna tarjeta
-        # ni en el donut — se preserva sin migrar (PLAN.md Decisión HITL
-        # #1), simplemente queda fuera del resumen hasta que alguien de
-        # campo lo reclasifique manualmente vía el modal nuevo.
-        context['vanos_seccionados'] = stats.get(Vano.Estado.SECCIONADO, 0)
-        context['vanos_especiales'] = stats.get(Vano.Estado.ESPECIAL, 0)
+            total = len(vanos_list)
+            context['total_vanos'] = total
+            context['vanos_ejecutados'] = stats.get(Vano.Estado.EJECUTADO, 0)
+            context['vanos_pendientes'] = stats.get(Vano.Estado.PENDIENTE, 0)
+            context['vanos_sin_permiso'] = stats.get(Vano.Estado.SIN_PERMISO, 0)
+            context['vanos_en_espera'] = stats.get(Vano.Estado.EN_ESPERA, 0)
+            # Issue #177 (sub-item A8) — Seccionado/Especial reemplazan a
+            # "No Ejecutado" en el resumen de 6 categorías. El dato legacy
+            # 'no_ejecutado' (1 vano en prod) NO se cuenta en ninguna tarjeta
+            # ni en el donut — se preserva sin migrar (PLAN.md Decisión HITL
+            # #1), simplemente queda fuera del resumen hasta que alguien de
+            # campo lo reclasifique manualmente vía el modal nuevo.
+            context['vanos_seccionados'] = stats.get(Vano.Estado.SECCIONADO, 0)
+            context['vanos_especiales'] = stats.get(Vano.Estado.ESPECIAL, 0)
 
         context['porcentaje'] = (
             round(context['vanos_ejecutados'] / total * 100) if total > 0 else 0

--- a/apps/lineas/importers_b21.py
+++ b/apps/lineas/importers_b21.py
@@ -213,9 +213,215 @@ def importar_tabla(texto: str, dry_run: bool = False) -> ResultadoImportacion:
     return resultado
 
 
-# Tabla embebida del issue #102 (snapshot mayo 2026). Persistida acá para que
-# el management command funcione offline. Si Sofi actualiza el issue, el
-# command acepta `--from-issue` para refrescar via gh.
+class VanoParseError(Exception):
+    """#102 — ``parse_vano_list`` no pudo interpretar el texto de vanos de
+    una fila del Excel real del cliente (att_01.xlsx, columna "Torres /
+    Vanos"). Fail-loud por diseño (F2 parser_spec): la función NUNCA debe
+    devolver un set vacío en silencio ni continuar con datos parciales sin
+    loggear — mejor romper ruidoso y que la migración capture el error por
+    fila que cargar datos incompletos sin que nadie se entere."""
+
+
+# #102 — Overrides manuales para filas irresolubles por regex puro (F2,
+# investigación BD prod). Único caso real detectado: LN 807/808 S1, texto
+# literal "Torre 5 (propiedad EEB) a la 42 y de la 42 a la 148" (~144 vanos
+# si se tomara literal) pero el Total declarado en el Excel es 108. F2
+# adoptó el rango 5-112 (108 vanos EXACTOS: 112-5+1=108) porque 112 coincide
+# EXACTO con el conteo real de torres de LN807 en BD (fuerte evidencia de
+# que "148" es un error de trascripción por "112"). Se aplica el mismo
+# rango numérico a LN808 también (113 torres reales, 1 de más, tolerable).
+CASOS_ESPECIALES: dict[tuple[str, str], set[int]] = {
+    ('LN 807/808', 'S1'): set(range(5, 113)),  # 108 vanos exactos
+}
+
+
+def parse_vano_list(
+    texto: str,
+    etiqueta_excel: str = '',
+    semestre: str = '',
+):
+    """
+    #102 — Parsea texto libre en español (columna "Torres / Vanos" del
+    Excel real del cliente, att_01.xlsx) a un ``set[int]`` de números de
+    vano — o, para el único caso de sub-grupos etiquetados del dataset, a
+    un ``dict[str, set[int]]`` (ver paso de sub-grupos abajo).
+
+    Reemplaza la heurística vieja de "primeros N vanos" (``_asignar_semestre``
+    original, issue #101/#102 bounce): ahora se consume la LISTA REAL de
+    vanos que el cliente reportó por semestre, no solo un conteo.
+
+    Fallback ordenado (parser_spec, F2 — el chequeo de sub-grupos etiquetados
+    se hace ANTES que el de lista explícita aunque el spec los enumere 3→4:
+    el único texto del dataset con sub-grupos también tiene comas DENTRO de
+    cada sub-grupo, así que si el split-por-coma corriera primero
+    fragmentaría los sub-grupos en vez de detectarlos):
+
+      1. Quitar sufijo de unidad conocido ("postes", case-insensitive).
+      2. RANGO SIMPLE: ``"1 al 104"``, ``"3 a 11"``, ``"1 a la 35"``,
+         ``"141 a la 240"`` (incluye rangos con offset que no arrancan en 1).
+      3. SUB-GRUPOS ETIQUETADOS: si el texto contiene ``";"`` Y ``"("`` (único
+         caso real del dataset: fila S2 de "LN 821/822, LN 821/826, LN
+         838/826, LN 822/826") → split por ``";"``, cada segmento matchea
+         ``r'^\\(([\\w/]+)\\)\\s*(.+)$'`` → ``{sub_etiqueta: parse_vano_list(resto)}``
+         recursivo. Devuelve ``dict[str, set[int]]`` — el caller (la
+         migración) decide a qué Línea(s) mapear cada sub-etiqueta según
+         ``MAPEO_EXCEL_A_LINEAS``.
+      4. LISTA EXPLÍCITA: normaliza ``" y "`` → ``", "``, split por coma,
+         cada token se intenta ``int()``; tokens no-numéricos (ej. "S/E
+         Sabana Portico", "Torre 5 (propiedad EEB)") se DESCARTAN de la
+         lista de números pero se registran en un log de warning (no
+         fatal — el resto de números válidos de la fila SÍ se cargan).
+      5. CASOS_ESPECIALES: override manual hardcodeado para overrides de
+         filas irresolubles por regex (ver arriba). Si ninguno de los pasos
+         2-5 matchea, la función FALLA RUIDOSO con ``VanoParseError``.
+    """
+    original = texto
+    if texto is None or not str(texto).strip():
+        raise VanoParseError(
+            f"texto vacío para línea={etiqueta_excel!r} semestre={semestre!r}"
+        )
+    t = str(texto).strip()
+
+    # (1) Sufijo de unidad conocido.
+    t = re.sub(r'\bpostes\b', '', t, flags=re.IGNORECASE).strip().rstrip('.').strip()
+
+    # (2) Rango simple (incluye offsets que no arrancan en 1, ej. "141 a la 240").
+    m = re.match(r'^(\d+)\s*al?\s*(?:la\s*)?(\d+)$', t, flags=re.IGNORECASE)
+    if m:
+        start, end = int(m.group(1)), int(m.group(2))
+        if start > end:
+            start, end = end, start
+        return set(range(start, end + 1))
+
+    # (3) Sub-grupos etiquetados ";" + "(...)" — chequeado ANTES de la lista
+    # explícita, ver docstring.
+    if ';' in t and '(' in t:
+        subgrupos: dict[str, set[int]] = {}
+        for segmento in t.split(';'):
+            segmento = segmento.strip()
+            if not segmento:
+                continue
+            sm = re.match(r'^\(([\w/]+)\)\s*(.+)$', segmento)
+            if not sm:
+                raise VanoParseError(
+                    f"sub-grupo no reconocido {segmento!r} en línea={etiqueta_excel!r} "
+                    f"semestre={semestre!r}: texto={original!r}"
+                )
+            sub_etiqueta, resto = sm.group(1), sm.group(2)
+            subgrupos[sub_etiqueta] = parse_vano_list(
+                resto,
+                etiqueta_excel=f"{etiqueta_excel} ({sub_etiqueta})",
+                semestre=semestre,
+            )
+        return subgrupos
+
+    # (4) Lista explícita: normalizar " y " -> ", ", descartar no-numéricos.
+    normalizado = re.sub(r'\s+y\s+', ', ', t, flags=re.IGNORECASE)
+    numeros: set[int] = set()
+    descartados: list[str] = []
+    for tok in normalizado.split(','):
+        tok = tok.strip()
+        if not tok:
+            continue
+        try:
+            numeros.add(int(tok))
+        except ValueError:
+            descartados.append(tok)
+    if descartados:
+        logger.warning(
+            "parse_vano_list: tokens no numéricos descartados en línea=%r "
+            "semestre=%r: %s (texto=%r)",
+            etiqueta_excel, semestre, descartados, original,
+        )
+    if numeros:
+        return numeros
+
+    # (5) CASOS_ESPECIALES — override manual final antes de fallar.
+    key = (etiqueta_excel, semestre)
+    if key in CASOS_ESPECIALES:
+        return CASOS_ESPECIALES[key]
+
+    raise VanoParseError(
+        f"no se pudo parsear vanos para línea={etiqueta_excel!r} "
+        f"semestre={semestre!r}: texto={original!r}"
+    )
+
+
+# #102 — Mapeo etiqueta-del-Excel-real -> códigos de Línea reales en BD.
+# Hardcodeado (``codigo_transelca`` está VACÍO en las 40 filas de BD, no
+# sirve como mecanismo de resolución — ver F2 causa_raiz). Confianza y
+# exclusiones documentadas por fila (mismo detalle en la migración 0017 y
+# en el JSON de salida de F2/F3). Etiquetas con lista vacía = Línea NO
+# EXISTE en BD (bloqueada, ver ``bloqueos`` en el output de F3) — NO se
+# crea ningún stub (violaría "nunca inventar evidencia").
+MAPEO_EXCEL_A_LINEAS: dict[str, list[str]] = {
+    'LN 5114': ['LN5114'],                            # alta
+    'LN 733': ['LN733'],                              # alta
+    'LN 734': ['LN734'],                              # alta
+    'LN 764/765': ['LN764', 'LN765'],                 # alta — doble circuito 33/33 EXACTO
+    'LN 801/802': ['LN801', 'LN802'],                 # alta — doble circuito 91/91
+    'LN 803/804': ['LN803', 'LN804'],                 # alta — doble circuito 14/16
+    'LN 805': ['LN805'],                              # alta
+    'LN 806/816': ['LN806', 'LN816'],                 # alta — doble circuito 201/202
+    'LN 839/840': ['LN839', 'LN840'],                 # alta — doble circuito 46/47
+    'LN 807/808': ['LN807', 'LN808'],                 # media — S1 requiere CASOS_ESPECIALES
+    'LN 809': ['LN809'],                              # alta
+    'LN 810': ['LN810'],                              # alta
+    'LN 811/812 y LN 812/813': ['LN811', 'LN812'],    # media/alta — LN813 EXCLUIDA (69 torres vs 178 pedidos, desproporción severa)
+    'LN 814/815 y LN 834/815': ['LN815', 'LN834'],    # alta/media — LN814 EXCLUIDA (23 torres vs 171 pedidos)
+    'LN 817/818': ['LN817', 'LN818'],                 # alta — doble circuito 177/177 EXACTO
+    'LN 819': ['LN819'],                              # alta
+    'LN 842': [],                                     # BLOQUEADA — Línea no existe en BD
+    'LN 821/822, LN 821/826, LN 838/826, LN 822/826': ['LN826', 'LN838'],  # ver reglas S1/S2 especiales en migración 0017 — LN821/LN822 EXCLUIDAS (torres≈0)
+    'LN 824/825': ['LN824', 'LN825'],                 # alta — doble circuito 50/50 EXACTO
+    'LN 827/828': ['LN827', 'LN828'],                 # alta — doble circuito 125/125 EXACTO
+    'LN 829/830': ['LN829', 'LN830'],                 # alta — doble circuito 13/11
+    'LN 5156/5157': ['LN5156', 'LN5157'],             # alta — doble circuito de POSTES 264/264 EXACTO
+    'LN 792': [],                                     # BLOQUEADA — Línea no existe en BD
+}
+
+
+def _resolver_lineas(etiqueta_excel: str) -> list:
+    """
+    #102 — Resuelve 1 etiqueta del Excel real a la lista de ``Linea`` reales
+    que representa (0, 1 o varias — patrón "doble circuito": misma
+    estructura física compartida por 2-4 líneas). Usa ``MAPEO_EXCEL_A_LINEAS``
+    (hardcodeado, ver arriba) en vez del split-by-"/" heurístico de
+    ``_resolver_linea`` (que estructuralmente sólo podía devolver 1 sola
+    Línea — incapaz de distribuir datos a las líneas adicionales de un
+    grupo "doble circuito").
+
+    NO lanza excepción si la etiqueta está bloqueada o no mapeada — el
+    caller decide cómo reportarlo (devuelve lista vacía).
+    """
+    from .models import Linea
+
+    lineas = []
+    for codigo in MAPEO_EXCEL_A_LINEAS.get(etiqueta_excel, []):
+        try:
+            lineas.append(Linea.objects.get(codigo=codigo))
+        except Linea.DoesNotExist:
+            logger.warning(
+                "_resolver_lineas: código %r (etiqueta=%r) no existe en BD",
+                codigo, etiqueta_excel,
+            )
+    return lineas
+
+
+# Tabla embebida del issue #102 (snapshot mayo 2026, formato conteo-por-
+# semestre). Persistida acá para que el management command
+# ``cargar_semestres_vanos`` funcione offline con el formato ORIGINAL de la
+# tabla del cuerpo del issue. Si Sofi actualiza el issue, el command acepta
+# `--from-issue` para refrescar via gh.
+#
+# NOTA (F2, jul-2026): esta tabla es un snapshot APROXIMADO de mayo 2026 —
+# solo tiene CONTEOS por semestre, no la lista real de qué vanos van en cada
+# uno (esa granularidad solo la trajo el Excel real del cliente, att_01.xlsx,
+# en julio). La carga masiva real de datos de #102 usa la migración
+# ``0017_carga_vanos_semestre_completa`` (parser ``parse_vano_list`` +
+# ``MAPEO_EXCEL_A_LINEAS`` arriba), NO esta tabla ni ``importar_tabla``.
+# Se conserva sin cambios (con sus tests existentes) como herramienta manual
+# de datafix aproximado para cuando no se tiene el Excel real a mano.
 TABLA_ISSUE_102 = """
 LÍNEA          | S1 Total | S2 Total | Todo Año | Total
 LN 5114        |   104    |   104    |    0     |  104

--- a/apps/lineas/migrations/0017_carga_vanos_semestre_completa.py
+++ b/apps/lineas/migrations/0017_carga_vanos_semestre_completa.py
@@ -1,0 +1,419 @@
+# Generated for Django 5.1.15 on 2026-07-22
+# Issue #102 (bounce=2, FIX_INCOMPLETO) — Carga masiva REAL de VanoSemestre
+# a partir del Excel att_01.xlsx del cliente (Instelec, jul-2026).
+#
+# Contexto (ver Instelec/SPRINTS/RUN_2026-07-22_0819/agents/Instelec_102_f2.json
+# para el análisis completo de F2): la migración 0011 creó el modelo
+# VanoSemestre y el management command `cargar_semestres_vanos` cargó datos
+# el 26-may-2026, pero esa carga usaba `TABLA_ISSUE_102` (solo CONTEOS por
+# semestre, formato "primeros N vanos") y en la práctica solo alcanzó a
+# LN5114 (100 vanos). Las otras 39 Líneas de la BD quedaron con 0 Vano y
+# `vano_semestres` con 0 filas — confirmado por F2 contra BD prod
+# (`SELECT count(*) FROM vano_semestres` = 0 el 22-jul-2026).
+#
+# Esta migración usa la LISTA REAL de vanos por línea/semestre (no un
+# conteo) directamente del Excel adjunto por el cliente, ya parseada con
+# `apps.lineas.importers_b21.parse_vano_list` (los números de abajo son el
+# resultado de correr el parser contra cada celda del Excel real — no se
+# lee el .xlsx en runtime, quedan hardcodeados aquí, mismo patrón que
+# `TABLA_ISSUE_102`).
+#
+# Scope: 22 de las 24 filas del Excel (23 etiquetas de línea + 1 fila TA
+# independiente). Excluidas explícitamente (decisiones de scope de F2, NO
+# bugs a corregir — ver `MAPEO_EXCEL_A_LINEAS` en importers_b21.py):
+#   - LN842, LN792: la Línea NO EXISTE en BD (0 filas con codigo/nombre
+#     ILIKE). NO se crea ningún stub (violaría "nunca inventar evidencia") —
+#     requieren datos maestros reales del cliente, issue/decisión aparte.
+#   - LN813 (del grupo 811/812/813): 69 torres reales en BD vs 178 vanos
+#     pedidos — desproporción severa, confianza baja.
+#   - LN814 (del grupo 814/815/834): 23 torres reales en BD vs 171 vanos
+#     pedidos — desproporción severa, confianza baja.
+#   - LN821, LN822 (del grupo 821/822/826/838): 1 y 0 torres reales en BD
+#     respectivamente — maestro de Torres prácticamente vacío, alto riesgo
+#     de crear vanos "fantasma". Del sub-desglose S2 de ese grupo, solo los
+#     sub-segmentos "(821/826)" y "(838/826)" se cargan (en LN826 y LN838
+#     respectivamente); el sub-segmento "(821/822)" se excluye por completo.
+#
+# Idempotente y re-ejecutable: `sincronizar_vanos_set` (bulk_create +
+# ignore_conflicts) para materializar Vano faltantes, `get_or_create` para
+# VanoSemestre. NO destructivo: nunca borra ni modifica un Vano existente
+# (preserva los 100 Vano preexistentes de LN5114 cargados por #101/0011).
+#
+# Nota de diseño: a diferencia del resto del portafolio (que usa
+# `apps.get_model()` para RunPython), esta migración importa los modelos
+# REALES (`apps.lineas.models`) porque necesita invocar el método de
+# negocio `Linea.sincronizar_vanos_set()` (no disponible en los modelos
+# históricos de `apps.get_model()`, que solo exponen campos). Es seguro acá
+# porque el método se introduce en el mismo release que esta migración (no
+# hay riesgo de "migration replay" contra una versión de código donde el
+# método no exista todavía).
+from django.db import migrations
+
+# ==============================================================================
+# Datos parseados del Excel real (att_01.xlsx, hoja "Vanos por Semestre").
+# Cada entrada: etiqueta del Excel -> {'lineas': [codigos...], 'semestres':
+# {'S1'/'S2'/'TA': set(numeros)}}.
+# ==============================================================================
+FILAS_EXCEL = {
+    'LN 5114': {
+        'lineas': ['LN5114'],
+        'semestres': {'S1': set(range(1, 105)), 'S2': set(range(1, 105))},
+    },
+    'LN 733': {
+        'lineas': ['LN733'],
+        'semestres': {'S1': set(range(1, 19)), 'S2': {2, 3, 4, 5, 7, 12, 16, 17}},
+    },
+    'LN 734': {
+        'lineas': ['LN734'],
+        'semestres': {
+            'S1': set(range(1, 36)),
+            'S2': {3, 4, 6, 8, 9, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+                   24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35},
+        },
+    },
+    'LN 764/765': {
+        'lineas': ['LN764', 'LN765'],
+        'semestres': {'S1': set(range(1, 34)), 'S2': set(range(1, 34))},
+    },
+    'LN 801/802': {
+        'lineas': ['LN801', 'LN802'],
+        'semestres': {
+            'S1': set(range(1, 88)),
+            'S2': {2, 3, 5, 6, 7, 9, 10, 12, 13, 17, 18, 20, 21, 22, 23, 25, 26,
+                   27, 28, 29, 32, 33, 36, 37, 38, 39, 40, 41, 44, 45, 49, 50,
+                   52, 54, 55, 56, 59, 61, 62, 64, 65, 66, 68, 70, 71, 72, 76,
+                   82, 85},
+        },
+    },
+    'LN 803/804': {
+        'lineas': ['LN803', 'LN804'],
+        'semestres': {'S1': set(range(3, 12)), 'S2': {3, 8}},
+    },
+    'LN 805': {
+        'lineas': ['LN805'],
+        'semestres': {
+            'S1': set(range(1, 247)),
+            # "S/E Sabana Portico" (token no-numérico) descartado por el
+            # parser (warning, no fatal) — quedan 129 números reales.
+            'S2': {1, 2, 5, 7, 8, 9, 11, 12, 19, 21, 22, 25, 26, 27, 28, 29, 30,
+                   31, 32, 36, 37, 38, 39, 40, 47, 48, 50, 59, 62, 63, 64, 65,
+                   66, 75, 76, 79, 80, 81, 86, 91, 92, 93, 95, 104, 109, 110,
+                   112, 113, 114, 115, 116, 118, 119, 120, 121, 122, 124, 125,
+                   127, 128, 132, 137, 138, 139, 140, 141, 142, 143, 152, 153,
+                   155, 156, 157, 158, 159, 160, 161, 162, 164, 165, 166, 167,
+                   168, 169, 170, 171, 172, 173, 176, 177, 178, 179, 181, 182,
+                   183, 184, 185, 186, 187, 188, 193, 194, 195, 196, 197, 198,
+                   199, 200, 201, 202, 203, 205, 207, 209, 215, 218, 229, 230,
+                   231, 233, 235, 236, 239, 240, 241, 242, 243, 244, 245},
+        },
+    },
+    'LN 806/816': {
+        'lineas': ['LN806', 'LN816'],
+        'semestres': {
+            'S1': set(range(1, 201)),
+            'S2': {1, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14, 17, 18, 20, 22, 23,
+                   24, 25, 26, 27, 28, 29, 30, 36, 38, 39, 40, 42, 43, 44, 47,
+                   48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 61, 62, 63, 64,
+                   66, 67, 70, 71, 74, 75, 76, 77, 78, 80, 103, 104, 106, 108,
+                   109, 112, 116, 118, 121, 123, 124, 125, 131, 132, 134, 135,
+                   137, 138, 139, 140, 141, 143, 148, 156, 161, 162, 163, 165,
+                   168, 176, 177, 178, 182, 185, 186, 187, 192, 194, 197},
+        },
+    },
+    'LN 839/840': {
+        'lineas': ['LN839', 'LN840'],
+        'semestres': {
+            'S1': set(range(1, 42)),
+            'S2': {1, 2, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 24, 25, 34, 35,
+                   36, 37, 40, 41},
+            # Fila TA independiente del Excel ("S1 y S2 (verde)", "aparece
+            # igual en ambos semestres").
+            'TA': {1, 2, 4, 5, 7, 10, 11, 12, 14, 23, 28, 36, 37},
+        },
+    },
+    'LN 807/808': {
+        'lineas': ['LN807', 'LN808'],
+        'semestres': {
+            # Texto literal del Excel: "Torre 5 (propiedad EEB) a la 42 y de
+            # la 42 a la 148" (Total declarado=108). No matchea rango simple
+            # ni lista explícita (parse_vano_list -> VanoParseError). F2
+            # adoptó el override CASOS_ESPECIALES: rango 5-112 (108 vanos
+            # EXACTOS, 112-5+1=108) porque 112 coincide EXACTO con el
+            # conteo real de torres de LN807 en BD — fuerte evidencia de que
+            # "148" es un error de trascripción por "112". Mismo rango
+            # aplicado a LN808 (113 torres reales, 1 de más, tolerable).
+            'S1': set(range(5, 113)),
+            'S2': {44, 45, 48, 50, 51, 52, 53, 54, 59, 61, 63, 66, 67, 69, 72,
+                   75, 77, 79, 80, 83, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94,
+                   95, 96, 97, 98, 99, 100, 101, 102, 104, 106, 107, 108, 109,
+                   110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121,
+                   122, 123, 126, 129, 131, 133, 134, 135, 136, 137, 138, 139,
+                   140, 142, 144, 145},
+            # Fila TA independiente del Excel ("S1 y S2 (verde)").
+            'TA': {43, 48, 49, 50, 51, 52, 53, 69, 88, 89, 90, 98, 120, 121,
+                   122, 133, 134, 135, 136, 137, 138, 139, 140, 142, 143, 144,
+                   145, 147},
+        },
+    },
+    'LN 809': {
+        'lineas': ['LN809'],
+        'semestres': {
+            'S1': set(range(1, 125)),
+            'S2': {2, 3, 4, 5, 7, 8, 10, 24, 25, 26, 28, 29, 37, 72, 76, 82, 85,
+                   87, 90, 92, 93, 101, 102, 104, 105, 107, 108, 116, 120, 122},
+        },
+    },
+    'LN 810': {
+        'lineas': ['LN810'],
+        'semestres': {
+            'S1': set(range(1, 205)),
+            'S2': {1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 20,
+                   21, 22, 23, 24, 26, 27, 29, 30, 32, 33, 36, 39, 40, 41, 42,
+                   43, 44, 45, 47, 54, 56, 67, 68, 69, 71, 72, 73, 74, 75, 76,
+                   77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91,
+                   92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104,
+                   105, 106, 107, 111, 116, 117, 118, 119, 120, 121, 122, 123,
+                   124, 128, 130, 131, 133, 135, 137, 139, 140, 141, 142, 143,
+                   144, 145, 146, 147, 149, 150, 151, 152, 153, 154, 155, 156,
+                   157, 158, 159, 161, 163, 164, 165, 166, 167, 168, 169, 170,
+                   171, 172, 173, 174, 175, 176, 178, 179, 180, 181, 182, 183,
+                   184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195,
+                   196, 197, 198, 199, 200, 201, 202, 203, 204, 205},
+        },
+    },
+    # LN813 EXCLUIDA (69 torres reales vs 178 vanos pedidos — ver docstring).
+    'LN 811/812 y LN 812/813': {
+        'lineas': ['LN811', 'LN812'],
+        'semestres': {
+            'S1': set(range(1, 179)),
+            'S2': {1, 2, 3, 10, 11, 18, 19, 22, 23, 24, 25, 26, 30, 31, 33, 35,
+                   36, 37, 38, 39, 40, 49, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+                   61, 62, 63, 65, 66, 68, 69, 70, 71, 72, 73, 74, 75, 77, 78,
+                   79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93,
+                   94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106,
+                   107, 108, 112, 114, 115, 116, 117, 118, 119, 120, 121, 122,
+                   123, 124, 125, 126, 127, 128, 132, 133, 139, 141, 142, 143,
+                   144, 145, 146, 148, 149, 152, 153, 156, 157, 159, 160, 162,
+                   163, 164, 165, 167, 168, 172, 175, 176, 177, 178},
+        },
+    },
+    # LN814 EXCLUIDA (23 torres reales vs 171 vanos pedidos — ver docstring).
+    # Incluye la fila TA independiente 'LN 834/815, S1 y S2 (verde)'.
+    'LN 814/815 y LN 834/815': {
+        'lineas': ['LN815', 'LN834'],
+        'semestres': {
+            'S1': set(range(1, 172)),
+            'S2': {1, 3, 4, 5, 7, 9, 11, 12, 13, 15, 16, 17, 20, 21, 23, 25, 29,
+                   30, 31, 33, 35, 36, 37, 40, 41, 43, 44, 49, 50, 53, 56, 57,
+                   60, 61, 64, 66, 70, 71, 72, 74, 75, 76, 77, 78, 79, 80, 81,
+                   82, 83, 84, 85, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98,
+                   99, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111,
+                   112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123,
+                   124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135,
+                   136, 137, 138, 139, 140, 141, 142, 143, 144, 146, 148, 151,
+                   152, 154, 158, 159, 160, 162, 163, 165, 168, 170, 171},
+            'TA': {76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 101, 102, 103, 104,
+                   105, 106, 107, 108, 109, 110},
+        },
+    },
+    'LN 817/818': {
+        'lineas': ['LN817', 'LN818'],
+        'semestres': {
+            'S1': set(range(1, 176)),
+            'S2': {1, 6, 8, 9, 10, 12, 14, 24, 27, 29, 31, 32, 33, 34, 46, 52,
+                   53, 54, 55, 57, 58, 59, 60, 61, 65, 66, 67, 69, 70, 78, 80,
+                   82, 83, 85, 98, 100, 108, 111, 147, 149, 158, 170, 171},
+        },
+    },
+    'LN 819': {
+        'lineas': ['LN819'],
+        'semestres': {'S1': set(range(1, 141)), 'S2': {2, 3, 18, 21}},
+    },
+    # LN 842: Línea NO EXISTE en BD — BLOQUEADA, excluida por completo (ver
+    # docstring). NO incluida en FILAS_EXCEL.
+    'LN 824/825': {
+        'lineas': ['LN824', 'LN825'],
+        'semestres': {
+            'S1': set(range(1, 46)),
+            'S2': {3, 26, 31, 33, 35, 37, 38, 40, 41},
+        },
+    },
+    'LN 827/828': {
+        'lineas': ['LN827', 'LN828'],
+        'semestres': {
+            'S1': set(range(1, 124)),
+            'S2': {6, 21, 23, 28, 31, 42, 59, 61, 63, 64, 66, 67, 68, 70, 83,
+                   89, 93, 94, 99, 105, 118, 119},
+        },
+    },
+    'LN 829/830': {
+        'lineas': ['LN829', 'LN830'],
+        'semestres': {'S1': set(range(1, 8)), 'S2': {1, 2, 4, 5, 6, 7}},
+    },
+    'LN 5156/5157': {
+        'lineas': ['LN5156', 'LN5157'],
+        # Doble circuito de POSTES. Solo S1 (264 vanos) -- el Excel dice
+        # EXPLÍCITAMENTE "Sin trabajo registrado en S2": NO se crea
+        # VanoSemestre S2 para este par (señal negativa real, no un olvido).
+        'semestres': {'S1': set(range(1, 265))},
+    },
+    # LN 792: Línea NO EXISTE en BD — BLOQUEADA, excluida por completo (ver
+    # docstring). NO incluida en FILAS_EXCEL.
+}
+
+# Fila especial: la única del dataset con sub-grupos etiquetados en S2 (ver
+# parser_spec en importers_b21.py, paso de sub-grupos). S1 y S2 aplican a
+# SUBCONJUNTOS DISTINTOS de líneas dentro de la misma etiqueta-fila del
+# Excel, así que no encaja en la forma uniforme {'lineas': [...], 'semestres':
+# {...}} de FILAS_EXCEL.
+FILA_821_822_826_838 = {
+    'etiqueta': 'LN 821/822, LN 821/826, LN 838/826, LN 822/826',
+    # S1 (rango completo 1-90) solo a LN826 (mejor ajuste, 92 torres reales).
+    's1_lineas': ['LN826'],
+    's1_numeros': set(range(1, 91)),
+    # S2 desglosado por sub-segmento (ver texto original: "(821/822) ...;
+    # (821/826) ...; (838/826) ..."). "(821/822)" se EXCLUYE por completo
+    # (LN821=1 torre, LN822=0 torres reales en BD -- maestro de Torres casi
+    # inexistente, alto riesgo de vanos fantasma).
+    's2_subgrupos': {
+        '821/826': {
+            'lineas': ['LN826'],
+            'numeros': {24, 26, 27, 28, 29, 31, 33, 34, 38, 39, 40, 41, 42, 43,
+                        48, 49, 51, 53, 54, 55, 56, 57, 58, 59, 60, 61, 64, 65,
+                        66, 67, 68, 69, 71, 73, 75, 77, 78, 83, 85, 86, 87, 88,
+                        89},
+        },
+        '838/826': {
+            'lineas': ['LN838'],
+            'numeros': {13, 21, 22, 31},
+        },
+        # '821/822': EXCLUIDO — LN821/LN822 fuera de scope (ver docstring).
+    },
+}
+
+
+def _sincronizar_y_cargar_semestre(Linea, linea_codigo, semestre, numeros, resumen):
+    """Resuelve 1 código de Línea, materializa los Vano faltantes con
+    ``sincronizar_vanos_set`` y crea/asegura VanoSemestre (idempotente,
+    ``get_or_create``) para cada número. Acumula contadores en ``resumen``
+    (dict mutable) en vez de retornarlos — se llama muchas veces en el loop
+    principal."""
+    from apps.lineas.models import Vano, VanoSemestre
+
+    if not numeros:
+        return
+    try:
+        linea = Linea.objects.get(codigo=linea_codigo)
+    except Linea.DoesNotExist:
+        resumen['fallidas'].append(
+            f"{linea_codigo}/{semestre}: Linea no existe en BD (revisar mapeo)"
+        )
+        return
+
+    linea.sincronizar_vanos_set(numeros)
+
+    vanos_por_numero = {
+        v.numero: v.id
+        for v in Vano.objects.filter(linea=linea, numero__in=[str(n) for n in numeros])
+    }
+    for n in sorted(numeros):
+        vano_id = vanos_por_numero.get(str(n))
+        if vano_id is None:
+            # Defensivo — no debería pasar, se acaba de sincronizar.
+            resumen['fallidas'].append(
+                f"{linea_codigo}/{semestre}: vano {n} no se materializó (inesperado)"
+            )
+            continue
+        _, created = VanoSemestre.objects.get_or_create(
+            vano_id=vano_id,
+            semestre=semestre,
+            defaults={'estado': 'pendiente'},
+        )
+        if created:
+            resumen['creados'] += 1
+        else:
+            resumen['existentes'] += 1
+
+
+def cargar_vanos_semestre(apps, schema_editor):
+    # Se usan los modelos REALES (no `apps.get_model`) — ver nota de diseño
+    # en el docstring del módulo: se necesita `sincronizar_vanos_set`, que
+    # los modelos históricos de `apps.get_model` no exponen.
+    from apps.lineas.models import Linea
+
+    resumen = {'creados': 0, 'existentes': 0, 'fallidas': []}
+
+    for _etiqueta, datos in FILAS_EXCEL.items():
+        for linea_codigo in datos['lineas']:
+            for semestre, numeros in datos['semestres'].items():
+                _sincronizar_y_cargar_semestre(
+                    Linea, linea_codigo, semestre, numeros, resumen
+                )
+
+    # Fila especial multi-subgrupo (821/822/826/838).
+    for linea_codigo in FILA_821_822_826_838['s1_lineas']:
+        _sincronizar_y_cargar_semestre(
+            Linea, linea_codigo, 'S1', FILA_821_822_826_838['s1_numeros'], resumen
+        )
+    for _sub_etiqueta, sub in FILA_821_822_826_838['s2_subgrupos'].items():
+        for linea_codigo in sub['lineas']:
+            _sincronizar_y_cargar_semestre(
+                Linea, linea_codigo, 'S2', sub['numeros'], resumen
+            )
+
+    print(
+        f"\n[0017_carga_vanos_semestre_completa] VanoSemestre creados={resumen['creados']} "
+        f"existentes={resumen['existentes']} fallidas={len(resumen['fallidas'])}"
+    )
+    for f in resumen['fallidas']:
+        print(f"  - {f}")
+
+
+def revertir_vanos_semestre(apps, schema_editor):
+    """Reversa: elimina SOLO los VanoSemestre (vano, semestre) que esta
+    migración es responsable de crear — re-derivados de las mismas
+    ``FILAS_EXCEL``/``FILA_821_822_826_838`` de arriba, no por un flag de
+    "creado por esta migración" (el modelo no tiene uno).
+
+    NO toca la tabla `vanos`: los Vano materializados por
+    `sincronizar_vanos_set` quedan (pueden ser reusados por trabajo futuro,
+    incluida la propia re-ejecución de esta migración) — mismo criterio no
+    destructivo documentado en 0016_vano_historial_backfill.
+
+    Nota: si algo AJENO a esta migración crease independientemente un
+    VanoSemestre idéntico (mismo vano+semestre) entre el forward y el
+    reverse, quedaría también borrado — edge case aceptado y documentado,
+    no hay forma de distinguirlo sin un campo de proveniencia dedicado.
+    """
+    from apps.lineas.models import VanoSemestre
+
+    def _borrar(linea_codigo, semestre, numeros):
+        if not numeros:
+            return
+        VanoSemestre.objects.filter(
+            vano__linea__codigo=linea_codigo,
+            vano__numero__in=[str(n) for n in numeros],
+            semestre=semestre,
+        ).delete()
+
+    for _etiqueta, datos in FILAS_EXCEL.items():
+        for linea_codigo in datos['lineas']:
+            for semestre, numeros in datos['semestres'].items():
+                _borrar(linea_codigo, semestre, numeros)
+
+    for linea_codigo in FILA_821_822_826_838['s1_lineas']:
+        _borrar(linea_codigo, 'S1', FILA_821_822_826_838['s1_numeros'])
+    for sub in FILA_821_822_826_838['s2_subgrupos'].values():
+        for linea_codigo in sub['lineas']:
+            _borrar(linea_codigo, 'S2', sub['numeros'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('lineas', '0016_vano_historial_backfill'),
+    ]
+
+    operations = [
+        migrations.RunPython(cargar_vanos_semestre, revertir_vanos_semestre),
+    ]

--- a/apps/lineas/models_base.py
+++ b/apps/lineas/models_base.py
@@ -240,6 +240,52 @@ class Linea(BaseModel):
             Vano.objects.bulk_create(nuevos, batch_size=500, ignore_conflicts=True)
         return len(nuevos)
 
+    def sincronizar_vanos_set(self, numeros):
+        """Materializa filas ``Vano`` para un ``set``/iterable arbitrario de
+        números de esta línea (no solo ``range(1, N+1)``).
+
+        Generaliza ``sincronizar_vanos`` (#101, que solo soporta "primeros N
+        vanos consecutivos") para #102: la lista REAL de vanos por semestre
+        que reportó el cliente no es necesariamente contigua desde 1 (ej.
+        LN734 S2 arranca en 3, o LN842 S1 es el rango 141-240). Mismo patrón
+        idempotente y NO destructivo que ``sincronizar_vanos``: solo crea los
+        vanos faltantes (``bulk_create`` + ``ignore_conflicts``, respeta el
+        mismo tope defensivo ``MAX_VANOS_AUTOGENERADOS``), nunca borra ni
+        modifica vanos existentes.
+
+        Args:
+            numeros: iterable de enteros positivos (números de vano a
+                asegurar que existan). Valores no convertibles a ``int``
+                positivo se ignoran silenciosamente (mismo criterio laxo que
+                ``sincronizar_vanos`` para entradas inválidas).
+
+        Devuelve la cantidad de vanos efectivamente creados.
+        """
+        limpios = set()
+        for n in numeros or ():
+            try:
+                iv = int(n)
+            except (TypeError, ValueError):
+                continue
+            if iv > 0:
+                limpios.add(iv)
+        if not limpios:
+            return 0
+        if len(limpios) > self.MAX_VANOS_AUTOGENERADOS:
+            # Tope defensivo — mismo criterio que sincronizar_vanos: nunca
+            # materializar más de MAX_VANOS_AUTOGENERADOS de una sola vez.
+            limpios = set(sorted(limpios)[: self.MAX_VANOS_AUTOGENERADOS])
+
+        existentes = set(self.vanos.values_list('numero', flat=True))
+        nuevos = [
+            Vano(linea=self, numero=str(n))
+            for n in limpios
+            if str(n) not in existentes
+        ]
+        if nuevos:
+            Vano.objects.bulk_create(nuevos, batch_size=500, ignore_conflicts=True)
+        return len(nuevos)
+
 
 class Torre(BaseModel):
     """

--- a/apps/lineas/tests_issue_102.py
+++ b/apps/lineas/tests_issue_102.py
@@ -1,0 +1,358 @@
+"""
+Tests #102 (bounce=2, FIX_INCOMPLETO) — Parser de texto libre español para
+listas/rangos de vanos, resolución de Línea(s) por etiqueta del Excel real,
+``Linea.sincronizar_vanos_set`` y la migración de datos versionada 0017.
+
+Convención: flat file ``tests_issue_102.py`` (mismo patrón que
+``tests_b21.py``/``tests_vanos_sync.py`` — TestCase de Django, runnable con
+``python manage.py test apps.lineas.tests_issue_102``). La app ``lineas``
+también tiene un paquete ``tests/`` (``test_issue_177.py``,
+``test_issue_182.py``) pero esos usan clases ``@pytest.mark.django_db`` NO
+discoverables por ``manage.py test`` (unittest discovery real) — se prefiere
+el patrón flat+TestCase, consistente con el resto de B2.1.
+
+Cubre:
+- parse_vano_list: rango simple, rango con offset (no arranca en 1, caso
+  LN842), lista explícita con "y", caso no-contiguo (LN734), tokens
+  no-numéricos descartados (no fatal), sub-grupos etiquetados (";"+"(...)"),
+  CASOS_ESPECIALES (LN807/808 S1), fail-loud (VanoParseError) sin override.
+- MAPEO_EXCEL_A_LINEAS / _resolver_lineas: doble circuito -> 2 Líneas,
+  etiqueta bloqueada -> lista vacía, exclusiones documentadas ausentes.
+- Linea.sincronizar_vanos_set: idempotencia, no-destructivo, set arbitrario
+  no contiguo, cap MAX_VANOS_AUTOGENERADOS, entradas inválidas.
+- Migración 0017 (invocada directo, no vía `migrate`): dato legacy real
+  LN5114 (100 Vano preexistentes de #101) no se rompe ni duplica.
+"""
+
+import importlib.util
+import os
+
+from django.test import TestCase
+
+from apps.lineas.importers_b21 import (
+    CASOS_ESPECIALES,
+    MAPEO_EXCEL_A_LINEAS,
+    VanoParseError,
+    _resolver_lineas,
+    parse_vano_list,
+)
+from apps.lineas.models import Linea, Vano
+from apps.lineas.models_b21 import VanoSemestre
+
+
+def _linea(codigo, nombre=None):
+    return Linea.objects.create(
+        codigo=codigo,
+        nombre=nombre or f"Test {codigo}",
+        cliente=Linea.Cliente.TRANSELCA,
+    )
+
+
+class TestParseVanoListRangoYLista(TestCase):
+    """Casos "normales": rango simple y lista explícita."""
+
+    def test_rango_simple_1_al_n(self):
+        self.assertEqual(parse_vano_list("1 al 104"), set(range(1, 105)))
+
+    def test_rango_simple_variantes_de_texto(self):
+        # "1 a 104", "1 a la 35", "3 a 11" — todas variantes reales del Excel.
+        self.assertEqual(parse_vano_list("1 a 104"), set(range(1, 105)))
+        self.assertEqual(parse_vano_list("1 a la 35"), set(range(1, 36)))
+        self.assertEqual(parse_vano_list("3 a 11"), set(range(3, 12)))
+
+    def test_rango_con_offset_no_arranca_en_1_caso_ln842(self):
+        # LN842 (bloqueada por Linea inexistente, pero el PARSER en sí debe
+        # poder con el texto: "141 a la 240").
+        self.assertEqual(parse_vano_list("141 a la 240"), set(range(141, 241)))
+
+    def test_lista_explicita_con_y(self):
+        self.assertEqual(
+            parse_vano_list("2, 3, 4, 5, 7, 12, 16 y 17"),
+            {2, 3, 4, 5, 7, 12, 16, 17},
+        )
+
+    def test_caso_no_contiguo_ln734(self):
+        # LN734 S2: arranca en 3, con huecos (no incluye 5, 7, 10, 11...).
+        texto = (
+            "3, 4, 6, 8, 9, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, "
+            "24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34 y 35"
+        )
+        resultado = parse_vano_list(texto)
+        self.assertEqual(len(resultado), 29)
+        self.assertNotIn(5, resultado)
+        self.assertNotIn(7, resultado)
+        self.assertIn(3, resultado)
+        self.assertIn(35, resultado)
+
+    def test_tokens_no_numericos_se_descartan_sin_fallar(self):
+        # LN805 S2 trae "S/E Sabana Portico" mezclado con números reales.
+        texto = "S/E Sabana Portico, 1, 2, 5"
+        resultado = parse_vano_list(texto)
+        self.assertEqual(resultado, {1, 2, 5})
+
+    def test_sufijo_postes_se_ignora(self):
+        # LN5156/5157: "1 al 264 postes".
+        self.assertEqual(parse_vano_list("1 al 264 postes"), set(range(1, 265)))
+
+
+class TestParseVanoListSubgrupos(TestCase):
+    """Caso ambiguo: sub-grupos etiquetados con ';' + '(...)' (único caso
+    real del dataset: LN 821/822, LN 821/826, LN 838/826, LN 822/826 S2)."""
+
+    def test_subgrupos_etiquetados_devuelve_dict(self):
+        texto = "(821/822) 5, 7, 10 y 23; (838/826) 13, 21, 22 y 31"
+        resultado = parse_vano_list(texto)
+        self.assertIsInstance(resultado, dict)
+        self.assertEqual(set(resultado.keys()), {"821/822", "838/826"})
+        self.assertEqual(resultado["821/822"], {5, 7, 10, 23})
+        self.assertEqual(resultado["838/826"], {13, 21, 22, 31})
+
+    def test_subgrupo_no_reconocido_falla_ruidoso(self):
+        with self.assertRaises(VanoParseError):
+            parse_vano_list("(821/822) 5, 7; sin-parentesis 10 y 23")
+
+
+class TestParseVanoListCasoAmbiguo807808(TestCase):
+    """Caso ambiguo LN807/808 S1 — texto irresoluble por regex puro, override
+    manual vía CASOS_ESPECIALES."""
+
+    def test_texto_literal_807_808_s1_usa_caso_especial(self):
+        texto = "Torre 5 (propiedad EEB) a la 42 y de la 42 a la 148"
+        resultado = parse_vano_list(texto, etiqueta_excel="LN 807/808", semestre="S1")
+        self.assertEqual(resultado, set(range(5, 113)))
+        self.assertEqual(len(resultado), 108)
+
+    def test_caso_especial_esta_documentado_en_el_dict(self):
+        self.assertIn(("LN 807/808", "S1"), CASOS_ESPECIALES)
+
+    def test_mismo_texto_sin_etiqueta_semestre_falla_ruidoso(self):
+        # Sin (etiqueta_excel, semestre) no hay match en CASOS_ESPECIALES —
+        # debe fallar ruidoso, NUNCA devolver set vacío en silencio.
+        texto = "Torre 5 (propiedad EEB) a la 42 y de la 42 a la 148"
+        with self.assertRaises(VanoParseError):
+            parse_vano_list(texto)
+
+
+class TestParseVanoListFailLoud(TestCase):
+    """Fail-loud: nunca set vacío silencioso."""
+
+    def test_texto_vacio_falla(self):
+        with self.assertRaises(VanoParseError):
+            parse_vano_list("")
+
+    def test_texto_none_falla(self):
+        with self.assertRaises(VanoParseError):
+            parse_vano_list(None)
+
+    def test_texto_solo_no_numerico_falla(self):
+        with self.assertRaises(VanoParseError):
+            parse_vano_list("S/E Sabana Portico, Torre 5 (propiedad EEB)")
+
+
+class TestMapeoExcelALineas(TestCase):
+    """MAPEO_EXCEL_A_LINEAS documenta doble-circuito y bloqueos/exclusiones."""
+
+    def test_doble_circuito_2_lineas(self):
+        self.assertEqual(MAPEO_EXCEL_A_LINEAS["LN 764/765"], ["LN764", "LN765"])
+
+    def test_lineas_bloqueadas_lista_vacia(self):
+        self.assertEqual(MAPEO_EXCEL_A_LINEAS["LN 842"], [])
+        self.assertEqual(MAPEO_EXCEL_A_LINEAS["LN 792"], [])
+
+    def test_exclusiones_confianza_baja_ausentes_del_grupo(self):
+        # LN813 excluida del grupo 811/812/813 (desproporción severa).
+        self.assertNotIn("LN813", MAPEO_EXCEL_A_LINEAS["LN 811/812 y LN 812/813"])
+        # LN814 excluida del grupo 814/815/834.
+        self.assertNotIn("LN814", MAPEO_EXCEL_A_LINEAS["LN 814/815 y LN 834/815"])
+        # LN821/LN822 excluidas del grupo 821/822/826/838 (torres≈0 en BD).
+        grupo_821 = MAPEO_EXCEL_A_LINEAS["LN 821/822, LN 821/826, LN 838/826, LN 822/826"]
+        self.assertNotIn("LN821", grupo_821)
+        self.assertNotIn("LN822", grupo_821)
+
+
+class TestResolverLineas(TestCase):
+    def test_resuelve_doble_circuito_a_2_lineas(self):
+        _linea("LN764")
+        _linea("LN765")
+        lineas = _resolver_lineas("LN 764/765")
+        self.assertEqual({ln.codigo for ln in lineas}, {"LN764", "LN765"})
+
+    def test_etiqueta_bloqueada_devuelve_lista_vacia(self):
+        self.assertEqual(_resolver_lineas("LN 842"), [])
+
+    def test_etiqueta_no_mapeada_devuelve_lista_vacia(self):
+        self.assertEqual(_resolver_lineas("LN 99999"), [])
+
+    def test_codigo_mapeado_pero_ausente_en_bd_se_omite(self):
+        # LN764 mapeada pero no creada en BD -> se omite (no crashea).
+        _linea("LN765")
+        lineas = _resolver_lineas("LN 764/765")
+        self.assertEqual({ln.codigo for ln in lineas}, {"LN765"})
+
+
+class TestSincronizarVanosSet(TestCase):
+    """Generaliza sincronizar_vanos (#101) a un set arbitrario no contiguo."""
+
+    def test_crea_set_no_contiguo(self):
+        linea = _linea("L-102A")
+        creados = linea.sincronizar_vanos_set({2, 3, 4, 5, 7, 12, 16, 17})
+        self.assertEqual(creados, 8)
+        self.assertEqual(linea.vanos.count(), 8)
+        numeros = set(linea.vanos.values_list("numero", flat=True))
+        self.assertEqual(numeros, {"2", "3", "4", "5", "7", "12", "16", "17"})
+
+    def test_rango_con_offset(self):
+        # Caso LN842: "141 a la 240" — NO debe crear vanos 1..140.
+        linea = _linea("L-102B")
+        creados = linea.sincronizar_vanos_set(set(range(141, 241)))
+        self.assertEqual(creados, 100)
+        self.assertEqual(linea.vanos.count(), 100)
+        self.assertFalse(linea.vanos.filter(numero="1").exists())
+        self.assertTrue(linea.vanos.filter(numero="141").exists())
+        self.assertTrue(linea.vanos.filter(numero="240").exists())
+
+    def test_idempotente(self):
+        linea = _linea("L-102C")
+        self.assertEqual(linea.sincronizar_vanos_set({1, 2, 3}), 3)
+        # Segunda corrida con el MISMO set: 0 nuevos, sin duplicados.
+        self.assertEqual(linea.sincronizar_vanos_set({1, 2, 3}), 0)
+        self.assertEqual(linea.vanos.count(), 3)
+
+    def test_ampliar_solo_crea_faltantes(self):
+        linea = _linea("L-102D")
+        linea.sincronizar_vanos_set({1, 2, 3})
+        creados = linea.sincronizar_vanos_set({2, 3, 4, 5})
+        self.assertEqual(creados, 2)  # solo 4 y 5 son nuevos
+        self.assertEqual(linea.vanos.count(), 5)
+
+    def test_no_destructivo_preserva_estado(self):
+        linea = _linea("L-102E")
+        linea.sincronizar_vanos_set({1, 2, 3})
+        v = linea.vanos.get(numero="2")
+        v.estado = Vano.Estado.EJECUTADO
+        v.save(update_fields=["estado"])
+        linea.sincronizar_vanos_set({1, 2, 3})  # re-run
+        self.assertEqual(linea.vanos.get(numero="2").estado, Vano.Estado.EJECUTADO)
+
+    def test_cap_max_autogenerados(self):
+        linea = _linea("L-102F")
+        numeros = set(range(1, Linea.MAX_VANOS_AUTOGENERADOS + 501))
+        creados = linea.sincronizar_vanos_set(numeros)
+        self.assertEqual(creados, Linea.MAX_VANOS_AUTOGENERADOS)
+        self.assertEqual(linea.vanos.count(), Linea.MAX_VANOS_AUTOGENERADOS)
+
+    def test_entradas_invalidas_se_ignoran(self):
+        linea = _linea("L-102G")
+        creados = linea.sincronizar_vanos_set({1, "abc", None, -5, 0, 2})
+        self.assertEqual(creados, 2)
+        self.assertEqual(linea.vanos.count(), 2)
+
+    def test_set_vacio_devuelve_cero(self):
+        linea = _linea("L-102H")
+        self.assertEqual(linea.sincronizar_vanos_set(set()), 0)
+        self.assertEqual(linea.sincronizar_vanos_set(None), 0)
+
+
+class TestMigracion0017CargaVanosSemestre(TestCase):
+    """
+    Invoca la función RunPython de la migración 0017 directamente (no vía
+    ``manage.py migrate`` — la suite corre con ``--nomigrations``/BD SQLite
+    efímera por test; invocar la función a mano sobre los modelos REALES ya
+    creados en `setUp` es equivalente y más rápido). Cubre el requisito de
+    "test contra dato legacy real": LN5114 con 100 Vano preexistentes (como
+    en prod, #101) no se rompe ni duplica.
+    """
+
+    @classmethod
+    def _cargar_funcion_migracion(cls):
+        ruta = os.path.join(
+            os.path.dirname(__file__),
+            "migrations",
+            "0017_carga_vanos_semestre_completa.py",
+        )
+        spec = importlib.util.spec_from_file_location("mig_0017_test", ruta)
+        modulo = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(modulo)
+        return modulo
+
+    def setUp(self):
+        self.mig = self._cargar_funcion_migracion()
+        # Dato legacy real: LN5114 con 100 Vano preexistentes (numero 1..100),
+        # igual que en prod tras #101.
+        self.ln5114 = _linea("LN5114")
+        Vano.objects.bulk_create([Vano(linea=self.ln5114, numero=str(i)) for i in range(1, 101)])
+        # Resto de líneas usadas por el subconjunto de filas que ejercito
+        # en este test (no las 35 completas — cubierto end-to-end contra
+        # SQLite real durante el desarrollo de F3, ver JSON de salida).
+        for codigo in ("LN733", "LN5156", "LN5157", "LN826", "LN838"):
+            _linea(codigo)
+
+    def test_dato_legacy_ln5114_no_se_rompe_ni_duplica(self):
+        self.mig.cargar_vanos_semestre(None, None)
+
+        self.ln5114.refresh_from_db()
+        # 104 vanos totales: 100 preexistentes + 4 nuevos (101-104, S1='1 al 104').
+        self.assertEqual(self.ln5114.vanos.count(), 104)
+        # El vano #1 preexistente sigue siendo el mismo registro (no duplicado).
+        self.assertEqual(self.ln5114.vanos.filter(numero="1").count(), 1)
+        s1_count = VanoSemestre.objects.filter(vano__linea=self.ln5114, semestre="S1").count()
+        self.assertEqual(s1_count, 104)
+
+    def test_discriminante_ln733_s1_vs_s2(self):
+        self.mig.cargar_vanos_semestre(None, None)
+        linea = Linea.objects.get(codigo="LN733")
+        s1 = VanoSemestre.objects.filter(vano__linea=linea, semestre="S1").count()
+        s2 = VanoSemestre.objects.filter(vano__linea=linea, semestre="S2").count()
+        self.assertEqual(s1, 18)
+        self.assertEqual(s2, 8)
+        self.assertNotEqual(s1, s2)
+
+    def test_ln5156_5157_s1_sin_s2_senal_negativa(self):
+        # "Sin trabajo registrado en S2" -- NO debe crear VanoSemestre S2.
+        self.mig.cargar_vanos_semestre(None, None)
+        ln5156 = Linea.objects.get(codigo="LN5156")
+        ln5157 = Linea.objects.get(codigo="LN5157")
+        self.assertEqual(
+            VanoSemestre.objects.filter(vano__linea=ln5156, semestre="S1").count(), 264
+        )
+        self.assertEqual(VanoSemestre.objects.filter(vano__linea=ln5156, semestre="S2").count(), 0)
+        self.assertEqual(
+            VanoSemestre.objects.filter(vano__linea=ln5157, semestre="S1").count(), 264
+        )
+
+    def test_subgrupo_821_826_838_826_no_mezcla_lineas(self):
+        # S1 solo LN826; S2 desglosado (LN826 sub-segmento 821/826, LN838
+        # sub-segmento 838/826), sub-segmento 821/822 EXCLUIDO por completo.
+        self.mig.cargar_vanos_semestre(None, None)
+        ln826 = Linea.objects.get(codigo="LN826")
+        ln838 = Linea.objects.get(codigo="LN838")
+        self.assertEqual(VanoSemestre.objects.filter(vano__linea=ln826, semestre="S1").count(), 90)
+        self.assertEqual(VanoSemestre.objects.filter(vano__linea=ln826, semestre="S2").count(), 43)
+        self.assertEqual(VanoSemestre.objects.filter(vano__linea=ln838, semestre="S1").count(), 0)
+        self.assertEqual(VanoSemestre.objects.filter(vano__linea=ln838, semestre="S2").count(), 4)
+
+    def test_idempotente_re_ejecutar_no_duplica(self):
+        self.mig.cargar_vanos_semestre(None, None)
+        primero = VanoSemestre.objects.count()
+        self.mig.cargar_vanos_semestre(None, None)
+        segundo = VanoSemestre.objects.count()
+        self.assertEqual(primero, segundo)
+
+    def test_linea_bloqueada_no_crashea_la_migracion_completa(self):
+        # LN842/LN792 no están en FILAS_EXCEL -- no deberían generar ningún
+        # intento de resolución. El resto de líneas SÍ deben cargar bien
+        # (la migración no aborta por completo ante bloqueos).
+        self.mig.cargar_vanos_semestre(None, None)  # no debe lanzar excepción
+        self.assertGreater(VanoSemestre.objects.count(), 0)
+
+    def test_reverse_borra_solo_vanosemestre_no_vanos(self):
+        self.mig.cargar_vanos_semestre(None, None)
+        total_vanos_antes = Vano.objects.count()
+        self.assertGreater(VanoSemestre.objects.count(), 0)
+
+        self.mig.revertir_vanos_semestre(None, None)
+
+        self.assertEqual(VanoSemestre.objects.count(), 0)
+        # No destructivo: los Vano materializados quedan (incluidos los 100
+        # preexistentes de LN5114 + los nuevos que la migración creó).
+        self.assertEqual(Vano.objects.count(), total_vanos_antes)


### PR DESCRIPTION
## Refs #102 (bounce=2, FIX_INCOMPLETO)

Corrección autónoma completa (F1 a F3 + 90 tests OK) — **DEPLOY GATE lo detuvo para tu revisión**, ver abajo.

### Qué hace
1. **`apps/campo/views.py`** — cablea el filtro `?semestre=S1|S2|TA` del grid de `RegistroAvanceCreateView` (estaba en el template pero nunca conectado al backend). Backward-compatible: sin el parámetro, comportamiento idéntico al actual.
2. **`apps/lineas/importers_b21.py`** — nuevo parser `parse_vano_list` que lee la LISTA REAL de vanos por línea/semestre del Excel del cliente (att_01.xlsx), reemplazando la heurística "primeros N vanos" que causó el bounce.
3. **`apps/lineas/migrations/0017_carga_vanos_semestre_completa.py`** — migración de datos que carga ~5600 VanoSemestre para 22/24 filas del Excel (35 líneas). LN842/LN792 quedan bloqueadas (línea no existe en BD, no se inventa stub).

### Por qué el DEPLOY GATE lo frenó (probable falso positivo — pido tu OK)
`deploy_gate.py` (detección mecánica #181) marcó HOLD porque el diff de `apps/lineas/tests_issue_102.py` contiene la frase **"Invoca la función RunPython de la migración 0017 directamente"** — pero esa línea es un **docstring de una clase de test** (`TestMigracion0017CargaVanosSemestre`), no código ejecutable. El test carga la función de la migración vía `importlib` para probarla contra la BD de test (SQLite/Postgres efímera), **nunca contra prod**. El gate ya exime comentarios `#` y docstrings de una sola línea (patrón anterior, Coditeq issue 58) pero no cubre docstrings **multi-línea** — gap agregado a BACKLOG.md del skill multiagente.

El cambio real que toca BD es la **migración 0017**, que por política ya deploya autónoma (auto-migrate en el deploy, red = E2E post-deploy) — no requiere aprobación por sí sola. Si estás de acuerdo con el análisis, este PR puede mergearse y desplegarse igual que cualquier intervención con migración.

### Evidencia
- Self-verify: checks a/b/c (`manage.py check`, `makemigrations --check`, `migrate --plan`) limpios.
- `manage.py test apps.lineas apps.campo` → **90/90 tests OK** (4.17s).
- `migrate --plan` confirma la migración 0017 aplica limpio (Raw Python operation).
- Journey E2E ya preparado (`Instelec_102.yaml`) para F5 post-deploy.

### Reproceso (bounce=2)
La intervención anterior (issue 101, migración 0011) solo cargó LN5114 (100 vanos, conteo en vez de lista real). Esta corrección usa la lista REAL del Excel y corrige además el gap de diseño en `_asignar_semestre` (no soportaba rangos no contiguos).

Refs #102 — sin closing keywords (deploy y cierre los maneja Indunnova tras tu OK).