### PR TITLE
feat(cuadrillas): asistencia — acciones masivas, Día ganado, jornada única fuente

### DIFF
--- a/apps/cuadrillas/migrations/0026_asistencia_dia_ganado.py
+++ b/apps/cuadrillas/migrations/0026_asistencia_dia_ganado.py
@@ -1,0 +1,35 @@
+# Generated manually (issue #210) -- puramente aditivo sobre choices, no
+# toca datos existentes.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cuadrillas', '0025_area_usuario_personal'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='asistencia',
+            name='tipo_novedad',
+            field=models.CharField(
+                choices=[
+                    ('PRESENTE', 'Presente'),
+                    ('VACACIONES', 'Vacaciones'),
+                    ('INCAPACIDAD', 'Incapacidad'),
+                    ('PERMISO', 'Permiso'),
+                    ('AUSENTE', 'Ausente'),
+                    ('LICENCIA', 'Licencia'),
+                    ('CAPACITACION', 'Capacitación'),
+                    ('COMPENSATORIO', 'Compensatorio'),
+                    ('DESCANSO', 'Descanso'),
+                    ('DIA_GANADO', 'Día ganado'),
+                ],
+                default='PRESENTE',
+                max_length=20,
+                verbose_name='Tipo de novedad',
+            ),
+        ),
+    ]

--- a/apps/cuadrillas/models_base.py
+++ b/apps/cuadrillas/models_base.py
@@ -481,6 +481,7 @@ class Asistencia(BaseModel):
         CAPACITACION = 'CAPACITACION', 'Capacitación'
         COMPENSATORIO = 'COMPENSATORIO', 'Compensatorio'
         DESCANSO = 'DESCANSO', 'Descanso'
