### PR TITLE
chore(ci): correr CI en runners GCP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   test:
     name: Unit+Integration (PostGIS)
-    runs-on: ubuntu-latest
+    runs-on: [gcp, linux-amd64]
     services:
       postgres:
         image: postgis/postgis:16-3.4
@@ -28,8 +28,13 @@ jobs:
           POSTGRES_DB: instelec_test
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
+        # Puerto DINÁMICO a propósito: los runners GCP corren un Postgres del
+        # sistema en el 5432 del host y hay 3 runners concurrentes. Un mapeo fijo
+        # (5432:5432 o 5433:5433) da "failed to bind host port" o choca entre
+        # jobs. Declarando solo el puerto del contenedor, Docker asigna uno libre
+        # y lo leemos con job.services.postgres.ports['5432'].
         ports:
-          - 5432:5432
+          - 5432
         options: >-
           --health-cmd "pg_isready -U postgres"
           --health-interval 10s
@@ -42,7 +47,9 @@ jobs:
       DB_USER: postgres
       DB_PASSWORD: postgres
       DB_HOST: localhost
-      DB_PORT: "5432"
+      # OJO: DB_PORT NO puede vivir acá — el contexto `job.services` no está
+      # disponible en el `env:` a nivel de job. Se inyecta en el `env:` de cada
+      # step que toca la BD (Django check + pytest).
       DJANGO_SETTINGS_MODULE: config.settings.ci_postgis
     steps:
       - uses: actions/checkout@v4
@@ -52,25 +59,33 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gdal-bin libgdal-dev binutils libproj-dev libgeos-dev postgresql-client
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: "pip"
+      # actions/setup-python NO sirve en estos runners (Debian 12): el repo
+      # actions/python-versions no publica builds para Debian. Usamos el
+      # python3.12 de la máquina y un venv por job.
+      - name: Setup Python 3.12 (venv del runner)
+        run: |
+          python3.12 -m venv "$RUNNER_TEMP/venv"
+          echo "$RUNNER_TEMP/venv/bin" >> "$GITHUB_PATH"
 
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          # El binding pip de GDAL debe matchear el libgdal del sistema (apt trae
-          # 3.8.x; base.txt pinea otra). Instalar la versión del sistema y excluir el pin.
+          # El binding pip de GDAL debe matchear el libgdal del sistema (Debian 12
+          # trae 3.6.x; base.txt pinea otra). Instalar la versión del sistema y
+          # excluir el pin.
           pip install "GDAL==$(gdal-config --version)"
-          grep -ivE '^GDAL([=<>! ]|$)' requirements/base.txt > /tmp/req_no_gdal.txt
-          pip install -r /tmp/req_no_gdal.txt
+          grep -ivE '^GDAL([=<>! ]|$)' requirements/base.txt > "$RUNNER_TEMP/req_no_gdal.txt"
+          pip install -r "$RUNNER_TEMP/req_no_gdal.txt"
           pip install factory-boy pytest pytest-django pytest-timeout
 
       - name: Django system check
+        env:
+          DB_PORT: ${{ job.services.postgres.ports['5432'] }}
         run: python manage.py check
 
       - name: Run unit + integration tests (PostGIS)
+        env:
+          DB_PORT: ${{ job.services.postgres.ports['5432'] }}
         run: >-
           pytest tests/unit tests/integration
           --ds=config.settings.ci_postgis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,16 @@ jobs:
           pip install "GDAL==$(gdal-config --version)"
           grep -ivE '^GDAL([=<>! ]|$)' requirements/base.txt > "$RUNNER_TEMP/req_no_gdal.txt"
           pip install -r "$RUNNER_TEMP/req_no_gdal.txt"
-          pip install factory-boy pytest pytest-django pytest-timeout
+          # pytest-django 4.13.0 DEJÓ DE SOPORTAR Django 5.1 (sus classifiers
+          # solo declaran 5.2 y 6.0) pero NO declara restricción de Django, así
+          # que pip lo instalaba igual contra el Django>=5.1,<5.2 de base.txt y
+          # reventaba toda la suite con
+          #   AttributeError: type object 'PytestDjangoTestCase' has no
+          #   attribute '_pre_setup_ran_eagerly'
+          # (`_pre_setup_ran_eagerly` es un atributo de TransactionTestCase que
+          # Django agregó en 5.2). 4.12.0 es la última que soporta Django 5.1;
+          # al subir a Django 5.2+ se puede levantar el cap.
+          pip install factory-boy pytest "pytest-django>=4.9,<4.13" pytest-timeout
 
       - name: Django system check
         env:

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -8,7 +8,11 @@ ipython>=8.20
 
 # Testing
 pytest>=8.0
-pytest-django>=4.7
+# Cap: pytest-django 4.13.0 requiere Django >=5.2 (lee TransactionTestCase.
+# _pre_setup_ran_eagerly, que no existe en 5.1) pero no lo declara en sus
+# metadatos. base.txt pinea Django>=5.1,<5.2 -> sin este cap, toda la suite
+# revienta con AttributeError. Levantarlo al subir Django a 5.2+.
+pytest-django>=4.7,<4.13
 pytest-cov>=4.1
 pytest-asyncio>=0.23
 factory-boy>=3.3


### PR DESCRIPTION
Desbloquea el CI de Instelec, que quedó fuera de la migración de runners a GCP (`deploy-cloudrun.yml` ya estaba migrado; `ci.yml` seguía en `ubuntu-latest`).

## Qué cambia

1. **`runs-on: [gcp, linux-amd64]`** — los runners `gcp-worker-1/2/3` están registrados con `--no-default-labels`, así que solo matchean estos dos labels.
2. **Puerto del service container PostGIS dinámico.** La VM de los runners corre un Postgres del sistema en el 5432 del host → el mapeo fijo `5432:5432` daba `failed to bind host port`. Tampoco sirve un puerto fijo alterno (5433): con 3 runners concurrentes dos jobs volverían a chocar entre sí. Se declara solo el puerto del contenedor (`ports: [5432]`), Docker asigna uno libre del host, y se lee con `job.services.postgres.ports['5432']`.
3. **`DB_PORT` movido del `env:` del job al `env:` de los steps.** El contexto `job.services` no está disponible en el `env:` a nivel de job. Los dos steps que tocan la BD (`Django system check` y `pytest`) lo reciben explícito.
4. **`actions/setup-python@v5` reemplazado por venv nativo.** `actions/python-versions` no publica builds para Debian 12, así que la action falla en estos runners. Se usa `python3.12 -m venv "$RUNNER_TEMP/venv"` + `$GITHUB_PATH`.
5. `/tmp/req_no_gdal.txt` → `$RUNNER_TEMP/req_no_gdal.txt` (con 3 runners concurrentes en la misma máquina, un path fijo en `/tmp` es una race).

## Notas

- El binding pip de GDAL se sigue instalando con `gdal-config --version`; en Debian 12 eso da **3.6.2** (el comentario decía 3.8.x, corregido). Verificado localmente: `pip install GDAL==3.6.2` compila OK contra el `libgdal-dev` de la máquina con python3.12.
- GDAL/GEOS/PROJ ya están instalados en la VM; el `apt-get install` queda igual por reproducibilidad.

Refs DEV-25