### PR TITLE
feat(cuadrillas): exportar nómina por rango de fechas + duplicar desde cualquier semana

### DIFF
--- a/apps/actividades/exporters.py
+++ b/apps/actividades/exporters.py
@@ -352,11 +352,60 @@ class ProgramacionSemanalHorizontalExporter:
         Returns:
             BytesIO con el contenido del .xlsx
         """
-        from apps.cuadrillas.views_semanal import _bloque_a_dict, _bloques_qs
+        from apps.cuadrillas.views_semanal import _bloques_qs
+
+        return self._escribir_hoja(_bloques_qs(anio, semana), f"Sem {semana:02d}-{anio}")
+
+    def generar_excel_rango(self, fecha_inicio, fecha_fin):
+        """
+        Genera un ÚNICO Excel horizontal consolidando TODAS las cuadrillas
+        (bloques) activas cuya ``fecha`` cae dentro de ``[fecha_inicio,
+        fecha_fin]`` (rango de fechas calendario arbitrario, sin importar a
+        qué semana ISO pertenece cada una) -- issue #211.
+
+        A diferencia de ``generar_excel`` (que filtra por prefijo de código
+        ``WW-YYYY-``, una semana ISO por vez), este método consulta
+        ``Cuadrilla`` directo por su campo ``fecha`` propio, así que un rango
+        que cruza 2+ semanas ISO trae TODOS los bloques en un solo archivo.
+
+        Args:
+            fecha_inicio: date
+            fecha_fin: date
+
+        Returns:
+            BytesIO con el contenido del .xlsx
+        """
+        from apps.cuadrillas.models import Cuadrilla
+
+        cuadrillas_qs = (
+            Cuadrilla.objects.filter(
+                fecha__gte=fecha_inicio, fecha__lte=fecha_fin, activa=True
+            )
+            .select_related(
+                "linea_asignada",
+                "vehiculo",
+                "supervisor",
+                "tipo_actividad",
+                "tramo",
+                "reprogramado_desde",
+            )
+            .prefetch_related("miembros__usuario", "miembros__rol_cuadrilla")
+            .order_by("fecha", "codigo")
+        )
+        titulo = f"{fecha_inicio:%d-%m} a {fecha_fin:%d-%m}"
+        return self._escribir_hoja(cuadrillas_qs, titulo)
+
+    def _escribir_hoja(self, cuadrillas_qs, titulo_hoja):
+        """Helper compartido: escribe headers + itera ``cuadrillas_qs`` (vía
+        ``_bloque_a_dict``/``_escribir_bloque``) + ajusta column_widths.
+        Extraído de ``generar_excel`` (issue #211) para que
+        ``generar_excel_rango`` reuse el MISMO layout ya validado por el
+        cliente sin duplicar HEADERS/estilos/anchos de columna."""
+        from apps.cuadrillas.views_semanal import _bloque_a_dict
 
         self.workbook = Workbook()
         self.sheet = self.workbook.active
-        self.sheet.title = f"Sem {semana:02d}-{anio}"[:31]
+        self.sheet.title = titulo_hoja[:31]
 
         for col_idx, header in enumerate(self.HEADERS, start=1):
             cell = self.sheet.cell(row=1, column=col_idx, value=header)
@@ -366,7 +415,7 @@ class ProgramacionSemanalHorizontalExporter:
             cell.alignment = Alignment(horizontal="center", vertical="center", wrap_text=True)
 
         row_num = 2
-        for numero, cuadrilla in enumerate(_bloques_qs(anio, semana), start=1):
+        for numero, cuadrilla in enumerate(cuadrillas_qs, start=1):
             b = _bloque_a_dict(cuadrilla)
             row_num = self._escribir_bloque(numero, cuadrilla.fecha_fin, b, row_num)
 

--- a/apps/cuadrillas/tests_issue_178_bc.py
+++ b/apps/cuadrillas/tests_issue_178_bc.py
@@ -233,7 +233,9 @@ class TestC1GridSemanal(TestCase):
         self.assertEqual(resp.status_code, 200)
         html = resp.content.decode()
         self.assertIn("PEDRO PEREZ", html)
-        self.assertIn("Duplicar semana anterior", html)
+        # Issue #207: el botón ya no dice "anterior" (el origen ahora es
+        # elegible vía selector, no fijo a N-1).
+        self.assertIn("Duplicar semana", html)
         self.assertIn("Exportar PDF", html)
 
     def test_grid_semana_vacia_no_500(self):

--- a/apps/cuadrillas/tests_issue_207.py
+++ b/apps/cuadrillas/tests_issue_207.py
@@ -1,0 +1,197 @@
+"""Tests #207 — Duplicar semana: elegir semana base (no solo la anterior).
+
+Issue: Indunnova16/Instelec#207
+
+Basados en los 2 escenarios del journey E2E (SPRINTS/RUN_2026-08-07_0220/
+journeys/Instelec_207.yaml), traducidos a ``TestCase`` reales de Django:
+
+  m1: desde una semana destino vacía, elegir una semana origen que NO es la
+      N-1 (fixture año 2099 -- no toca datos reales) y duplicar directo, sin
+      encadenar.
+  m2: cuando el destino YA tiene programación (pide confirmación), la semana
+      origen elegida debe viajar a través del redirect ``?confirmar_duplicado=1``
+      y del hidden field del form de confirmar -- no perderse y caer de
+      vuelta en el fallback N-1.
+
+Ejecutar:
+  DJANGO_SETTINGS_MODULE=config.settings.dev_lite \
+    venv/bin/python -m pytest apps/cuadrillas/tests_issue_207.py -v \
+    -o python_files="tests_*.py test_*.py"
+"""
+
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from apps.cuadrillas.models import Cuadrilla, CuadrillaMiembro
+
+Usuario = get_user_model()
+
+
+def _crear_admin():
+    return Usuario.objects.create_user(
+        email="admin_207@test.com",
+        password="testpass123!",
+        first_name="Admin",
+        last_name="207",
+        rol="admin",
+        is_staff=True,
+    )
+
+
+def _crear_usuario(documento, nombre):
+    partes = nombre.split(maxsplit=1)
+    return Usuario.objects.create(
+        email=f"{documento}@test.local",
+        documento=documento,
+        first_name=partes[0],
+        last_name=partes[1] if len(partes) > 1 else "",
+        rol="liniero",
+        is_active=True,
+    )
+
+
+def _crear_bloque(codigo, fecha, miembros, nombre="MANTENIMIENTO - 207"):
+    c = Cuadrilla.objects.create(
+        codigo=codigo,
+        nombre=nombre,
+        activa=True,
+        observaciones="",
+        fecha=fecha,
+    )
+    for usuario, cargo, rol_cuadrilla in miembros:
+        CuadrillaMiembro.objects.create(
+            cuadrilla=c,
+            usuario=usuario,
+            rol_cuadrilla_id=rol_cuadrilla,
+            cargo=cargo,
+            costo_dia=0,
+            fecha_inicio=fecha,
+            activo=True,
+        )
+    return c
+
+
+class TestM1DuplicarSemanaOrigenElegidaSinEncadenar(TestCase):
+    """Escenario m1 del journey: destino vacío (32/2099), origen elegido
+    28/2099 (NO la N-1, que sería 31/2099 y está vacía)."""
+
+    def setUp(self):
+        self.admin = _crear_admin()
+        self.client.force_login(self.admin)
+        self.jefe = _crear_usuario("QA0207M1JEF", "QAE207M1 Jefe")
+
+    def test_duplicar_desde_semana_no_anterior_sin_encadenar(self):
+        _crear_bloque(
+            "28-2099-0001-QAE",
+            date(2099, 7, 8),
+            [(self.jefe, "JT_CTA", "LINIERO_I")],
+            nombre="QA_E2E_207_ORIGEN",
+        )
+
+        # Semana 31/2099 (la N-1 de 32) está vacía a propósito -- el fallback
+        # viejo hubiera fallado acá.
+        resp_destino_vacio = self.client.get(
+            reverse("cuadrillas:semanal_grid", args=[2099, 32])
+        )
+        self.assertEqual(resp_destino_vacio.status_code, 200)
+        self.assertIn("No hay programación cargada", resp_destino_vacio.content.decode())
+        # El selector ofrece la semana 28 como opción de origen.
+        self.assertIn('value="28-2099"', resp_destino_vacio.content.decode())
+
+        resp = self.client.post(
+            reverse("cuadrillas:semanal_duplicar", args=[2099, 32]),
+            {"semana_origen_key": "28-2099"},
+        )
+        self.assertEqual(resp.status_code, 302)
+
+        nueva = Cuadrilla.objects.get(codigo="32-2099-0001-QAE")
+        self.assertEqual(nueva.nombre, "QA_E2E_207_ORIGEN")
+        # Delta real: semana 28 -> semana 32 = 4 semanas ISO = 28 días.
+        self.assertEqual(nueva.fecha, date(2099, 8, 5))
+        self.assertEqual(nueva.miembros.first().fecha_inicio, date(2099, 8, 5))
+
+        resp_final = self.client.get(resp.url)
+        html = resp_final.content.decode()
+        self.assertIn("desde la semana 28/2099", html)
+        self.assertIn("QA_E2E_207_ORIGEN", html)
+
+    def test_sin_semana_origen_key_cae_en_fallback_n_menos_1(self):
+        """Compatibilidad: si el POST no manda `semana_origen_key` (callers
+        viejos), el comportamiento es EXACTAMENTE el histórico (N-1)."""
+        f = date(2026, 3, 16)
+        _crear_bloque(
+            "12-2026-0001-MAN",
+            f,
+            [(self.jefe, "JT_CTA", "LINIERO_I")],
+        )
+        resp = self.client.post(reverse("cuadrillas:semanal_duplicar", args=[2026, 13]))
+        self.assertEqual(resp.status_code, 302)
+        copia = Cuadrilla.objects.get(codigo="13-2026-0001-MAN")
+        self.assertEqual(copia.fecha, date(2026, 3, 23))
+
+
+class TestM2ConfirmarDuplicadoPreservaSemanaOrigenElegida(TestCase):
+    """Escenario m2 del journey: destino (44/2099) YA tiene programación
+    (fuerza confirmación); origen elegido 40/2099 (NO la N-1, 43/2099, que
+    está vacía) debe sobrevivir el paso de confirmación."""
+
+    def setUp(self):
+        self.admin = _crear_admin()
+        self.client.force_login(self.admin)
+        self.jefe = _crear_usuario("QA0207M2JEF", "QAE207M2 Jefe")
+
+    def test_confirmar_preserva_semana_origen_elegida(self):
+        _crear_bloque(
+            "40-2099-0001-QAX",
+            date(2099, 9, 30),
+            [(self.jefe, "JT_CTA", "LINIERO_I")],
+            nombre="QA_E2E_207_M2_ORIGEN",
+        )
+        _crear_bloque(
+            "44-2099-0002-QAX",
+            date(2099, 10, 26),
+            [],
+            nombre="QA_E2E_207_M2_DESTINO_PREVIO",
+        )
+
+        # 1er POST (sin confirmar): destino ya tiene datos -> pide
+        # confirmación, propagando la semana origen ELEGIDA en el redirect.
+        resp1 = self.client.post(
+            reverse("cuadrillas:semanal_duplicar", args=[2099, 44]),
+            {"semana_origen_key": "40-2099"},
+        )
+        self.assertEqual(resp1.status_code, 302)
+        self.assertIn("semana_origen_key=40-2099", resp1.url)
+        self.assertFalse(Cuadrilla.objects.filter(codigo="44-2099-0001-QAX").exists())
+
+        # La página de confirmación (GET siguiendo el redirect) trae el
+        # hidden field con la semana origen elegida, NO la N-1 (43).
+        resp_confirm_page = self.client.get(resp1.url)
+        html_confirm = resp_confirm_page.content.decode()
+        self.assertIn('name="semana_origen_key" value="40-2099"', html_confirm)
+
+        # 2do POST (confirmar=1 + semana_origen_key=40-2099, como manda el
+        # hidden field del form de confirmar) -> duplica desde 40, NO desde
+        # 43 (vacía) ni pierde la selección.
+        resp2 = self.client.post(
+            reverse("cuadrillas:semanal_duplicar", args=[2099, 44]),
+            {"confirmar": "1", "semana_origen_key": "40-2099"},
+            follow=True,
+        )
+        self.assertEqual(resp2.status_code, 200)
+
+        nueva = Cuadrilla.objects.get(codigo="44-2099-0001-QAX")
+        self.assertEqual(nueva.nombre, "QA_E2E_207_M2_ORIGEN")
+        # Delta real: semana 40 -> semana 44 = 4 semanas ISO = 28 días.
+        self.assertEqual(nueva.fecha, date(2099, 10, 28))
+
+        # El bloque YA existente en destino no se tocó.
+        destino_previo = Cuadrilla.objects.get(codigo="44-2099-0002-QAX")
+        self.assertEqual(destino_previo.nombre, "QA_E2E_207_M2_DESTINO_PREVIO")
+
+        html2 = resp2.content.decode()
+        self.assertIn("desde la semana 40/2099", html2)
+        self.assertIn("QA_E2E_207_M2_ORIGEN", html2)

--- a/apps/cuadrillas/tests_issue_211.py
+++ b/apps/cuadrillas/tests_issue_211.py
@@ -1,0 +1,230 @@
+"""Tests #211 — Export consolidado de nómina por rango de fechas.
+
+Issue: Indunnova16/Instelec#211
+
+``ProgramacionSemanalExportarRangoView`` (GET
+/cuadrillas/semanal/exportar-rango/?fecha_inicio=...&fecha_fin=...) consolida
+en UN solo Excel todas las cuadrillas (bloques) activas cuya ``fecha`` cae en
+el rango pedido, sin importar la semana ISO de cada una — a diferencia del
+export existente (``semanal_exportar_horizontal``), que solo cubre una
+semana ISO por vez.
+
+Ejecutar:
+  DJANGO_SETTINGS_MODULE=config.settings.dev_lite \
+    venv/bin/python -m pytest apps/cuadrillas/tests_issue_211.py -v \
+    -o python_files="tests_*.py test_*.py"
+"""
+
+from datetime import date
+from io import BytesIO
+
+import openpyxl
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from apps.actividades.exporters import ProgramacionSemanalHorizontalExporter
+from apps.cuadrillas.models import Cuadrilla, CuadrillaMiembro
+
+Usuario = get_user_model()
+
+
+def _crear_admin():
+    return Usuario.objects.create_user(
+        email="admin_211@test.com",
+        password="testpass123!",
+        first_name="Admin",
+        last_name="211",
+        rol="admin",
+        is_staff=True,
+    )
+
+
+def _crear_usuario(documento, nombre):
+    partes = nombre.split(maxsplit=1)
+    return Usuario.objects.create(
+        email=f"{documento}@test.local",
+        documento=documento,
+        first_name=partes[0],
+        last_name=partes[1] if len(partes) > 1 else "",
+        rol="liniero",
+        is_active=True,
+    )
+
+
+def _crear_bloque(codigo, fecha, miembros, nombre="MANTENIMIENTO - 211"):
+    c = Cuadrilla.objects.create(
+        codigo=codigo,
+        nombre=nombre,
+        activa=True,
+        observaciones="",
+        fecha=fecha,
+    )
+    for usuario, cargo, rol_cuadrilla in miembros:
+        CuadrillaMiembro.objects.create(
+            cuadrilla=c,
+            usuario=usuario,
+            rol_cuadrilla_id=rol_cuadrilla,
+            cargo=cargo,
+            costo_dia=0,
+            fecha_inicio=fecha,
+            activo=True,
+        )
+    return c
+
+
+def _leer_columna_personal(xlsx_bytes):
+    """Devuelve el set de nombres (columna PERSONAL, índice 7) presentes en
+    el .xlsx generado — para verificar contenido real fila-por-fila (no solo
+    tamaño en bytes, a diferencia del journey E2E que no lee celdas)."""
+    wb = openpyxl.load_workbook(BytesIO(xlsx_bytes))
+    ws = wb.active
+    nombres = set()
+    for row in ws.iter_rows(min_row=2, values_only=True):
+        if row[6]:
+            nombres.add(row[6])
+    return nombres
+
+
+class TestExporterGenerarExcelRango(TestCase):
+    """Unit: ProgramacionSemanalHorizontalExporter.generar_excel_rango()."""
+
+    def setUp(self):
+        self.jt_a = _crear_usuario("111211", "PEDRO PEREZ")
+        self.jt_b = _crear_usuario("222211", "JUAN GOMEZ")
+
+    def test_consolida_dos_cuadrillas_de_semanas_iso_distintas(self):
+        """Dos bloques en semanas ISO distintas (2 y 5 de 2026) pero dentro
+        del mismo rango calendario (enero) -> ambos aparecen en UN Excel."""
+        _crear_bloque(
+            "02-2026-0001-QAA",
+            date(2026, 1, 6),
+            [(self.jt_a, "JT_CTA", "LINIERO_I")],
+            nombre="RANGO_A",
+        )
+        _crear_bloque(
+            "05-2026-0001-QAB",
+            date(2026, 1, 27),
+            [(self.jt_b, "JT_CTA", "LINIERO_I")],
+            nombre="RANGO_B",
+        )
+        # Bloque FUERA del rango pedido -- no debe aparecer.
+        _crear_bloque(
+            "10-2026-0001-QAC",
+            date(2026, 3, 1),
+            [(self.jt_a, "JT_CTA", "LINIERO_I")],
+            nombre="FUERA_DE_RANGO",
+        )
+
+        output = ProgramacionSemanalHorizontalExporter().generar_excel_rango(
+            date(2026, 1, 1), date(2026, 1, 31)
+        )
+        nombres = _leer_columna_personal(output.read())
+        self.assertIn("PEDRO PEREZ", nombres)
+        self.assertIn("JUAN GOMEZ", nombres)
+
+    def test_excluye_cuadrilla_inactiva(self):
+        c = _crear_bloque(
+            "02-2026-0002-QAD",
+            date(2026, 1, 6),
+            [(self.jt_a, "JT_CTA", "LINIERO_I")],
+            nombre="INACTIVA",
+        )
+        c.activa = False
+        c.save(update_fields=["activa"])
+
+        output = ProgramacionSemanalHorizontalExporter().generar_excel_rango(
+            date(2026, 1, 1), date(2026, 1, 31)
+        )
+        nombres = _leer_columna_personal(output.read())
+        self.assertNotIn("PEDRO PEREZ", nombres)
+
+    def test_generar_excel_semanal_existente_sin_cambio_de_comportamiento(self):
+        """El refactor a _escribir_hoja NO debe alterar generar_excel()."""
+        _crear_bloque(
+            "02-2026-0001-QAA",
+            date(2026, 1, 6),
+            [(self.jt_a, "JT_CTA", "LINIERO_I")],
+            nombre="RANGO_A",
+        )
+        output = ProgramacionSemanalHorizontalExporter().generar_excel(2026, 2)
+        wb = openpyxl.load_workbook(BytesIO(output.read()))
+        ws = wb.active
+        self.assertEqual(ws.title, "Sem 02-2026")
+        headers = [c.value for c in next(ws.iter_rows(min_row=1, max_row=1))]
+        self.assertEqual(headers[:2], ["#", "ACTIVIDAD"])
+
+
+class TestExportarRangoView(TestCase):
+    """Integration: GET /cuadrillas/semanal/exportar-rango/."""
+
+    def setUp(self):
+        self.admin = _crear_admin()
+        self.client.force_login(self.admin)
+        self.jt_a = _crear_usuario("333211", "ANA TORRES")
+        self.jt_b = _crear_usuario("444211", "LUIS DIAZ")
+
+    def test_export_rango_cruzando_semanas_iso_trae_ambos_bloques(self):
+        """Escenario exacto del issue: exportar un rango que cruza 2+ semanas
+        ISO distintas y confirmar que el Excel trae ambas."""
+        _crear_bloque(
+            "02-2026-0010-QAE",
+            date(2026, 1, 6),
+            [(self.jt_a, "JT_CTA", "LINIERO_I")],
+            nombre="VIEW_RANGO_A",
+        )
+        _crear_bloque(
+            "05-2026-0010-QAF",
+            date(2026, 1, 27),
+            [(self.jt_b, "JT_CTA", "LINIERO_I")],
+            nombre="VIEW_RANGO_B",
+        )
+
+        resp = self.client.get(
+            reverse("cuadrillas:semanal_exportar_rango"),
+            {"fecha_inicio": "2026-01-01", "fecha_fin": "2026-01-31"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp["Content-Type"],
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+        self.assertGreater(len(resp.content), 2000)
+        nombres = _leer_columna_personal(resp.content)
+        self.assertIn("ANA TORRES", nombres)
+        self.assertIn("LUIS DIAZ", nombres)
+
+    def test_export_rango_sin_fechas_400(self):
+        resp = self.client.get(reverse("cuadrillas:semanal_exportar_rango"))
+        self.assertEqual(resp.status_code, 400)
+
+    def test_export_rango_fecha_fin_antes_de_inicio_400(self):
+        resp = self.client.get(
+            reverse("cuadrillas:semanal_exportar_rango"),
+            {"fecha_inicio": "2026-01-31", "fecha_fin": "2026-01-01"},
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_export_rango_fecha_invalida_400(self):
+        resp = self.client.get(
+            reverse("cuadrillas:semanal_exportar_rango"),
+            {"fecha_inicio": "no-es-fecha", "fecha_fin": "2026-01-31"},
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    def test_export_rango_requiere_login(self):
+        self.client.logout()
+        resp = self.client.get(
+            reverse("cuadrillas:semanal_exportar_rango"),
+            {"fecha_inicio": "2026-01-01", "fecha_fin": "2026-01-31"},
+        )
+        self.assertIn(resp.status_code, (302, 301))
+
+    def test_export_rango_vacio_no_500(self):
+        """Rango sin ninguna cuadrilla -> 200 con Excel vacío (solo headers),
+        no 500 -- misma robustez que el export semanal existente."""
+        resp = self.client.get(
+            reverse("cuadrillas:semanal_exportar_rango"),
+            {"fecha_inicio": "2026-06-01", "fecha_fin": "2026-06-30"},
+        )
+        self.assertEqual(resp.status_code, 200)

--- a/apps/cuadrillas/views_semanal.py
+++ b/apps/cuadrillas/views_semanal.py
@@ -390,6 +390,9 @@ def _contexto_semana(anio, semana, request=None):
         "origen_anio": origen_anio,
         "origen_semana": origen_semana,
         "origen_tiene_datos": _bloques_qs(origen_anio, origen_semana).exists(),
+        # Issue #207: universo de semanas elegibles como origen del "Duplicar
+        # semana" (no solo N-1) -- excluye la propia semana destino.
+        "semanas_disponibles": _semanas_con_datos(excluir=(anio, semana)),
         "prev_anio": prev_anio,
         "prev_semana": prev_semana,
         "next_anio": next_anio,
@@ -400,6 +403,64 @@ def _contexto_semana(anio, semana, request=None):
 # ---------------------------------------------------------------------------
 # Vistas
 # ---------------------------------------------------------------------------
+
+
+def _semanas_con_datos(excluir=None):
+    """Todas las (anio, semana) distintas con AL MENOS un bloque (Cuadrilla)
+    activo, con conteo de bloques, ordenadas desc (más reciente primero).
+    Mismo patrón de recorrido de código que ``_semana_mas_reciente_con_datos``
+    -- issue #207, alimenta el selector de "semana origen" de Duplicar semana
+    (ya no limitado a N-1). ``excluir``, si se pasa, es una tupla
+    ``(anio, semana)`` que se omite del resultado (la semana destino no debe
+    aparecer como opción de origen de sí misma)."""
+    conteo = {}
+    codigos = Cuadrilla.objects.filter(
+        codigo__regex=r"^[0-9]{2}-[0-9]{4}-", activa=True
+    ).values_list("codigo", flat=True)
+    for codigo in codigos:
+        partes = codigo.split("-")
+        try:
+            sem, ano = int(partes[0]), int(partes[1])
+        except (ValueError, IndexError):
+            continue
+        if 1 <= sem <= 53 and 2000 <= ano <= 2100:
+            conteo[(ano, sem)] = conteo.get((ano, sem), 0) + 1
+    if excluir is not None:
+        conteo.pop(tuple(excluir), None)
+    return [
+        {"anio": ano, "semana": sem, "n_bloques": n, "key": f"{sem:02d}-{ano}"}
+        for (ano, sem), n in sorted(conteo.items(), key=lambda kv: kv[0], reverse=True)
+    ]
+
+
+def _parse_semana_origen_key(key):
+    """Parsea un ``semana_origen_key`` formato ``SS-AAAA`` (ej. ``'28-2099'``)
+    a ``(anio, semana)``. Devuelve ``(None, None)`` si viene vacío o mal
+    formado -- issue #207, campo compuesto único para que la selección de
+    origen viaje en 1 solo parámetro a través del paso de confirmación (ver
+    ``ProgramacionSemanalDuplicarView``)."""
+    key = (key or "").strip()
+    if not key or "-" not in key:
+        return None, None
+    semana_str, _, anio_str = key.partition("-")
+    try:
+        semana, anio = int(semana_str), int(anio_str)
+    except ValueError:
+        return None, None
+    if 1 <= semana <= 53 and 2000 <= anio <= 2100:
+        return anio, semana
+    return None, None
+
+
+def _resolver_origen_duplicado(request, anio, semana):
+    """Semana origen para "Duplicar semana" (issue #207): lee
+    ``semana_origen_key`` del POST; si no viene o no parsea, fallback EXACTO
+    a ``_semana_anterior`` -- 100% compatible con callers/tests que no envían
+    el campo nuevo (comportamiento histórico N-1 sin cambios)."""
+    origen_anio, origen_semana = _parse_semana_origen_key(request.POST.get("semana_origen_key"))
+    if origen_anio is None:
+        return _semana_anterior(anio, semana)
+    return origen_anio, origen_semana
 
 
 def _semana_mas_reciente_con_datos():
@@ -453,6 +514,23 @@ class ProgramacionSemanalGridView(LoginRequiredMixin, RoleRequiredMixin, Templat
         # Cuando la semana destino ya tiene datos, el POST de duplicar pide
         # confirmación redirigiendo aquí con ?confirmar_duplicado=1.
         context["confirmar_duplicado"] = self.request.GET.get("confirmar_duplicado") == "1"
+
+        # Issue #207: semana origen ELEGIDA en el selector de "Duplicar
+        # semana" -- viaja como query param ``semana_origen_key`` a través
+        # del paso de confirmación. Default = N-1 (``origen_anio``/
+        # ``origen_semana``, comportamiento histórico) si no viene o es
+        # inválida. Estas variables ``origen_seleccionado_*`` (distintas de
+        # ``origen_anio``/``origen_semana``, que SIEMPRE son N-1) son las que
+        # debe pintar el mensaje/hidden-field del paso de confirmación.
+        key = (self.request.GET.get("semana_origen_key") or "").strip()
+        origen_sel_anio, origen_sel_semana = _parse_semana_origen_key(key)
+        if origen_sel_anio is None:
+            origen_sel_anio = context["origen_anio"]
+            origen_sel_semana = context["origen_semana"]
+        context["origen_seleccionado_anio"] = origen_sel_anio
+        context["origen_seleccionado_semana"] = origen_sel_semana
+        context["semana_origen_key"] = key or f"{origen_sel_semana:02d}-{origen_sel_anio}"
+
         # Issue #188 (A2): choices del form de bloque (crear/editar), reusadas
         # por _bloque_form.html vía include. La cascada Línea→Tramo real
         # (AJAX) llega en A3 — acá solo se precargan los catálogos activos.
@@ -963,21 +1041,29 @@ class ProgramacionSemanalBloqueReprogramarView(LoginRequiredMixin, RoleRequiredM
 
 
 class ProgramacionSemanalDuplicarView(LoginRequiredMixin, RoleRequiredMixin, View):
-    """Copia los bloques (Cuadrilla + CuadrillaMiembro) de la semana anterior a
-    la semana destino como base editable. NO destructivo: si un bloque ya existe
-    en el destino se omite (no se sobrescribe). Las NOVEDADES no se duplican."""
+    """Copia los bloques (Cuadrilla + CuadrillaMiembro) de una semana origen a
+    la semana destino como base editable. Issue #207: el origen ya NO está
+    limitado a la semana inmediatamente anterior -- se lee de
+    ``semana_origen_key`` (POST, formato ``SS-AAAA``), con fallback a la
+    semana anterior (``_semana_anterior``) si no viene. El shift de fechas se
+    calcula por el delta real de días entre origen y destino (no un +7 fijo).
+    NO destructivo: si un bloque ya existe en el destino se omite (no se
+    sobrescribe). Las NOVEDADES no se duplican."""
 
     allowed_roles = ROLES_CUADRILLAS
 
     def post(self, request, anio, semana):
         anio, semana = int(anio), int(semana)
-        origen_anio, origen_semana = _semana_anterior(anio, semana)
+        # Issue #207: origen ya NO está fijo a la semana anterior -- se lee
+        # de `semana_origen_key` (POST), con fallback exacto a
+        # `_semana_anterior` si no viene o no parsea (compatibilidad).
+        origen_anio, origen_semana = _resolver_origen_duplicado(request, anio, semana)
         origen = list(_bloques_qs(origen_anio, origen_semana))
 
         if not origen:
             messages.error(
                 request,
-                f"La semana anterior ({origen_semana:02d}/{origen_anio}) no tiene "
+                f"La semana {origen_semana:02d}/{origen_anio} no tiene "
                 f"programación cargada; no hay nada que duplicar.",
             )
             return redirect("cuadrillas:semanal_grid", anio=anio, semana=semana)
@@ -991,7 +1077,22 @@ class ProgramacionSemanalDuplicarView(LoginRequiredMixin, RoleRequiredMixin, Vie
                 f"sobrescriben). Confirmá para continuar.",
             )
             url = reverse("cuadrillas:semanal_grid", args=[anio, semana])
-            return redirect(f"{url}?confirmar_duplicado=1")
+            # Issue #207: la semana origen ELEGIDA viaja en el redirect para
+            # que el paso de confirmación no la pierda (ver
+            # ProgramacionSemanalGridView.get_context_data).
+            return redirect(
+                f"{url}?confirmar_duplicado=1&semana_origen_key={origen_semana:02d}-{origen_anio}"
+            )
+
+        # Issue #207: delta real (en días) entre la semana origen y la
+        # destino -- generaliza el shift antes hardcodeado a 7 días (una
+        # semana), para que un origen arbitrario (ej. 4 semanas antes) corra
+        # las fechas correctamente. Fallback defensivo a 7 solo si
+        # `_rango_calendario` no puede resolver alguna de las dos semanas
+        # (semana ISO inválida, caso borde no esperado en operación normal).
+        lunes_origen, _ = _rango_calendario(origen_anio, origen_semana)
+        lunes_destino, _ = _rango_calendario(anio, semana)
+        delta_dias = (lunes_destino - lunes_origen).days if lunes_origen and lunes_destino else 7
 
         creadas = 0
         omitidas = 0
@@ -1010,7 +1111,7 @@ class ProgramacionSemanalDuplicarView(LoginRequiredMixin, RoleRequiredMixin, Vie
                     linea_asignada=c.linea_asignada,
                     activa=True,
                     observaciones=c.observaciones,
-                    fecha=_shift(c.fecha, 7),
+                    fecha=_shift(c.fecha, delta_dias),
                 )
                 for m in c.miembros.all():
                     if not m.activo:
@@ -1021,8 +1122,8 @@ class ProgramacionSemanalDuplicarView(LoginRequiredMixin, RoleRequiredMixin, Vie
                         rol_cuadrilla=m.rol_cuadrilla,
                         cargo=m.cargo,
                         costo_dia=m.costo_dia,
-                        fecha_inicio=_shift(m.fecha_inicio, 7) or date.today(),
-                        fecha_fin=_shift(m.fecha_fin, 7),
+                        fecha_inicio=_shift(m.fecha_inicio, delta_dias) or date.today(),
+                        fecha_fin=_shift(m.fecha_fin, delta_dias),
                         activo=True,
                         es_conductor_interno=m.es_conductor_interno,
                     )
@@ -1103,6 +1204,50 @@ class ProgramacionSemanalExportarHorizontalView(LoginRequiredMixin, RoleRequired
         return resp
 
 
+class ProgramacionSemanalExportarRangoView(LoginRequiredMixin, RoleRequiredMixin, View):
+    """GET /cuadrillas/semanal/exportar-rango/?fecha_inicio=YYYY-MM-DD&fecha_fin=YYYY-MM-DD
+    (issue #211).
+
+    Export consolidado: UN solo Excel con TODAS las cuadrillas activas cuya
+    ``fecha`` cae en el rango indicado, sin importar la semana ISO a la que
+    pertenezca cada una -- reemplaza el flujo de exportar semana por semana
+    (``ProgramacionSemanalExportarHorizontalView``) cuando el rango pedido
+    cruza 2+ semanas ISO."""
+
+    allowed_roles = ROLES_CUADRILLAS
+
+    def get(self, request):
+        from apps.actividades.exporters import ProgramacionSemanalHorizontalExporter
+
+        fecha_inicio_str = (request.GET.get("fecha_inicio") or "").strip()
+        fecha_fin_str = (request.GET.get("fecha_fin") or "").strip()
+        if not fecha_inicio_str or not fecha_fin_str:
+            return HttpResponse(
+                "Debe indicar fecha_inicio y fecha_fin para exportar el rango.", status=400
+            )
+        try:
+            fecha_inicio = date.fromisoformat(fecha_inicio_str)
+            fecha_fin = date.fromisoformat(fecha_fin_str)
+        except ValueError:
+            return HttpResponse("Las fechas ingresadas no son válidas.", status=400)
+        if fecha_fin < fecha_inicio:
+            return HttpResponse(
+                "La fecha fin no puede ser anterior a la fecha inicio.", status=400
+            )
+
+        output = ProgramacionSemanalHorizontalExporter().generar_excel_rango(
+            fecha_inicio, fecha_fin
+        )
+        resp = HttpResponse(
+            output.read(),
+            content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+        resp["Content-Disposition"] = (
+            f'attachment; filename="programacion_{fecha_inicio:%Y%m%d}_{fecha_fin:%Y%m%d}.xlsx"'
+        )
+        return resp
+
+
 urlpatterns = [
     path("semanal/", ProgramacionSemanalIndexView.as_view(), name="semanal_index"),
     path(
@@ -1125,6 +1270,14 @@ urlpatterns = [
         "semanal/<int:anio>/<int:semana>/exportar/",
         ProgramacionSemanalExportarHorizontalView.as_view(),
         name="semanal_exportar_horizontal",
+    ),
+    # Issue #211 — export Excel consolidado por rango de fechas arbitrario
+    # (cruza semanas ISO). "exportar-rango" no matchea el converter <int:> de
+    # los patterns de arriba, sin conflicto de resolución.
+    path(
+        "semanal/exportar-rango/",
+        ProgramacionSemanalExportarRangoView.as_view(),
+        name="semanal_exportar_rango",
     ),
     # Issue #188 (A3) — grid editable in-place: crear bloque + cascada Línea→Tramo.
     path(

--- a/templates/cuadrillas/partials/_tab_semanas.html
+++ b/templates/cuadrillas/partials/_tab_semanas.html
@@ -69,29 +69,59 @@ prev/next, origen_*, confirmar_duplicado, tipos_actividad_bloque, etc).
                 Exportar Excel
             </a>
 
-            <!-- Duplicar semana anterior -->
+            <!-- Exportar Excel consolidado por rango de fechas (issue #211) -->
+            <form method="get" action="{% url 'cuadrillas:semanal_exportar_rango' %}"
+                  class="flex items-center gap-1 px-2 py-1 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg"
+                  aria-label="Exportar programación consolidada por rango de fechas">
+                <label class="sr-only" for="id_export_fecha_inicio">Fecha inicio del rango a exportar</label>
+                <input type="date" id="id_export_fecha_inicio" name="fecha_inicio" required
+                       class="text-sm rounded border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
+                <span class="text-gray-400 text-sm">—</span>
+                <label class="sr-only" for="id_export_fecha_fin">Fecha fin del rango a exportar</label>
+                <input type="date" id="id_export_fecha_fin" name="fecha_fin" required
+                       class="text-sm rounded border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100">
+                <button type="submit"
+                        class="px-3 py-1.5 bg-emerald-700 text-white rounded-lg hover:bg-emerald-800 transition text-sm"
+                        aria-label="Exportar Excel consolidado del rango de fechas elegido">
+                    Exportar rango
+                </button>
+            </form>
+
+            <!-- Duplicar semana (issue #207: elegir cualquier semana origen, no solo la anterior) -->
             {% if confirmar_duplicado %}
             <form method="post" action="{% url 'cuadrillas:semanal_duplicar' anio=anio semana=semana %}" class="inline">
                 {% csrf_token %}
                 <input type="hidden" name="confirmar" value="1">
+                <input type="hidden" name="semana_origen_key" value="{{ semana_origen_key }}">
                 <button type="submit"
                         class="px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 transition"
-                        aria-label="Confirmar duplicar semana anterior">
+                        aria-label="Confirmar duplicar semana">
                     Confirmar duplicado
                 </button>
             </form>
             {% else %}
-            <form method="post" action="{% url 'cuadrillas:semanal_duplicar' anio=anio semana=semana %}" class="inline">
+            <form method="post" action="{% url 'cuadrillas:semanal_duplicar' anio=anio semana=semana %}" class="inline-flex items-center gap-2">
                 {% csrf_token %}
+                <label class="sr-only" for="id_semana_origen_key">Semana origen a duplicar</label>
+                <select name="semana_origen_key" id="id_semana_origen_key"
+                        {% if not semanas_disponibles %}disabled{% endif %}
+                        class="text-sm rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+                        aria-label="Semana origen a duplicar">
+                    {% for s in semanas_disponibles %}
+                    <option value="{{ s.key }}" {% if s.key == semana_origen_key %}selected{% endif %}>
+                        Semana {{ s.semana }}/{{ s.anio }} ({{ s.n_bloques }} bloque(s))
+                    </option>
+                    {% endfor %}
+                </select>
                 <button type="submit"
-                        {% if not origen_tiene_datos %}disabled title="La semana {{ origen_semana }}/{{ origen_anio }} no tiene programación para duplicar"{% endif %}
+                        {% if not semanas_disponibles %}disabled title="No hay ninguna semana con programación cargada para duplicar"{% endif %}
                         class="px-4 py-2 rounded-lg transition flex items-center gap-2
-                               {% if origen_tiene_datos %}bg-blue-600 text-white hover:bg-blue-700{% else %}bg-gray-300 text-gray-500 cursor-not-allowed dark:bg-gray-700 dark:text-gray-500{% endif %}"
-                        aria-label="Duplicar la programación de la semana anterior">
+                               {% if semanas_disponibles %}bg-blue-600 text-white hover:bg-blue-700{% else %}bg-gray-300 text-gray-500 cursor-not-allowed dark:bg-gray-700 dark:text-gray-500{% endif %}"
+                        aria-label="Duplicar la semana elegida como origen">
                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/>
                     </svg>
-                    Duplicar semana anterior
+                    Duplicar semana
                 </button>
             </form>
             {% endif %}
@@ -101,7 +131,7 @@ prev/next, origen_*, confirmar_duplicado, tipos_actividad_bloque, etc).
     {% if confirmar_duplicado %}
     <div class="p-4 rounded-lg bg-amber-50 dark:bg-amber-900/30 border border-amber-300 dark:border-amber-700 text-amber-800 dark:text-amber-200">
         Esta semana ya tiene programación. Al confirmar se agregarán únicamente los bloques
-        de la semana {{ origen_semana }}/{{ origen_anio }} que aún no existan (los actuales no se modifican).
+        de la semana {{ origen_seleccionado_semana }}/{{ origen_seleccionado_anio }} que aún no existan (los actuales no se modifican).
     </div>
     {% endif %}
 


### PR DESCRIPTION
## Resumen
- **#211**: nuevo `generar_excel_rango()` consolida en un excel todas las cuadrillas por rango de fecha arbitrario (no limitado a semana ISO), reusando el layout ya validado. Nueva vista `GET /cuadrillas/semanal/exportar-rango/?fecha_inicio=&fecha_fin=`.
- **#207**: "Duplicar semana" ya no fijo a N-1 — selector con todas las semanas con datos, shift de fechas por delta real (no hardcodeado a 7).

Refs #211 Refs #207

## Test plan
- [x] `apps.cuadrillas.tests_issue_211` + `tests_issue_207` (nuevos) + `tests_issue_178_bc` (adaptado).
- [x] Suite `apps.cuadrillas`+`apps.actividades` — 217/218 (1 failure pre-existente en `main`, no relacionado, confirmado sin estos cambios).