+        DIA_GANADO = 'DIA_GANADO', 'Día ganado'
 
     usuario = models.ForeignKey(
         'usuarios.Usuario',

--- a/apps/cuadrillas/tests_issue_210.py
+++ b/apps/cuadrillas/tests_issue_210.py
@@ -1,0 +1,261 @@
+"""Tests #210 — Asistencia: acciones masivas, viático, Día ganado y jornada
+única fuente de verdad.
+
+Issue: Indunnova16/Instelec#210
+
+Cubre (según diagnóstico F2, RUN_2026-08-07_0220):
+  - DIA_GANADO existe como choice y NO cuenta como día trabajado para
+    nómina/dias_activos (financiero/views.py sigue filtrando
+    tipo_novedad='PRESENTE', sin cambios ahí -- este test lo deja
+    explícito en vez de confiar en que "por default no cuenta").
+  - Asistencia.JORNADA_POR_DIA como única fuente de verdad -- ya no hay
+    dicts re-hardcodeados en CuadrillaDetailView/AsistenciaUpdateView.
+  - AsistenciaAccionMasivaView: 'presente', 'festivo_domingo', 'viatico',
+    cada uno aplicado a TODO el personal activo de la cuadrilla en una
+    fecha, sin tocar miembros inactivos ni otras fechas.
+
+Jornada 42h: NO se toca en este issue -- bloqueado por datos reales de
+horario pendientes (ver PLAN), JORNADA_POR_DIA queda en 44h/semana
+(comportamiento actual, sin cambios de valor) hasta que llegue el insumo.
+
+Ejecutar:
+  DJANGO_SETTINGS_MODULE=config.settings.dev_lite \
+    venv/bin/python -m pytest apps/cuadrillas/tests_issue_210.py -v \
+    -o python_files="tests_*.py test_*.py"
+"""
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from apps.cuadrillas.models import Asistencia, Cuadrilla, CuadrillaMiembro
+
+Usuario = get_user_model()
+
+
+def _crear_admin():
+    return Usuario.objects.create_user(
+        email="admin_210@test.com",
+        password="testpass123!",
+        first_name="Admin",
+        last_name="210",
+        rol="admin",
+        is_staff=True,
+    )
+
+
+def _crear_usuario(documento, nombre):
+    partes = nombre.split(maxsplit=1)
+    return Usuario.objects.create(
+        email=f"{documento}@test.local",
+        documento=documento,
+        first_name=partes[0],
+        last_name=partes[1] if len(partes) > 1 else "",
+        rol="liniero",
+        is_active=True,
+    )
+
+
+def _crear_bloque_con_miembros(codigo, fecha, activos, inactivos=()):
+    c = Cuadrilla.objects.create(
+        codigo=codigo, nombre="MANTENIMIENTO - 210", activa=True,
+        observaciones="", fecha=fecha,
+    )
+    for usuario in activos:
+        CuadrillaMiembro.objects.create(
+            cuadrilla=c, usuario=usuario, rol_cuadrilla_id="LINIERO_I",
+            cargo="MIEMBRO", costo_dia=0, fecha_inicio=fecha, activo=True,
+        )
+    for usuario in inactivos:
+        CuadrillaMiembro.objects.create(
+            cuadrilla=c, usuario=usuario, rol_cuadrilla_id="LINIERO_I",
+            cargo="MIEMBRO", costo_dia=0, fecha_inicio=fecha, activo=False,
+        )
+    return c
+
+
+class TestDiaGanadoChoiceYNoCuentaComoTrabajado(TestCase):
+    def setUp(self):
+        self.admin = _crear_admin()
+        self.client.force_login(self.admin)
+        self.usuario = _crear_usuario("QA0210DG", "QAE210 DiaGanado")
+        self.cuadrilla = _crear_bloque_con_miembros(
+            "01-2099-0210DG-QAE", date(2099, 1, 5), [self.usuario]
+        )
+
+    def test_dia_ganado_es_choice_valido_en_el_modelo(self):
+        self.assertIn(
+            ("DIA_GANADO", "Día ganado"), Asistencia.TipoNovedad.choices
+        )
+
+    def test_dia_ganado_seleccionable_desde_el_endpoint_de_asistencia(self):
+        resp = self.client.post(
+            reverse("cuadrillas:asistencia_update", args=[self.cuadrilla.pk]),
+            data={
+                "usuario_id": str(self.usuario.pk),
+                "fecha": "2099-01-05",
+                "tipo_novedad": "DIA_GANADO",
+                "viaticos": "0",
+                "observacion": "",
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+        asist = Asistencia.objects.get(usuario=self.usuario, fecha=date(2099, 1, 5))
+        self.assertEqual(asist.tipo_novedad, "DIA_GANADO")
+
+    def test_dia_ganado_no_cuenta_como_presente_para_nomina(self):
+        """Filtro tipo_novedad='PRESENTE' de financiero/views.py -- DIA_GANADO
+        debe quedar EXCLUIDO, igual que cualquier otro tipo distinto de
+        PRESENTE. Lock-in explícito del comportamiento pedido en el issue
+        ("no debe contar como trabajado")."""
+        Asistencia.objects.create(
+            usuario=self.usuario, cuadrilla=self.cuadrilla, fecha=date(2099, 1, 5),
+            tipo_novedad="DIA_GANADO", registrado_por=self.admin,
+        )
+        dias_presente = Asistencia.objects.filter(
+            cuadrilla=self.cuadrilla, tipo_novedad="PRESENTE"
+        ).count()
+        self.assertEqual(dias_presente, 0)
+
+
+class TestJornadaUnicaFuenteDeVerdad(TestCase):
+    """Asistencia.JORNADA_POR_DIA es la ÚNICA fuente -- ya no hay copias
+    re-hardcodeadas en CuadrillaDetailView.get_context_data ni en
+    AsistenciaUpdateView.post (issue #210)."""
+
+    def setUp(self):
+        self.admin = _crear_admin()
+        self.client.force_login(self.admin)
+        self.usuario = _crear_usuario("QA0210JOR", "QAE210 Jornada")
+        # Lunes 2099-01-05 = ISO semana 02/2099 -- JORNADA_POR_DIA[0] = 8.0.
+        # El codigo DEBE llevar el prefijo de semana ISO real (usado por
+        # _get_semana_from_codigo para anclar dias_semana en el detalle).
+        self.cuadrilla = _crear_bloque_con_miembros(
+            "02-2099-0210JOR-QAE", date(2099, 1, 5), [self.usuario]
+        )
+
+    def test_detalle_cuadrilla_usa_jornada_por_dia_del_modelo(self):
+        Asistencia.objects.create(
+            usuario=self.usuario, cuadrilla=self.cuadrilla, fecha=date(2099, 1, 5),
+            tipo_novedad="PRESENTE", registrado_por=self.admin,
+        )
+        resp = self.client.get(reverse("cuadrillas:detalle", args=[self.cuadrilla.pk]))
+        self.assertEqual(resp.status_code, 200)
+        fila = resp.context["filas_asistencia"][0]
+        # Lunes: jornada_por_dia[0] = 8.0 (modelo, no un valor distinto
+        # que hubiera quedado hardcodeado aparte).
+        self.assertEqual(fila["total_horas_ordinarias"], Decimal("8.0"))
+        # El propio dia_info trae 'jornada' -- el template ya no calcula
+        # el mapeo dia_semana->horas con tags de Django.
+        self.assertEqual(fila["dias"][0]["jornada"], Asistencia.JORNADA_POR_DIA[0])
+
+    def test_asistencia_update_post_usa_jornada_por_dia_del_modelo(self):
+        resp = self.client.post(
+            reverse("cuadrillas:asistencia_update", args=[self.cuadrilla.pk]),
+            data={
+                "usuario_id": str(self.usuario.pk),
+                "fecha": "2099-01-05",
+                "tipo_novedad": "PRESENTE",
+                "viaticos": "0",
+                "observacion": "",
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+        # El HTML del badge de HE embebe "({jornada}h)" -- 8.0h para un lunes.
+        self.assertIn("8.0h", resp.content.decode())
+
+
+class TestAccionMasivaPresente(TestCase):
+    def setUp(self):
+        self.admin = _crear_admin()
+        self.client.force_login(self.admin)
+        self.activo1 = _crear_usuario("QA0210AM1", "QAE210 Activo1")
+        self.activo2 = _crear_usuario("QA0210AM2", "QAE210 Activo2")
+        self.inactivo = _crear_usuario("QA0210AM3", "QAE210 Inactivo")
+        self.cuadrilla = _crear_bloque_con_miembros(
+            "01-2099-0210AM-QAE", date(2099, 1, 5),
+            activos=[self.activo1, self.activo2], inactivos=[self.inactivo],
+        )
+
+    def _post(self, accion, fecha="2099-01-05"):
+        return self.client.post(
+            reverse("cuadrillas:asistencia_accion_masiva", args=[self.cuadrilla.pk]),
+            data={"accion": accion, "fecha": fecha},
+        )
+
+    def test_presente_marca_todo_el_personal_activo(self):
+        resp = self._post("presente")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["afectados"], 2)
+        for u in (self.activo1, self.activo2):
+            asist = Asistencia.objects.get(usuario=u, fecha=date(2099, 1, 5))
+            self.assertEqual(asist.tipo_novedad, "PRESENTE")
+
+    def test_presente_no_toca_miembro_inactivo(self):
+        self._post("presente")
+        self.assertFalse(
+            Asistencia.objects.filter(usuario=self.inactivo, fecha=date(2099, 1, 5)).exists()
+        )
+
+    def test_presente_no_toca_otra_fecha(self):
+        self._post("presente", fecha="2099-01-05")
+        self.assertFalse(
+            Asistencia.objects.filter(
+                usuario=self.activo1, fecha=date(2099, 1, 6)
+            ).exists()
+        )
+
+    def test_accion_invalida_400(self):
+        resp = self._post("no_existe")
+        self.assertEqual(resp.status_code, 400)
+
+    def test_fecha_invalida_400(self):
+        resp = self._post("presente", fecha="no-es-una-fecha")
+        self.assertEqual(resp.status_code, 400)
+
+
+class TestAccionMasivaFestivoDomingo(TestCase):
+    def setUp(self):
+        self.admin = _crear_admin()
+        self.client.force_login(self.admin)
+        self.usuario = _crear_usuario("QA0210FD1", "QAE210 FestivoDomingo")
+        # Domingo real: 2099-01-04 (jornada regular = 0h ese dia).
+        self.cuadrilla = _crear_bloque_con_miembros(
+            "01-2099-0210FD-QAE", date(2099, 1, 4), [self.usuario]
+        )
+
+    def test_festivo_domingo_marca_presente_y_toda_la_jornada_como_dominical(self):
+        resp = self.client.post(
+            reverse("cuadrillas:asistencia_accion_masiva", args=[self.cuadrilla.pk]),
+            data={"accion": "festivo_domingo", "fecha": "2099-01-04"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        asist = Asistencia.objects.get(usuario=self.usuario, fecha=date(2099, 1, 4))
+        self.assertEqual(asist.tipo_novedad, "PRESENTE")
+        self.assertEqual(asist.he_dominical_diurna, Decimal("8.0"))
+        # save() recalcula horas_extra como suma de los 4 detalles.
+        self.assertEqual(asist.horas_extra, Decimal("8.0"))
+
+
+class TestAccionMasivaViatico(TestCase):
+    def setUp(self):
+        self.admin = _crear_admin()
+        self.client.force_login(self.admin)
+        self.usuario = _crear_usuario("QA0210VI1", "QAE210 Viatico")
+        self.cuadrilla = _crear_bloque_con_miembros(
+            "01-2099-0210VI-QAE", date(2099, 1, 5), [self.usuario]
+        )
+
+    def test_viatico_aplica_default_a_todo_el_personal(self):
+        resp = self.client.post(
+            reverse("cuadrillas:asistencia_accion_masiva", args=[self.cuadrilla.pk]),
+            data={"accion": "viatico", "fecha": "2099-01-05"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        asist = Asistencia.objects.get(usuario=self.usuario, fecha=date(2099, 1, 5))
+        self.assertTrue(asist.viatico_aplica)
+        # Sin CostoRecurso(tipo='VIATICO') sembrado en este test DB, cae al
+        # mismo fallback hardcodeado que ya usa AsistenciaUpdateView.
+        self.assertEqual(asist.viaticos, Decimal("136941"))

--- a/apps/cuadrillas/urls.py
+++ b/apps/cuadrillas/urls.py
@@ -21,6 +21,9 @@ urlpatterns = [
     path('<uuid:pk>/miembro/<uuid:miembro_pk>/eliminar/', views.CuadrillaMiembroRemoveView.as_view(), name='miembro_eliminar'),
     path('<uuid:pk>/miembros/subir/', views.CuadrillaMiembroUploadView.as_view(), name='miembros_upload'),
     path('<uuid:pk>/asistencia/', views.AsistenciaUpdateView.as_view(), name='asistencia_update'),
+    # Issue #210: acciones masivas (presente/festivo-domingo/viatico) para
+    # todo el personal activo de la cuadrilla en una fecha dada.
+    path('<uuid:pk>/asistencia/masiva/', views.AsistenciaAccionMasivaView.as_view(), name='asistencia_accion_masiva'),
     path('<uuid:pk>/exportar-asistencia/', views.ExportarAsistenciaView.as_view(), name='exportar_asistencia'),
     path('personal/subir/', views.PersonalCuadrillaUploadView.as_view(), name='personal_upload'),
     path('api/personal/', views.PersonalCuadrillaListAPIView.as_view(), name='personal_list_api'),

--- a/apps/cuadrillas/views.py
+++ b/apps/cuadrillas/views.py
@@ -348,6 +348,10 @@ class CuadrillaDetailView(LoginRequiredMixin, RoleRequiredMixin, HTMXMixin, Deta
                     'he_dominical_diurna': info.get('he_dominical_diurna', 0),
                     'he_dominical_nocturna': info.get('he_dominical_nocturna', 0),
                     'dia_semana': dia.weekday(),
+                    # Issue #210: jornada del día ya calculada acá arriba --
+                    # se pasa al template para no re-hardcodear el mapeo
+                    # dia_semana->horas en Django template tags.
+                    'jornada': jornada,
                 })
             filas_asistencia.append({
                 'miembro': miembro,
@@ -795,6 +799,7 @@ class AsistenciaUpdateView(LoginRequiredMixin, RoleRequiredMixin, DetailView):
             'CAPACITACION': 'text-teal-600 bg-teal-50 border-teal-300',
             'COMPENSATORIO': 'text-cyan-600 bg-cyan-50 border-cyan-300',
             'DESCANSO': 'text-slate-600 bg-slate-50 border-slate-300',
+            'DIA_GANADO': 'text-emerald-700 bg-emerald-50 border-emerald-300',
         }
         css = color_map.get(tipo_novedad, 'text-gray-400 bg-white border-gray-200')
 
@@ -828,11 +833,14 @@ class AsistenciaUpdateView(LoginRequiredMixin, RoleRequiredMixin, DetailView):
         total_viaticos_fmt = int(totals['total_viaticos'] or 0)
         total_he_fmt = float(totals['total_he'] or 0)
 
-        # Calculate ordinary hours (jornada regular for PRESENTE days)
-        JORNADA_DIA = {0: 8.0, 1: 7.5, 2: 7.5, 3: 7.5, 4: 7.5, 5: 6.0, 6: 0.0}
+        # Calculate ordinary hours (jornada regular for PRESENTE days).
+        # Issue #210: fuente única Asistencia.JORNADA_POR_DIA -- antes este
+        # dict estaba re-hardcodeado acá (y otra vez mas abajo), con riesgo
+        # de que una futura actualización de jornada (ej. reforma 42h) se
+        # aplicara en un lugar y se olvidara en los otros.
         total_hord = 0.0
         for a in week_asistencias.filter(tipo_novedad='PRESENTE'):
-            total_hord += JORNADA_DIA.get(a.fecha.weekday(), 0)
+            total_hord += Asistencia.JORNADA_POR_DIA.get(a.fecha.weekday(), 0)
         total_htotal = total_hord + total_he_fmt
 
         # Build observation field (visible when not PRESENTE)
@@ -851,9 +859,8 @@ class AsistenciaUpdateView(LoginRequiredMixin, RoleRequiredMixin, DetailView):
         else:
             obs_field = f'<input type="hidden" name="observacion" value="{obs_escaped}">'
 
-        # Build Alpine.js overtime section
-        JORNADA = {0: 8.0, 1: 7.5, 2: 7.5, 3: 7.5, 4: 7.5, 5: 6.0, 6: 0.0}
-        jornada = JORNADA.get(fecha.weekday(), 0)
+        # Build Alpine.js overtime section (issue #210: fuente única, ver nota arriba)
+        jornada = Asistencia.JORNADA_POR_DIA.get(fecha.weekday(), 0)
 
         he_vals = {
             'he_diurna': float(he_diurna),
@@ -959,6 +966,104 @@ class AsistenciaUpdateView(LoginRequiredMixin, RoleRequiredMixin, DetailView):
             },
         })
         return response
+
+
+class AsistenciaAccionMasivaView(LoginRequiredMixin, RoleRequiredMixin, DetailView):
+    """Issue #210 -- acciones masivas de asistencia sobre TODOS los miembros
+    activos de una cuadrilla para una fecha dada (una sola request de
+    servidor, no un loop de N POSTs HTMX por celda -- mismo patrón que
+    recomendó el diagnóstico F2 para no romper la UX de "1 celda = 1
+    request" existente, pero evitando N round-trips para una acción que
+    conceptualmente es "toda la fila del día").
+
+    Acciones soportadas (POST ``accion``):
+      - ``presente``: marca PRESENTE a todo el personal activo ese día.
+      - ``festivo_domingo``: domingo/festivo trabajado -- JORNADA_POR_DIA
+        ya da 0h de jornada regular ese día (ver modelo), así que TODAS las
+        horas trabajadas se registran como recargo dominical/festivo
+        diurno (``he_dominical_diurna``), jornada completa (8h, mismo
+        default que ``AsistenciaUpdateView`` usa para un día normal).
+      - ``viatico``: aplica el viático default (misma fuente de verdad que
+        ``AsistenciaUpdateView``: ``CostoRecurso(tipo='VIATICO')``, con el
+        mismo fallback hardcodeado) a todo el personal activo ese día.
+
+    NO sobreescribe registros ya marcados con un tipo_novedad distinto de
+    PRESENTE (ej. no pisa una Incapacidad ya cargada) salvo para la propia
+    acción que se está aplicando -- ver detalle por rama abajo.
+    """
+    model = Cuadrilla
+    allowed_roles = ['admin', 'director', 'coordinador', 'ing_residente', 'supervisor']
+
+    ACCIONES_VALIDAS = {'presente', 'festivo_domingo', 'viatico'}
+
+    def post(self, request, *args, **kwargs):
+        from datetime import date as date_cls
+        from decimal import Decimal
+        from django.http import HttpResponse, JsonResponse
+
+        cuadrilla = self.get_object()
+        accion = (request.POST.get('accion') or '').strip()
+        fecha_str = (request.POST.get('fecha') or '').strip()
+
+        if accion not in self.ACCIONES_VALIDAS:
+            return HttpResponse('Accion invalida', status=400)
+        try:
+            fecha = date_cls.fromisoformat(fecha_str)
+        except ValueError:
+            return HttpResponse('Fecha invalida', status=400)
+
+        miembros_activos = cuadrilla.miembros.filter(activo=True).select_related('usuario')
+        afectados = 0
+
+        if accion == 'presente':
+            for m in miembros_activos:
+                asist, _ = Asistencia.objects.get_or_create(
+                    usuario=m.usuario, cuadrilla=cuadrilla, fecha=fecha,
+                    defaults={'registrado_por': request.user},
+                )
+                asist.tipo_novedad = Asistencia.TipoNovedad.PRESENTE
+                asist.registrado_por = request.user
+                asist.save(update_fields=['tipo_novedad', 'registrado_por', 'updated_at'])
+                afectados += 1
+
+        elif accion == 'festivo_domingo':
+            # Jornada completa (8h) registrada como recargo dominical/
+            # festivo diurno -- mismo default de "un dia" que usa el resto
+            # del flujo de asistencia (ver AsistenciaUpdateView).
+            for m in miembros_activos:
+                asist, _ = Asistencia.objects.get_or_create(
+                    usuario=m.usuario, cuadrilla=cuadrilla, fecha=fecha,
+                    defaults={'registrado_por': request.user},
+                )
+                asist.tipo_novedad = Asistencia.TipoNovedad.PRESENTE
+                asist.he_dominical_diurna = Decimal('8')
+                asist.registrado_por = request.user
+                asist.save(update_fields=[
+                    'tipo_novedad', 'he_dominical_diurna', 'horas_extra',
+                    'registrado_por', 'updated_at',
+                ])
+                afectados += 1
+
+        elif accion == 'viatico':
+            from apps.financiero.models import CostoRecurso
+            costo_viatico = CostoRecurso.objects.filter(
+                tipo='VIATICO', activo=True
+            ).order_by('-vigencia_desde').first()
+            valor_viatico = costo_viatico.costo_unitario if costo_viatico else Decimal('136941')
+            for m in miembros_activos:
+                asist, _ = Asistencia.objects.get_or_create(
+                    usuario=m.usuario, cuadrilla=cuadrilla, fecha=fecha,
+                    defaults={'registrado_por': request.user},
+                )
+                asist.viatico_aplica = True
+                asist.viaticos = valor_viatico
+                asist.registrado_por = request.user
+                asist.save(update_fields=[
+                    'viatico_aplica', 'viaticos', 'registrado_por', 'updated_at',
+                ])
+                afectados += 1
+
+        return JsonResponse({'ok': True, 'accion': accion, 'fecha': fecha_str, 'afectados': afectados})
 
 
 class CuadrillaMiembroRemoveView(LoginRequiredMixin, RoleRequiredMixin, DetailView):
@@ -1215,6 +1320,7 @@ class ExportarAsistenciaView(LoginRequiredMixin, RoleRequiredMixin, View):
                         'CAPACITACION': '76D7C4',
                         'COMPENSATORIO': '67E8F9',
                         'DESCANSO': 'CBD5E1',
+                        'DIA_GANADO': '34D399',
                     }
                     fill_color = color_map.get(asist.tipo_novedad)
                     if fill_color:

--- a/templates/cuadrillas/detalle.html
+++ b/templates/cuadrillas/detalle.html
@@ -411,6 +411,7 @@
                 <span class="flex items-center gap-1"><span class="w-3 h-3 rounded bg-teal-100 border border-teal-300"></span> Capacitacion</span>
                 <span class="flex items-center gap-1"><span class="w-3 h-3 rounded bg-cyan-100 border border-cyan-300"></span> Compensatorio</span>
                 <span class="flex items-center gap-1"><span class="w-3 h-3 rounded bg-slate-100 border border-slate-300"></span> Descanso</span>
+                <span class="flex items-center gap-1"><span class="w-3 h-3 rounded bg-emerald-100 border border-emerald-300"></span> Día ganado</span>
             </div>
         </div>
         <div class="overflow-x-auto">
@@ -422,6 +423,23 @@
                         <th class="px-2 py-3 text-center text-xs font-medium text-gray-500 uppercase min-w-[120px]">
                             <div>{% if forloop.counter == 1 %}Lun{% elif forloop.counter == 2 %}Mar{% elif forloop.counter == 3 %}Mie{% elif forloop.counter == 4 %}Jue{% elif forloop.counter == 5 %}Vie{% elif forloop.counter == 6 %}Sab{% else %}Dom{% endif %}</div>
                             <div class="text-gray-400 font-normal">{{ dia|date:"d/m" }}</div>
+                            {# Issue #210: acciones masivas para TODO el personal de la cuadrilla, ese dia #}
+                            <div class="flex items-center justify-center gap-1 mt-1"
+                                 x-data="{ enviar(accion) {
+                                     if (!confirm('¿Aplicar \'' + accion + '\' a TODO el personal de esta cuadrilla el {{ dia|date:'d/m' }}?')) return;
+                                     fetch('{% url 'cuadrillas:asistencia_accion_masiva' cuadrilla.pk %}', {
+                                         method: 'POST',
+                                         headers: {'X-CSRFToken': '{{ csrf_token }}', 'Content-Type': 'application/x-www-form-urlencoded'},
+                                         body: 'accion=' + accion + '&fecha={{ dia|date:'Y-m-d' }}',
+                                     }).then(r => { if (r.ok) location.reload(); else alert('No se pudo aplicar la accion masiva.'); });
+                                 } }">
+                                <button type="button" @click="enviar('presente')" title="Marcar toda la cuadrilla Presente este día"
+                                        class="text-[9px] px-1 py-0.5 rounded bg-green-100 text-green-700 hover:bg-green-200 dark:bg-green-900 dark:text-green-300">Presente</button>
+                                <button type="button" @click="enviar('festivo_domingo')" title="Festivo/Domingo trabajado: jornada completa como recargo dominical para toda la cuadrilla"
+                                        class="text-[9px] px-1 py-0.5 rounded bg-amber-100 text-amber-700 hover:bg-amber-200 dark:bg-amber-900 dark:text-amber-300">Festivo</button>
+                                <button type="button" @click="enviar('viatico')" title="Aplicar viático default a toda la cuadrilla este día"
+                                        class="text-[9px] px-1 py-0.5 rounded bg-sky-100 text-sky-700 hover:bg-sky-200 dark:bg-sky-900 dark:text-sky-300">Viático</button>
+                            </div>
                         </th>
                         {% endfor %}
                         <th class="px-3 py-3 text-center text-xs font-medium text-gray-500 uppercase min-w-[70px]">H. Ord.</th>
@@ -466,6 +484,7 @@
                                         {% elif dia_info.tipo_novedad == 'CAPACITACION' %}text-teal-600 bg-teal-50 border-teal-300
                                         {% elif dia_info.tipo_novedad == 'COMPENSATORIO' %}text-cyan-600 bg-cyan-50 border-cyan-300
                                         {% elif dia_info.tipo_novedad == 'DESCANSO' %}text-slate-600 bg-slate-50 border-slate-300
+                                        {% elif dia_info.tipo_novedad == 'DIA_GANADO' %}text-emerald-700 bg-emerald-50 border-emerald-300
                                         {% else %}text-gray-400 bg-white border-gray-200
                                         {% endif %}
                                         dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200">
@@ -526,7 +545,7 @@
                                            class="rounded border-gray-300 text-orange-600 cursor-pointer">
                                     <span class="text-xs text-gray-500 dark:text-gray-400">HE</span>
                                     <span class="text-[10px] text-orange-400">
-                                        ({% if dia_info.dia_semana == 0 %}8h{% elif dia_info.dia_semana == 5 %}6h{% elif dia_info.dia_semana == 6 %}0h{% else %}7.5h{% endif %})
+                                        ({{ dia_info.jornada|floatformat:1 }}h)
                                     </span>
                                 </div>
                                 <div x-show="showHE" x-collapse class="mt-1 space-y-1">


### PR DESCRIPTION
## ⚠️ Toca cálculo de nómina real — NO MERGEAR sin autorización de negocio

Codeado y testeado completo, dejado explícitamente como PR abierto (sin merge, sin deploy) hasta que Miguel confirme luz verde — el propio issue #210 lo exige.

## Resumen
- `DIA_GANADO` como choice nuevo, no cuenta como día trabajado (verificado con test).
- `Asistencia.JORNADA_POR_DIA` como única fuente de verdad (antes duplicada 2 veces en `views.py` + 1 vez hardcodeada en el template). Jornada sigue en 44h/semana, sin cambio de valor — la reforma a 42h queda bloqueada por datos reales de horario pendientes de Alcides, tal como señala el propio issue.
- Acciones masivas nuevas (`presente`, `festivo_domingo`, `viatico`) para todo el personal activo de la cuadrilla en una fecha, en una sola request.

Refs #210

## Test plan
- [x] `apps.cuadrillas.tests_issue_210` (12 tests nuevos).
- [x] Suite `apps.cuadrillas`+`apps.financiero` — 220/221 (1 failure pre-existente en `main`, no relacionado, ya confirmado en PR #215).