### PR TITLE
fix(pagos): portal de pagos sin estilos — Bootstrap nunca se cargaba

### DIFF
--- a/apps/pagos/tests_issue_195.py
+++ b/apps/pagos/tests_issue_195.py
@@ -144,3 +144,39 @@ class WebhookYaEstabaAprobadoTests(TestCase):
             'pago que ya estaba APROBADO — falta el guard ya_estaba_aprobado.'
         )
         self.assertEqual(Pago.objects.filter(wompi_transaction_id='TX-WEBHOOK-1').count(), 1)
+
+
+class PortalCargaEstilosBootstrapTests(TestCase):
+    """Reproceso #195 (bounce): el hardening de backend quedó validado, pero
+    los templates de /pagos/ usan clases Bootstrap 5 (card, badge, btn...)
+    sin que Bootstrap CSS se cargara nunca -- base.html solo declaraba
+    `extra_head`, no `extra_css` (el bloque de portal.html quedaba huérfano
+    y Django lo descartaba en silencio). Ver PLAN F2 (RUN_2026-08-07_0220)."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email='qa_pagos_195_css@test.com', password='x', rol='admin',
+        )
+        self.plan = PlanServicio.objects.create(nombre='Plan QA', precio=Decimal('150000'))
+        Suscripcion.objects.create(plan=self.plan, estado='PENDIENTE')
+        self.client.force_login(self.user)
+
+    def _assert_bootstrap_cargado(self, url):
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        html = resp.content.decode()
+        self.assertIn('bootstrap@5.3.3/dist/css/bootstrap.min.css', html)
+        self.assertIn('bootstrap-icons@1.11.3', html)
+
+    def test_portal_carga_bootstrap(self):
+        self._assert_bootstrap_cargado(reverse('pagos:portal'))
+
+    def test_portal_carga_driver_js_css_bloque_ya_no_huerfano(self):
+        resp = self.client.get(reverse('pagos:portal'))
+        self.assertIn('driver.js@1.3.1/dist/driver.css', resp.content.decode())
+
+    def test_historial_carga_bootstrap(self):
+        self._assert_bootstrap_cargado(reverse('pagos:historial'))
+
+    def test_facturacion_carga_bootstrap(self):
+        self._assert_bootstrap_cargado(reverse('pagos:facturacion'))

--- a/templates/base.html
+++ b/templates/base.html
@@ -92,6 +92,7 @@
         }
     </style>
 
+    {% block extra_css %}{% endblock %}
     {% block extra_head %}{% endblock %}
 </head>
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100" hx-ext="loading-states" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>

--- a/templates/pagos/datos_facturacion.html
+++ b/templates/pagos/datos_facturacion.html
@@ -3,6 +3,11 @@
 
 {% block title %}Datos de Facturacion - Instelec{% endblock %}
 
+{% block extra_css %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+{% endblock %}
+
 {% block content %}
 <div class="row justify-content-center">
     <div class="col-lg-8">

--- a/templates/pagos/historial.html
+++ b/templates/pagos/historial.html
@@ -3,6 +3,11 @@
 
 {% block title %}Historial de Pagos - Instelec{% endblock %}
 
+{% block extra_css %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+{% endblock %}
+
 {% block content %}
 <div class="container">
     <div class="d-flex justify-content-between align-items-center mb-4">

--- a/templates/pagos/portal.html
+++ b/templates/pagos/portal.html
@@ -4,6 +4,8 @@
 {% block title %}Portal de Pagos - Instelec{% endblock %}
 
 {% block extra_css %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/driver.js@1.3.1/dist/driver.css">
 {% endblock %}
 


### PR DESCRIPTION
## Resumen
Reproceso #195: el hardening de backend (2026-07-30) quedó bien validado, pero el rebote del cliente es sobre el render visual — el portal de pagos se ve como texto plano.

Root cause: los templates de `apps/pagos` usan clases Bootstrap 5 pero `base.html` solo carga Tailwind. Confirmado con curl autenticado contra prod: 0 referencias a "bootstrap" en el HTML servido de las 3 vistas. Bug secundario del mismo origen: `portal.html` declaraba `{% block extra_css %}` que `base.html` nunca definía — se descartaba en silencio (tampoco cargaba el CSS del tour).

Fix CSS-only vía CDN, scoped a los 3 templates de pagos (no toca el resto del portafolio Tailwind-only).

Refs #195

## Test plan
- [x] 4 tests nuevos (`PortalCargaEstilosBootstrapTests`) — confirman que las 3 vistas sirven el link de Bootstrap y que el bloque de driver.js ya no es huérfano.
- [x] Suite completa `apps/pagos/` — 69/69 verde.